### PR TITLE
Added organiser relation to zaak

### DIFF
--- a/app/Enums/DocumentVertrouwelijkhedenByUserType.php
+++ b/app/Enums/DocumentVertrouwelijkhedenByUserType.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Enums;
+
+use App\Models\Users\AdminUser;
+use App\Models\Users\AdvisorUser;
+use App\Models\Users\MunicipalityAdminUser;
+use App\Models\Users\OrganiserUser;
+use App\Models\Users\ReviewerMunicipalityAdminUser;
+use App\Models\Users\ReviewerUser;
+
+enum DocumentVertrouwelijkhedenByUserType: string
+{
+    case Openbaar = 'openbaar';
+    case BeperktOpenbaar = 'beperkt_openbaar';
+    case Intern = 'intern';
+    case Zaakvertrouwelijk = 'zaakvertrouwelijk';
+    case Vertrouwelijk = 'vertrouwelijk';
+    case Confidentieel = 'confidentieel';
+    case Geheim = 'geheim';
+    case ZeerGegeheim = 'zeer_geheim';
+
+    public static function fromUserType(string $userType): array
+    {
+        return match ($userType) {
+            OrganiserUser::class => [self::Zaakvertrouwelijk->value],
+            AdvisorUser::class => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value],
+            MunicipalityAdminUser::class => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            ReviewerMunicipalityAdminUser::class => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            ReviewerUser::class => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            AdminUser::class => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            default => [self::Openbaar->value],
+        };
+    }
+}

--- a/app/Filament/Municipality/Resources/Zaken/Schemas/ZaakInfolist.php
+++ b/app/Filament/Municipality/Resources/Zaken/Schemas/ZaakInfolist.php
@@ -43,20 +43,26 @@ class ZaakInfolist
                     ->columns(12)
                     ->columnSpanFull()
                     ->schema([
-                        Section::make('Informatie')
-                            ->description('Informatie over de zaak')
+                        Section::make(__('municipality/resources/zaak.infolist.sections.information.label'))
+                            ->description(__('municipality/resources/zaak.infolist.sections.information.description'))
                             ->columns(2)
-                            ->schema(self::informationschema())
+                            ->schema(array_merge(self::informationschema(), [
+                                TextEntry::make('reference_data.organisator')
+                                    ->label(__('municipality/resources/zaak.columns.organisator.label')),
+                                TextEntry::make('openzaak.uiterlijkeEinddatumAfdoening')
+                                    ->date('d-m-Y')
+                                    ->label(__('municipality/resources/zaak.columns.uiterlijkeEinddatumAfdoening.label')),
+                            ]))
                             ->columnSpan(8),
-                        Section::make('Acties')
-                            ->description('Voer wijzigingen uit binnen de zaak')
+                        Section::make(__('municipality/resources/zaak.infolist.sections.actions.label'))
+                            ->description(__('municipality/resources/zaak.infolist.sections.actions.description'))
                             ->schema([
                                 TextEntry::make('reference_data.risico_classificatie')
                                     ->label(__('municipality/resources/zaak.columns.risico_classificatie.label'))
                                     ->afterLabel(Schema::end([
                                         Icon::make('heroicon-o-pencil-square'),
                                         Action::make('editRisicoClassificatie')
-                                            ->label(__('Wijzigen'))
+                                            ->label(__('municipality/resources/zaak.infolist.sections.actions.actions.edit_risico_classificatie.label'))
                                             ->fillForm(function (Zaak $record): array {
                                                 /** @var ZaakReferenceData $referenceData */
                                                 $referenceData = $record->reference_data;
@@ -84,20 +90,25 @@ class ZaakInfolist
                             ])->columnSpan(4),
                         Tabs::make('Tabs')
                             ->tabs([
-                                Tab::make('Bestanden')
+                                Tab::make('documents')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.documents.label'))
                                     ->schema([
                                         Livewire::make(ZaakDocumentsTable::class, ['zaak' => $schema->model])->key('documents-table-'.($schema->model->id ?? 'new')),
                                     ]),
-                                Tab::make('Berichten')
+                                Tab::make('messages')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.messages.label'))
                                     ->schema([
                                     ]),
-                                Tab::make('Adviesvragen')
+                                Tab::make('advice_requests')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.advice_requests.label'))
                                     ->schema([
                                     ]),
-                                Tab::make('Locaties')
+                                Tab::make('locations')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.locations.label'))
                                     ->schema([
                                     ]),
-                                Tab::make('Log')
+                                Tab::make('log')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.log.label'))
                                     ->schema([
                                     ]),
                             ])

--- a/app/Filament/Organiser/Clusters/Settings.php
+++ b/app/Filament/Organiser/Clusters/Settings.php
@@ -11,6 +11,8 @@ use Filament\Facades\Filament;
 
 class Settings extends Cluster
 {
+    protected static ?int $navigationSort = 10;
+
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-cog-6-tooth';
 
     public static function getNavigationLabel(): string

--- a/app/Filament/Organiser/Pages/Calendar.php
+++ b/app/Filament/Organiser/Pages/Calendar.php
@@ -7,6 +7,8 @@ use App\Filament\Shared\Pages\Calendar as BaseCalendar;
 
 class Calendar extends BaseCalendar
 {
+    protected static ?int $navigationSort = 4;
+
     protected function getHeaderWidgets(): array
     {
         return [

--- a/app/Filament/Organiser/Pages/Dashboard.php
+++ b/app/Filament/Organiser/Pages/Dashboard.php
@@ -10,6 +10,8 @@ use Illuminate\Contracts\Support\Htmlable;
 
 class Dashboard extends BaseDashboard
 {
+    protected static ?int $navigationSort = 0;
+
     public function getTitle(): string|Htmlable
     {
         return self::greet().' '.auth()->user()->name;

--- a/app/Filament/Organiser/Pages/NewRequest.php
+++ b/app/Filament/Organiser/Pages/NewRequest.php
@@ -20,6 +20,8 @@ class NewRequest extends Page
 
     protected static ?string $slug = 'new-request/{openform?}';
 
+    protected static ?int $navigationSort = 1;
+
     // protected static string | array $routeMiddleware = ValidateOpenFormsPrefill::class; // prefill causes issues with openform submission, workaround for now is to save the of submission id from localstorage to the db
     protected static string|\BackedEnum|null $navigationIcon = 'heroicon-o-document-text';
 

--- a/app/Filament/Organiser/Resources/Zaken/Pages/ListZaken.php
+++ b/app/Filament/Organiser/Resources/Zaken/Pages/ListZaken.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Organiser\Resources\Zaken\Pages;
+
+use App\Filament\Organiser\Resources\Zaken\ZaakResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListZaken extends ListRecords
+{
+    protected static string $resource = ZaakResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            // CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Filament\Organiser\Resources\Zaken\Pages;
+
+use App\Filament\Organiser\Resources\Zaken\ZaakResource;
+use Filament\Resources\Pages\ViewRecord;
+
+class ViewZaak extends ViewRecord
+{
+    protected static string $resource = ZaakResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+
+        ];
+    }
+}

--- a/app/Filament/Organiser/Resources/Zaken/Schemas/ZaakInfolist.php
+++ b/app/Filament/Organiser/Resources/Zaken/Schemas/ZaakInfolist.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Filament\Organiser\Resources\Zaken\Schemas;
+
+use App\Filament\Municipality\Resources\Zaken\Schemas\ZaakInfolist as SchemasZaakInfolist;
+use App\Livewire\Zaken\ZaakDocumentsTable;
+use Filament\Schemas\Components\Grid;
+use Filament\Schemas\Components\Livewire;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+
+class ZaakInfolist
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Grid::make()
+                    ->columns(12)
+                    ->columnSpanFull()
+                    ->schema([
+                        Section::make(__('organiser/resources/zaak.infolist.sections.information.label'))
+                            ->description(__('organiser/resources/zaak.infolist.sections.information.description'))
+                            ->columns(2)
+                            ->columnSpanFull()
+                            ->schema(SchemasZaakInfolist::informationschema()),
+                        Tabs::make('Tabs')
+                            ->tabs([
+                                Tab::make('documents')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.documents.label'))
+                                    ->schema([
+                                        Livewire::make(ZaakDocumentsTable::class, ['zaak' => $schema->model])->key('documents-table-'.($schema->model->id ?? 'new')),
+                                    ]),
+                                Tab::make('messages')
+                                    ->label(__('municipality/resources/zaak.infolist.tabs.messages.label'))
+                                    ->schema([]),
+                            ])
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+}

--- a/app/Filament/Organiser/Resources/Zaken/ZaakResource.php
+++ b/app/Filament/Organiser/Resources/Zaken/ZaakResource.php
@@ -1,11 +1,10 @@
 <?php
 
-namespace App\Filament\Municipality\Resources\Zaken;
+namespace App\Filament\Organiser\Resources\Zaken;
 
-use App\Filament\Municipality\Resources\Zaken\Pages\ListZaken;
-use App\Filament\Municipality\Resources\Zaken\Pages\ViewZaak;
-use App\Filament\Municipality\Resources\Zaken\Schemas\ZaakForm;
-use App\Filament\Municipality\Resources\Zaken\Schemas\ZaakInfolist;
+use App\Filament\Organiser\Resources\Zaken\Pages\ListZaken;
+use App\Filament\Organiser\Resources\Zaken\Pages\ViewZaak;
+use App\Filament\Organiser\Resources\Zaken\Schemas\ZaakInfolist;
 use App\Filament\Shared\Resources\Zaken\Tables\ZakenTable;
 use App\Models\Zaak;
 use BackedEnum;
@@ -22,23 +21,25 @@ class ZaakResource extends Resource
 
     protected static ?string $recordTitleAttribute = 'event_name';
 
-    protected static ?string $tenantOwnershipRelationshipName = 'municipality';
+    protected static ?string $tenantOwnershipRelationshipName = 'organisation';
 
     protected static ?string $slug = 'zaken';
 
+    protected static ?int $navigationSort = 2;
+
+    public static function getNavigationBadge(): ?string
+    {
+        return (string) static::getModel()::count();
+    }
+
     public static function getModelLabel(): string
     {
-        return __('municipality/resources/zaak.label');
+        return __('organiser/resources/zaak.label');
     }
 
     public static function getPluralModelLabel(): string
     {
-        return __('municipality/resources/zaak.plural_label');
-    }
-
-    public static function form(Schema $schema): Schema
-    {
-        return ZaakForm::configure($schema);
+        return __('organiser/resources/zaak.plural_label');
     }
 
     public static function infolist(Schema $schema): Schema

--- a/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
+++ b/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Filament\Municipality\Resources\Zaken\Tables;
+namespace App\Filament\Shared\Resources\Zaken\Tables;
 
 use Filament\Actions\ViewAction;
 use Filament\Tables\Columns\TextColumn;
@@ -16,6 +16,11 @@ class ZakenTable
             ->columns([
                 TextColumn::make('reference_data.naam_evenement')
                     ->label(__('municipality/resources/zaak.columns.naam_evenement.label'))
+                    ->sortable()
+                    ->searchable()
+                    ->forceSearchCaseInsensitive(),
+                TextColumn::make('reference_data.organisator')
+                    ->label(__('municipality/resources/zaak.columns.organisator.label'))
                     ->sortable()
                     ->searchable()
                     ->forceSearchCaseInsensitive(),
@@ -61,6 +66,11 @@ class ZakenTable
                     ])
                     ->multiple()
                     ->attribute('reference_data->risico_classificatie'),
+                SelectFilter::make('organisation_id')
+                    ->label(__('municipality/resources/zaak.columns.organisation.label'))
+                    ->relationship('organisation', 'name')
+                    ->searchable()
+                    ->multiple(),
             ], layout: FiltersLayout::AboveContent)
             ->deferFilters(false)
             ->recordActions([

--- a/app/Jobs/Zaak/AddEinddatumZGW.php
+++ b/app/Jobs/Zaak/AddEinddatumZGW.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Jobs\Zaak;
+
+use App\ValueObjects\OzZaak;
+use App\ValueObjects\OzZaaktype;
+use Carbon\Carbon;
+use Carbon\CarbonInterval;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Woweb\Openzaak\Openzaak;
+
+class AddEinddatumZGW implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private string $zaakUrlZGW) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(Openzaak $openzaak): void
+    {
+        $zaak = new OzZaak(...$openzaak->get($this->zaakUrlZGW)->toArray());
+
+        if (! $zaak->uiterlijkeEinddatumAfdoening && ! $zaak->einddatumGepland) {
+            $zaaktype = new OzZaaktype(...$openzaak->get($zaak->zaaktype)->toArray());
+            $uiterlijkeEinddatumAfdoeningInterval = new CarbonInterval($zaaktype->doorlooptijd);
+            $einddatumGeplandInterval = new CarbonInterval($zaaktype->servicenorm);
+
+            $resp = $openzaak->zaken()->zaken()->patch($zaak->uuid, [
+                'einddatumGepland' => Carbon::parse($zaak->startdatum)->add($einddatumGeplandInterval)->format('Y-m-d'),
+                'uiterlijkeEinddatumAfdoening' => Carbon::parse($zaak->startdatum)->add($uiterlijkeEinddatumAfdoeningInterval)->format('Y-m-d'),
+            ]);
+        }
+
+    }
+}

--- a/app/Jobs/Zaak/CreateZaak.php
+++ b/app/Jobs/Zaak/CreateZaak.php
@@ -2,13 +2,17 @@
 
 namespace App\Jobs\Zaak;
 
+use App\Models\Organisation;
+use App\Models\Users\OrganiserUser;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use App\ValueObjects\ObjectsApi\FormSubmissionObject;
 use App\ValueObjects\OzZaak;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Facades\Log;
+use Woweb\Openzaak\ObjectsApi;
 use Woweb\Openzaak\Openzaak;
 
 class CreateZaak implements ShouldQueue
@@ -23,9 +27,10 @@ class CreateZaak implements ShouldQueue
     /**
      * Execute the job.
      */
-    public function handle(Openzaak $openzaak): void
+    public function handle(Openzaak $openzaak, ObjectsApi $objectsapi): void
     {
-        $ozZaak = new OzZaak(...$openzaak->get($this->zaakUrlZGW.'?expand=zaakobjecten,eigenschappen,status,status.statustype')->toArray());
+        $ozZaak = new OzZaak(...$openzaak->get($this->zaakUrlZGW.'?expand=zaakobjecten,eigenschappen,status,status.statustype,rollen')->toArray());
+        $formSubmissionObject = new FormSubmissionObject(...$objectsapi->get(basename($ozZaak->data_object_url))->toArray());
         $zaaktype = Zaaktype::where(['zgw_zaaktype_url' => $ozZaak->zaaktype, 'is_active' => true])->first();
 
         if (! $zaaktype) {
@@ -34,18 +39,32 @@ class CreateZaak implements ShouldQueue
 
             return;
         }
-        $zaak = Zaak::updateOrCreate(
+        $organisation = Organisation::where('uuid', $formSubmissionObject->organisation_uuid)->first();
+        $user = OrganiserUser::where('uuid', $formSubmissionObject->user_uuid)->first();
+
+        if ($ozZaak->initiator && $ozZaak->initiator->betrokkeneType === 'natuurlijk_persoon') {
+            $organisator = $ozZaak->initiator->betrokkeneIdentificatie['voornamen'].' '.$ozZaak->initiator->betrokkeneIdentificatie['geslachtsnaam'];
+        } elseif ($ozZaak->initiator && $ozZaak->initiator->betrokkeneType === 'niet_natuurlijk_persoon') {
+            $organisator = $ozZaak->initiator->betrokkeneIdentificatie['statutaireNaam'].' - '.$ozZaak->initiator->contactpersoonRol['naam'];
+        } else {
+            $organisator = '';
+        }
+
+        Zaak::updateOrCreate(
             ['zgw_zaak_url' => $ozZaak->url],
             [
                 'public_id' => $ozZaak->identificatie,
                 'zaaktype_id' => $zaaktype->id,
                 'data_object_url' => $ozZaak->data_object_url,
+                'organisation_id' => $organisation?->id,
+                'user_id' => $user?->id,
                 'reference_data' => new ZaakReferenceData(
                     ...array_merge(
                         $ozZaak->eigenschappen_key_value,
                         [
                             'registratiedatum' => $ozZaak->registratiedatum,
                             'status_name' => $ozZaak->status_name,
+                            'organisator' => $organisator,
                         ]
                     )
                 ),

--- a/app/Jobs/Zaak/UpdateInitiatorZGW.php
+++ b/app/Jobs/Zaak/UpdateInitiatorZGW.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Jobs\Zaak;
+
+use App\ValueObjects\ObjectsApi\FormSubmissionObject;
+use App\ValueObjects\OzZaak;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Woweb\Openzaak\ObjectsApi;
+use Woweb\Openzaak\Openzaak;
+
+class UpdateInitiatorZGW implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(private string $zaakUrlZGW) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(Openzaak $openzaak, ObjectsApi $objectsapi): void
+    {
+        $zaak = new OzZaak(...$openzaak->get($this->zaakUrlZGW.'?expand=rollen,zaakobjecten')->toArray());
+        $formSubmissionObject = new FormSubmissionObject(...$objectsapi->get(basename($zaak->data_object_url))->toArray());
+
+        if ($formSubmissionObject->initiator && $zaak->initiator) {
+
+            if ($zaak->initiator->betrokkeneType === 'natuurlijk_persoon' && isset($formSubmissionObject->initiator['kvk']) && $formSubmissionObject->initiator['kvk']) {
+                // TODO cleenup this mess comming from OF
+                $adres = $formSubmissionObject->initiator['organisatie_adres'] ? json_decode(str_replace("'", '"', $formSubmissionObject->initiator['organisatie_adres']), true) : null;
+                $rolData = [
+                    'zaak' => $zaak->url,
+                    'betrokkeneType' => 'niet_natuurlijk_persoon',
+                    'roltype' => $zaak->initiator->roltype,
+                    'roltoelichting' => 'inzender formulier',
+                    'contactpersoonRol' => $formSubmissionObject->initiator['contactpersoon'] ?? null,
+                    'betrokkeneIdentificatie' => [
+                        'statutaireNaam' => $formSubmissionObject->initiator['organisatie_naam'],
+                        'annIdentificatie' => $formSubmissionObject->initiator['kvk'],
+                        'kvkNummer' => $formSubmissionObject->initiator['kvk'],
+                    ],
+                ];
+
+                if ($adres) {
+                    $rolData['betrokkeneIdentificatie']['verblijfsadres'] = [
+                        'aoaIdentificatie' => config('app.name').'-organisatieadres-'.Str::uuid(),
+                        'wplWoonplaatsNaam' => $adres['city'],
+                        'gorOpenbareRuimteNaam' => 'adres',
+                        'aoaPostcode' => $adres['postcode'],
+                        'aoaHuisnummer' => $adres['houseNumber'],
+                        'aoaHuisletter' => $adres['houseLetter'],
+                        'aoaHuisnummertoevoeging' => $adres['houseNumberAddition'],
+                    ];
+                }
+
+                $openzaak->zaken()->rollen()->put($zaak->initiator->uuid, $rolData);
+
+            } elseif (! isset($formSubmissionObject->initiator['kvk']) || ! $formSubmissionObject->initiator['kvk']) {
+                // no kvk so initiator is natuurlijk_persoon
+
+                $adres = $formSubmissionObject->initiator['natuurlijk_persoon_adres'];
+
+                $rolData = [
+                    'zaak' => $zaak->url,
+                    'betrokkeneType' => 'natuurlijk_persoon',
+                    'roltype' => $zaak->initiator->roltype,
+                    'roltoelichting' => 'inzender formulier',
+                    'contactpersoonRol' => $formSubmissionObject->initiator['contactpersoon'] ?? null,
+                    'betrokkeneIdentificatie' => [
+                        'geslachtsnaam' => $zaak->initiator->betrokkeneIdentificatie['geslachtsnaam'] ?? '',
+                        'voornamen' => $zaak->initiator->betrokkeneIdentificatie['voornamen'] ?? '',
+                    ],
+                ];
+
+                if (Arr::has($adres, ['land', 'postcode', 'plaatsnaam', 'straatnaam', 'huisnummer', 'huisletter', 'huisnummertoevoeging']) && (empty($adres['land']) || strtolower($adres['land']) == 'nederland')) {
+                    $rolData['betrokkeneIdentificatie']['verblijfsadres'] = [
+                        'aoaIdentificatie' => config('app.name').'-persoonsadres-'.Str::uuid(),
+                        'wplWoonplaatsNaam' => $adres['plaatsnaam'],
+                        'gorOpenbareRuimteNaam' => 'adres',
+                        'aoaPostcode' => $adres['postcode'],
+                        'aoaHuisnummer' => $adres['huisnummer'],
+                        'aoaHuisletter' => $adres['huisletter'],
+                        'aoaHuisnummertoevoeging' => $adres['huisnummertoevoeging'],
+                    ];
+                }
+
+                $openzaak->zaken()->rollen()->put($zaak->initiator->uuid, $rolData);
+            }
+
+        }
+    }
+}

--- a/app/Listeners/Zaak/ProcessCreateZaak.php
+++ b/app/Listeners/Zaak/ProcessCreateZaak.php
@@ -3,8 +3,10 @@
 namespace App\Listeners\Zaak;
 
 use App\Events\OpenNotification\CreateZaakNotificationReceived;
+use App\Jobs\Zaak\AddEinddatumZGW;
 use App\Jobs\Zaak\AddZaakeigenschappenZGW;
 use App\Jobs\Zaak\CreateZaak;
+use App\Jobs\Zaak\UpdateInitiatorZGW;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Bus;
@@ -28,7 +30,8 @@ class ProcessCreateZaak implements ShouldQueue
     {
         Bus::chain([
             new AddZaakeigenschappenZGW($event->notification->hoofdObject),
-            // TODO set uiterlijke eindatum afdoening en eindatum gepland
+            new AddEinddatumZGW($event->notification->hoofdObject),
+            new UpdateInitiatorZGW($event->notification->hoofdObject),
             // TODO add geometry to zaak
             new CreateZaak($event->notification->hoofdObject),
             // TODO send notificaties

--- a/app/Policies/ZaakPolicy.php
+++ b/app/Policies/ZaakPolicy.php
@@ -14,7 +14,7 @@ class ZaakPolicy
     public function viewAny(User $user): bool
     {
         return match ($user->role) {
-            Role::MunicipalityAdmin, Role::Reviewer => true,
+            Role::MunicipalityAdmin, Role::Reviewer, Role::Organiser => true,
             default => false,
         };
     }
@@ -24,6 +24,10 @@ class ZaakPolicy
      */
     public function view(User $user, Zaak $zaak): bool
     {
+        if ($user instanceof \App\Models\Users\OrganiserUser) {
+            return $user->canAccessOrganisation($zaak->organisation_id);
+        }
+
         return match ($user->role) {
             Role::MunicipalityAdmin, Role::Reviewer => true,
             default => false,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -6,8 +6,10 @@ use App\Actions\OpenNotification\GetIncommingNotificationType;
 use App\Console\Commands\SyncZaaktypen;
 use App\Filament\Admin\Resources\ApplicationResource\Pages\ListApplications;
 use App\Jobs\ProcessOpenNotification;
+use App\Jobs\Zaak\AddEinddatumZGW;
 use App\Jobs\Zaak\AddZaakeigenschappenZGW;
 use App\Jobs\Zaak\CreateZaak;
+use App\Jobs\Zaak\UpdateInitiatorZGW;
 use Carbon\CarbonInterval;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
@@ -51,7 +53,9 @@ class AppServiceProvider extends ServiceProvider
     {
         $this->app->bindMethod([ProcessOpenNotification::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class), typeProcessor: app(GetIncommingNotificationType::class)));
         $this->app->bindMethod([AddZaakeigenschappenZGW::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class), objectsapi: app(ObjectsApi::class)));
-        $this->app->bindMethod([CreateZaak::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class)));
+        $this->app->bindMethod([UpdateInitiatorZGW::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class), objectsapi: app(ObjectsApi::class)));
+        $this->app->bindMethod([CreateZaak::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class), objectsapi: app(ObjectsApi::class)));
+        $this->app->bindMethod([AddEinddatumZGW::class, 'handle'], fn ($job) => $job->handle(openzaak: app(Openzaak::class)));
 
         $this->app->bindMethod([SyncZaaktypen::class, 'handle'], fn ($command) => $command->handle(app(Openzaak::class)));
     }

--- a/app/ValueObjects/ModelAttributes/ZaakReferenceData.php
+++ b/app/ValueObjects/ModelAttributes/ZaakReferenceData.php
@@ -25,6 +25,7 @@ final readonly class ZaakReferenceData implements Arrayable, Castable
         public string $registratiedatum,
         public string $status_name,
         public ?string $naam_evenement = null,
+        public ?string $organisator = null,
         ...$otherParams
     ) {
         $this->start_evenement_datetime = Carbon::parse($this->start_evenement);
@@ -42,6 +43,7 @@ final readonly class ZaakReferenceData implements Arrayable, Castable
             'registratiedatum' => $this->registratiedatum,
             'status_name' => $this->status_name,
             'naam_evenement' => $this->naam_evenement,
+            'organisator' => $this->organisator,
         ];
     }
 

--- a/app/ValueObjects/ObjectsApi/FormSubmissionObject.php
+++ b/app/ValueObjects/ObjectsApi/FormSubmissionObject.php
@@ -13,6 +13,12 @@ class FormSubmissionObject implements Arrayable
 
     public readonly ?array $zaakeigenschappen_key_value;
 
+    public readonly string $organisation_uuid;
+
+    public readonly string $user_uuid;
+
+    public readonly array $initiator;
+
     public function __construct(
         public readonly string $uuid,
         public readonly string $type,
@@ -20,6 +26,9 @@ class FormSubmissionObject implements Arrayable
         ...$otherParams
     ) {
         $this->otherParams = $otherParams;
+        $this->organisation_uuid = $this->record['data'][strtolower(config('app.name')).'_organisation_uuid'] ?? '';
+        $this->user_uuid = $this->record['data'][strtolower(config('app.name')).'_user_uuid'] ?? '';
+        $this->initiator = $this->record['data']['initiator'] ?? [];
         $this->zaakeigenschappen = $this->record['data']['zaakeigenschappen'] ?? null;
         $this->zaakeigenschappen_key_value = $this->zaakeigenschappen
             ? Arr::mapWithKeys($this->zaakeigenschappen, fn ($item) => [key($item) => current($item)])
@@ -32,6 +41,9 @@ class FormSubmissionObject implements Arrayable
             'uuid' => $this->uuid,
             'type' => $this->type,
             'record' => $this->record,
+            'organisation_uuid' => $this->organisation_uuid,
+            'user_uuid' => $this->user_uuid,
+            'initiator' => $this->initiator,
             'otherParams' => $this->otherParams,
         ];
     }

--- a/app/ValueObjects/OzZaak.php
+++ b/app/ValueObjects/OzZaak.php
@@ -3,6 +3,7 @@
 namespace App\ValueObjects;
 
 use App\ValueObjects\ZGW\CatalogiEigenschap;
+use App\ValueObjects\ZGW\Rol;
 use App\ValueObjects\ZGW\ZaakEigenschap;
 use Carbon\Carbon;
 use Illuminate\Contracts\Support\Arrayable;
@@ -25,6 +26,8 @@ class OzZaak implements Arrayable
 
     public readonly array $eigenschappen_key_value;
 
+    public readonly ?Rol $initiator;
+
     public function __construct(
         public readonly string $uuid,
         public readonly string $url,
@@ -33,9 +36,16 @@ class OzZaak implements Arrayable
         public readonly string $omschrijving,
         public readonly string $startdatum,
         public readonly string $registratiedatum,
+        public readonly ?string $einddatum,
+        public readonly ?string $einddatumGepland,
+        public readonly ?string $uiterlijkeEinddatumAfdoening,
         private readonly array $_expand = [],
         ...$otherParams
     ) {
+        $this->initiator = Arr::has($this->_expand, 'rollen')
+            ? new Rol(...Arr::first(Arr::where($this->_expand['rollen'], fn ($item) => $item['omschrijvingGeneriek'] === 'initiator')))
+            : null;
+
         $this->status_name = Arr::has($this->_expand, 'status._expand.statustype.omschrijving')
             ? $this->_expand['status']['_expand']['statustype']['omschrijving']
             : null;
@@ -66,6 +76,9 @@ class OzZaak implements Arrayable
             'startdatum' => $this->startdatum,
             'status_name' => $this->status_name,
             'eigenschappen' => $this->eigenschappen,
+            'einddatum' => $this->einddatum ? Carbon::parse($this->einddatum) : null,
+            'einddatumGepland' => $this->einddatumGepland ? Carbon::parse($this->einddatumGepland) : null,
+            'uiterlijkeEinddatumAfdoening' => $this->uiterlijkeEinddatumAfdoening ? Carbon::parse($this->uiterlijkeEinddatumAfdoening) : null,
         ];
     }
 }

--- a/app/ValueObjects/ZGW/Rol.php
+++ b/app/ValueObjects/ZGW/Rol.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\ValueObjects\ZGW;
+
+use Illuminate\Contracts\Support\Arrayable;
+
+final readonly class Rol implements Arrayable
+{
+    /** @phpstan-ignore constructor.unusedParameter */
+    public function __construct(
+        public string $url,
+        public string $uuid,
+        public string $betrokkeneType,
+        public string $roltype,
+        public string $omschrijving,
+        public string $omschrijvingGeneriek,
+        public array $contactpersoonRol,
+        public array $betrokkeneIdentificatie,
+        ...$otherParams
+    ) {}
+
+    public function toArray(): array
+    {
+        return [
+            'uuid' => $this->uuid,
+            'url' => $this->url,
+            'betrokkeneType' => $this->betrokkeneType,
+            'roltype' => $this->roltype,
+            'omschrijving' => $this->omschrijving,
+            'omschrijvingGeneriek' => $this->omschrijvingGeneriek,
+            'contactpersoonRol' => $this->contactpersoonRol,
+            'betrokkeneIdentificatie' => $this->betrokkeneIdentificatie,
+        ];
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -9688,12 +9688,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/WowebNL/laravel-openzaak.git",
-                "reference": "508b1a59cbba7c5be6343e5e27355b401310adb9"
+                "reference": "32fb93770348242a2c3287034f745dbc584c3a1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WowebNL/laravel-openzaak/zipball/508b1a59cbba7c5be6343e5e27355b401310adb9",
-                "reference": "508b1a59cbba7c5be6343e5e27355b401310adb9",
+                "url": "https://api.github.com/repos/WowebNL/laravel-openzaak/zipball/32fb93770348242a2c3287034f745dbc584c3a1c",
+                "reference": "32fb93770348242a2c3287034f745dbc584c3a1c",
                 "shasum": ""
             },
             "require": {
@@ -9727,7 +9727,7 @@
                 "source": "https://github.com/WowebNL/laravel-openzaak/tree/main",
                 "issues": "https://github.com/WowebNL/laravel-openzaak/issues"
             },
-            "time": "2025-09-08T17:46:49+00:00"
+            "time": "2025-09-16T11:59:31+00:00"
         }
     ],
     "packages-dev": [

--- a/lang/nl/municipality/resources/zaak.php
+++ b/lang/nl/municipality/resources/zaak.php
@@ -23,5 +23,49 @@ return [
         'risico_classificatie' => [
             'label' => 'Risicoclassificatie',
         ],
+        'organisator' => [
+            'label' => 'Organisator',
+        ],
+        'organisation' => [
+            'label' => 'Organisatie',
+        ],
+        'uiterlijkeEinddatumAfdoening' => [
+            'label' => 'Uiterlijke einddatum afdoening',
+        ],
+    ],
+
+    'infolist' => [
+        'sections' => [
+            'information' => [
+                'label' => 'Informatie',
+                'description' => 'Informatie over de zaak',
+            ],
+            'actions' => [
+                'label' => 'Acties',
+                'description' => 'Voer wijzigingen uit binnen de zaak',
+                'actions' => [
+                    'edit_risico_classificatie' => [
+                        'label' => 'Wijzigen',
+                    ],
+                ],
+            ],
+        ],
+        'tabs' => [
+            'documents' => [
+                'label' => 'Bestanden',
+            ],
+            'messages' => [
+                'label' => 'Berichten',
+            ],
+            'advice_requests' => [
+                'label' => 'Adviesvragen',
+            ],
+            'locations' => [
+                'label' => 'Locaties',
+            ],
+            'log' => [
+                'label' => 'Log',
+            ],
+        ],
     ],
 ];

--- a/lang/nl/organiser/resources/zaak.php
+++ b/lang/nl/organiser/resources/zaak.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'label' => 'aanvraag',
+    'plural_label' => 'aanvragen',
+
+    'infolist' => [
+        'sections' => [
+            'information' => [
+                'label' => 'Informatie',
+                'description' => 'Informatie over de aanvraag',
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
Added:
- Zaak document vertrouwelijkheden per user type
- Organiser column to zaken table for Municipality
- Organisation filter to zaken table for Municipality
- Sorting menu items for organiser panel
- Organiser user can view requests made by the organisation (business and personal)
- Job to set correct uiterlijkeEinddatumAfdoening and einddatumGepland on case
- Job to update the initiator with form submission information (kvk, contactpersoon)
- CreateZaak job now also sets user and organisation relation if data is present in submission

Fixed:
- Zaakpolicy so OrganiserUser may view his own zaak
- translation strings for zaakinfolist
- breadcrumb is using event name instead of zaaknummer

Close: https://github.com/WowebNL/project-vrzl-vervanging-evenementassistent/issues/199
Close: https://github.com/WowebNL/project-vrzl-vervanging-evenementassistent/issues/201