### PR TITLE
fix admin invite can have a relation to multiple municipalities

### DIFF
--- a/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
+++ b/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
@@ -6,10 +6,13 @@ use App\Enums\Role;
 use App\Filament\Clusters\AdminSettings\Resources\AdminResource;
 use App\Mail\AdminInviteMail;
 use App\Models\AdminInvite;
+use App\Models\Municipality;
+use App\Models\User;
 use Filament\Actions;
-use Filament\Facades\Filament;
 use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Get;
 use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Support\Enums\MaxWidth;
@@ -36,6 +39,7 @@ class ListAdmins extends ListRecords
                         ->label(__('admin/resources/admin.actions.invite.form.email.label'))
                         ->email()
                         ->required()
+                        ->unique(table: User::class)
                         ->maxLength(255),
                     Radio::make('role')
                         ->label(__('admin/resources/admin.actions.invite.form.role.label'))
@@ -48,19 +52,28 @@ class ListAdmins extends ListRecords
                         ->descriptions([
                             Role::MunicipalityAdmin->value => __('admin/resources/admin.actions.invite.form.role.options.municipality_admin.description'),
                             Role::Admin->value => __('admin/resources/admin.actions.invite.form.role.options.admin.description'),
-                        ]),
+                        ])
+                        ->live(),
+                    Select::make('municipalities')
+                        ->multiple()
+                        ->options(Municipality::pluck('name', 'id'))
+                        ->label(__('admin/resources/admin.actions.invite.form.municipalities.label'))
+                        ->visible(fn (Get $get): bool => $get('role') === Role::MunicipalityAdmin->value)
+                        ->preload()
+                        ->required(),
                 ])
                 ->action(function ($data) {
-                    /** @var \App\Models\Organisation $tenant */
-                    $tenant = Filament::getTenant();
 
                     $adminInvite = AdminInvite::create([
-                        'municipality_id' => $tenant->id,
                         'name' => $data['name'],
                         'email' => $data['email'],
                         'role' => auth()->user()->role == Role::Admin ? $data['role'] : Role::MunicipalityAdmin,
                         'token' => Str::uuid(),
                     ]);
+
+                    if (isset($data['municipalities']) && $data['municipalities']) {
+                        $adminInvite->municipalities()->attach($data['municipalities']);
+                    }
 
                     Mail::to($adminInvite->email)
                         ->send(new AdminInviteMail($adminInvite));

--- a/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
+++ b/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
@@ -57,10 +57,11 @@ class ListAdmins extends ListRecords
                         ->live(),
                     Select::make('municipalities')
                         ->multiple()
-                        ->options(function() {
-                            if(auth()->user()->role === Role::Admin) {
+                        ->options(function () {
+                            if (auth()->user()->role === Role::Admin) {
                                 return Municipality::pluck('name', 'id');
-                            } 
+                            }
+
                             // If the user is a MunicipalityAdmin, return only the municipalities they are associated with
                             return auth()->user()->municipalities->pluck('name', 'id');
                         })

--- a/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
+++ b/app/Filament/Clusters/AdminSettings/Resources/AdminResource/Pages/ListAdmins.php
@@ -53,10 +53,17 @@ class ListAdmins extends ListRecords
                             Role::MunicipalityAdmin->value => __('admin/resources/admin.actions.invite.form.role.options.municipality_admin.description'),
                             Role::Admin->value => __('admin/resources/admin.actions.invite.form.role.options.admin.description'),
                         ])
+                        ->default(Role::MunicipalityAdmin->value)
                         ->live(),
                     Select::make('municipalities')
                         ->multiple()
-                        ->options(Municipality::pluck('name', 'id'))
+                        ->options(function() {
+                            if(auth()->user()->role === Role::Admin) {
+                                return Municipality::pluck('name', 'id');
+                            } 
+                            // If the user is a MunicipalityAdmin, return only the municipalities they are associated with
+                            return auth()->user()->municipalities->pluck('name', 'id');
+                        })
                         ->label(__('admin/resources/admin.actions.invite.form.municipalities.label'))
                         ->visible(fn (Get $get): bool => $get('role') === Role::MunicipalityAdmin->value)
                         ->preload()

--- a/app/Filament/Resources/UserResource/Pages/ListUsers.php
+++ b/app/Filament/Resources/UserResource/Pages/ListUsers.php
@@ -43,12 +43,13 @@ class ListUsers extends ListRecords
                     $tenant = Filament::getTenant();
 
                     $adminInvite = AdminInvite::create([
-                        'municipality_id' => $tenant->id,
                         'name' => $data['name'],
                         'email' => $data['email'],
                         'role' => Role::Reviewer,
                         'token' => Str::uuid(),
                     ]);
+
+                    $adminInvite->municipalities()->attach($tenant->id);
 
                     Mail::to($adminInvite->email)
                         ->send(new AdminInviteMail($adminInvite));

--- a/app/Mail/AdminInviteMail.php
+++ b/app/Mail/AdminInviteMail.php
@@ -49,7 +49,7 @@ class AdminInviteMail extends Mailable
             markdown: 'mail.admin-invite',
             with: [
                 'role' => strtolower($role->getLabel()),
-                'municipality' => $this->adminInvite->municipality,
+                'municipalities' => $this->adminInvite->municipalities,
                 'acceptUrl' => URL::signedRoute(
                     'admin-invites.accept',
                     ['token' => $this->adminInvite->token],

--- a/app/Models/AdminInvite.php
+++ b/app/Models/AdminInvite.php
@@ -5,7 +5,7 @@ namespace App\Models;
 use App\Enums\Role;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 class AdminInvite extends Model
 {
@@ -13,7 +13,6 @@ class AdminInvite extends Model
     use HasFactory;
 
     protected $fillable = [
-        'municipality_id',
         'name',
         'email',
         'role',
@@ -24,9 +23,9 @@ class AdminInvite extends Model
         'token',
     ];
 
-    public function municipality(): BelongsTo
+    public function municipalities(): BelongsToMany
     {
-        return $this->belongsTo(Municipality::class);
+        return $this->belongsToMany(Municipality::class, 'admin_invite_municipality');
     }
 
     protected function casts(): array

--- a/database/migrations/2025_07_16_070719_create_municipalities_table.php
+++ b/database/migrations/2025_07_16_070719_create_municipalities_table.php
@@ -30,5 +30,6 @@ return new class extends Migration
     public function down(): void
     {
         Schema::dropIfExists('municipalities');
+        Schema::dropIfExists('municipality_user');
     }
 };

--- a/database/migrations/2025_08_04_133342_drop_municipality_id_on_admin_invites_table.php
+++ b/database/migrations/2025_08_04_133342_drop_municipality_id_on_admin_invites_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('admin_invites', function (Blueprint $table) {
+            $table->dropForeign(['municipality_id']);
+            $table->dropColumn('municipality_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('admin_invites', function (Blueprint $table) {
+            $table->foreignId('municipality_id')->nullable()->constrained()->cascadeOnDelete();
+        });
+    }
+};

--- a/database/migrations/2025_08_04_133631_create_admin_invite_municipality_table.php
+++ b/database/migrations/2025_08_04_133631_create_admin_invite_municipality_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('admin_invite_municipality', function (Blueprint $table) {
+            $table->foreignId('municipality_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('admin_invite_id')->constrained()->cascadeOnDelete();
+            $table->primary(['municipality_id', 'admin_invite_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('admin_invite_municipality');
+    }
+};

--- a/lang/nl/admin/resources/admin.php
+++ b/lang/nl/admin/resources/admin.php
@@ -45,6 +45,9 @@ return [
                         ],
                     ],
                 ],
+                'municipalities' => [
+                    'label' => 'Selecteer de gemeente(n) waar de gemeentelijk beheerder toegang tot heeft',
+                ],
             ],
             'notification' => [
                 'title' => 'Uitnodiging verstuurd',

--- a/lang/nl/mail/admin-invite.php
+++ b/lang/nl/mail/admin-invite.php
@@ -3,6 +3,6 @@
 return [
     'subject' => 'Uitgenodigd als :role',
     'greeting' => 'Uitgenodigd als :role',
-    'body' => 'Je bent uitgenodigd als :role voor de gemeente :name in Eventloket.',
+    'body' => 'Je bent uitgenodigd als :role voor de gemeente(n) :name in Eventloket.',
     'button' => 'Uitnodiging accepteren',
 ];

--- a/resources/views/mail/admin-invite.blade.php
+++ b/resources/views/mail/admin-invite.blade.php
@@ -1,7 +1,7 @@
 <x-mail::message>
 # {{ __('mail/admin-invite.greeting', ['role' => $role]) }}
 
-{{ __('mail/admin-invite.body', ['role' => $role, 'name' => $municipality->name]) }}
+{{ __('mail/admin-invite.body', ['role' => $role, 'name' => $municipalities->pluck('name')->join(', ')]) }}
 
 <x-mail::button :url="$acceptUrl">
 {{ __('mail/admin-invite.button') }}

--- a/tests/Feature/AdminInviteTest.php
+++ b/tests/Feature/AdminInviteTest.php
@@ -51,7 +51,7 @@ test('admin can create a reviewer invite', function () {
 
     $invite = AdminInvite::where('email', $inviteeEmail)->first();
     expect($invite)->not->toBeNull()
-        ->and($invite->municipality_id)->toBe($this->municipality->id)
+        ->and($invite->municipalities()->first()->id)->toBe($this->municipality->id)
         ->and($invite->role)->toBe(Role::Reviewer);
 
     Mail::assertSent(AdminInviteMail::class, function ($mail) use ($inviteeEmail) {
@@ -66,11 +66,12 @@ test('existing user can accept a reviewer invite', function () {
     ]);
 
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $user->email,
         'role' => Role::Reviewer,
         'token' => Str::uuid(),
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     // Act
     $this->actingAs($user);
@@ -103,11 +104,12 @@ test('new user can register and accept a reviewer invite', function () {
     // Arrange
     $inviteeEmail = 'newreviewer@example.com';
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $inviteeEmail,
         'role' => Role::Reviewer,
         'token' => Str::uuid(),
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     $signedUrl = URL::signedRoute('admin-invites.accept', [
         'token' => $invite->token,
@@ -160,6 +162,7 @@ test('admin can create a municipality admin invite', function () {
         ->callAction('invite', [
             'email' => $inviteeEmail,
             'role' => Role::MunicipalityAdmin,
+            'municipalities' => [$this->municipality->id],
         ]);
 
     // Assert
@@ -167,7 +170,7 @@ test('admin can create a municipality admin invite', function () {
 
     $invite = AdminInvite::where('email', $inviteeEmail)->first();
     expect($invite)->not->toBeNull()
-        ->and($invite->municipality_id)->toBe($this->municipality->id)
+        ->and($invite->municipalities()->first()->id)->toBe($this->municipality->id)
         ->and($invite->role)->toBe(Role::MunicipalityAdmin);
 
     Mail::assertSent(AdminInviteMail::class, function ($mail) use ($inviteeEmail) {
@@ -182,11 +185,12 @@ test('existing user can accept a municipality admin invite', function () {
     ]);
 
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $user->email,
         'role' => Role::MunicipalityAdmin,
         'token' => Str::uuid(),
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     // Act
     $this->actingAs($user);
@@ -219,11 +223,12 @@ test('new user can register and accept a municipality admin invite', function ()
     // Arrange
     $inviteeEmail = 'newmunicadmin@example.com';
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $inviteeEmail,
         'role' => Role::MunicipalityAdmin,
         'token' => Str::uuid(),
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     $signedUrl = URL::signedRoute('admin-invites.accept', [
         'token' => $invite->token,
@@ -280,10 +285,9 @@ test('admin can create an admin invite', function () {
 
     // Assert
     $response->assertSuccessful();
-
     $invite = AdminInvite::where('email', $inviteeEmail)->first();
+
     expect($invite)->not->toBeNull()
-        ->and($invite->municipality_id)->toBe($this->municipality->id)
         ->and($invite->role)->toBe(Role::Admin);
 
     Mail::assertSent(AdminInviteMail::class, function ($mail) use ($inviteeEmail) {
@@ -298,11 +302,12 @@ test('existing user can accept an admin invite', function () {
     ]);
 
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $user->email,
         'role' => Role::Admin,
         'token' => Str::uuid(),
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     // Act
     $this->actingAs($user);
@@ -336,7 +341,6 @@ test('new user can register and accept an admin invite', function () {
     // Arrange
     $inviteeEmail = 'brandnewadmin@example.com';
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => $inviteeEmail,
         'role' => Role::Admin,
         'token' => Str::uuid(),
@@ -388,11 +392,12 @@ test('invite cannot be accepted by wrong user', function () {
     ]);
 
     $invite = AdminInvite::create([
-        'municipality_id' => $this->municipality->id,
         'email' => 'differentuser@example.com', // Different email than logged-in user
         'token' => Str::uuid(),
         'role' => Role::Reviewer,
     ]);
+
+    $invite->municipalities()->attach($this->municipality->id);
 
     // Act
     $this->actingAs($user);


### PR DESCRIPTION
Een admin invite had een belongsTo relation met een gemeente maar het is logischer om bij het aanmaken van een gemeentelijke beheerder om ook meteen de juiste gemeentes te koppelen. Om dit te kunnen doen moest de relatie om naar many - many. Deze PR wijzigt de relatie en voegt de optie toe om bij het uitnodigen van een gemeentelijke beheerder direct verplicht de gemeentes toe te kennen waartoe deze toegang heeft.

cc @LorensoD 