### PR TITLE
Add custom EditProfile page for Organiser panel

### DIFF
--- a/app/Filament/Organiser/Pages/EditProfile.php
+++ b/app/Filament/Organiser/Pages/EditProfile.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Filament\Organiser\Pages;
+
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Pages\Auth\EditProfile as BaseEditProfile;
+
+class EditProfile extends BaseEditProfile
+{
+    public function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                $this->getNameFormComponent(),
+                $this->getEmailFormComponent(),
+                TextInput::make('phone')
+                    ->label(__('organiser/pages/auth/register.form.phone.label'))
+                    ->maxLength(255),
+                $this->getPasswordFormComponent(),
+                $this->getPasswordConfirmationFormComponent(),
+            ]);
+    }
+}

--- a/app/Providers/Filament/OrganiserPanelProvider.php
+++ b/app/Providers/Filament/OrganiserPanelProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers\Filament;
 
 use App\Filament\Organiser\Clusters\Settings\Pages\EditOrganisationProfile;
+use App\Filament\Organiser\Pages\EditProfile;
 use App\Filament\Organiser\Pages\Register;
 use App\Filament\Organiser\Pages\Tenancy\RegisterOrganisation;
 use App\Models\Organisation;
@@ -50,7 +51,7 @@ class OrganiserPanelProvider extends PanelProvider
             ->tenantProfile(EditOrganisationProfile::class)
             ->passwordReset()
             ->emailVerification()
-            ->profile()
+            ->profile(EditProfile::class)
             ->discoverWidgets(in: app_path('Filament/Organiser/Widgets'), for: 'App\\Filament\\Organiser\\Widgets')
             ->widgets([
                 Widgets\AccountWidget::class,


### PR DESCRIPTION
Replaced the default profile edit page with a custom `EditProfile` page in the Organiser panel. Added support for editing the phone number alongside existing fields. Updated `OrganiserPanelProvider` to use the new EditProfile class.

Phone number field was still missing.