### PR TITLE
Add document attachment support for threads

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Filament\Shared\Resources\Zaken\Actions;
+
+use App\Models\Zaak;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Woweb\Openzaak\Openzaak;
+
+class NewDocumentVersionAction
+{
+    public static function make(Zaak $zaak): Action
+    {
+        return Action::make('new-version')
+            ->label(__('Nieuwe versie toevoegen'))
+            ->icon('heroicon-o-plus-circle')
+            ->modalSubmitAction(fn (Action $action) => $action->label(__('Nieuwe versie toevoegen')))
+            ->schema(fn (array $record) => self::schema($record['titel']))
+            ->modalAutofocus(false)
+            ->action(function (array $record, array $data, Action $action) use ($zaak): void {
+
+                self::createNewDocumentVersion($record['uuid'], $data, $zaak);
+
+                Notification::make()
+                    ->title('Nieuwe versie is toegevoegd')
+                    ->success()
+                    ->send();
+
+                $action->getLivewire()->dispatch('refreshTable');
+            });
+    }
+
+    public static function schema(?string $documentTitle = null): array
+    {
+        return [
+            TextInput::make('titel')
+                ->label(__('Titel'))
+                ->required()
+                ->maxLength(255)
+                ->default($documentTitle),
+            FileUpload::make('file')
+                ->label(__('Bestand'))
+                ->required()
+                ->maxSize(20480) // 20MB
+                ->directory('documents')
+                ->visibility('private')
+                ->storeFileNamesIn('file_name'),
+        ];
+    }
+
+    public static function createNewDocumentVersion(string $documentUuid, array $data, Zaak $zaak)
+    {
+        $oz = new Openzaak;
+        $lockString = $oz->documenten()->enkelvoudiginformatieobjecten()->lock($documentUuid);
+        $oz->documenten()->enkelvoudiginformatieobjecten()->patch($documentUuid,
+            [
+                'inhoud' => base64_encode(Storage::get($data['file'])),
+                'titel' => $data['titel'],
+                'auteur' => auth()->user()->name,
+                'bestandsnaam' => $data['file_name'],
+                'bestandsomvang' => Storage::size($data['file']),
+                'formaat' => Storage::mimeType($data['file']),
+                'lock' => $lockString,
+            ]
+        );
+        $oz->documenten()->enkelvoudiginformatieobjecten()->unlock($documentUuid, $lockString);
+
+        Storage::delete($data['file']);
+
+        Cache::forget("zaak.{$zaak->id}.documenten");
+    }
+}

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Filament\Shared\Resources\Zaken\Actions;
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+use App\Models\Zaak;
+use App\ValueObjects\ZGW\Informatieobject;
+use Filament\Actions\Action;
+use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Woweb\Openzaak\Openzaak;
+
+class UploadDocumentAction
+{
+    public static function make(Zaak $zaak): Action
+    {
+        return Action::make('upload')
+            ->label(__('Nieuw bestand toevoegen'))
+            ->icon('heroicon-o-arrow-up-tray')
+            ->modalSubmitAction(fn (Action $action) => $action->label(__('Bestand toevoegen')))
+            ->schema(self::schema($zaak))
+            ->modalAutofocus(false)
+            ->action(function (array $data, Action $action) use ($zaak): void {
+                self::uploadDocument($data, $zaak);
+
+                Notification::make()
+                    ->title('Document is toegevoegd')
+                    ->success()
+                    ->send();
+
+                $action->getLivewire()->dispatch('refreshTable');
+            });
+    }
+
+    public static function schema(Zaak $zaak): array
+    {
+        return [
+            TextInput::make('titel')
+                ->label(__('Titel'))
+                ->required()
+                ->maxLength(255),
+            Select::make('informatieobjecttype')
+                ->label(__('Type document'))
+                ->options(fn () => $zaak->zaaktype->document_types->pluck('omschrijving', 'url')->toArray())
+                ->required(),
+            Select::make('vertrouwelijkheidaanduiding')
+                ->label(__('Wie mag dit document inzien?'))
+                ->options(function () {
+                    /** @phpstan-ignore-next-line */
+                    $vertrouwelijkheden = DocumentVertrouwelijkheden::fromUserRole(auth()->user()->role);
+                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
+                    $options = [];
+                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
+                        if (in_array($key, $vertrouwelijkheden)) {
+                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
+                        }
+                    }
+
+                    return $options;
+                })
+                ->required(),
+            FileUpload::make('file')
+                ->label(__('Bestand'))
+                ->required()
+                ->maxSize(20480) // 20MB
+                ->directory('documents')
+                ->visibility('private')
+                ->storeFileNamesIn('file_name'),
+        ];
+    }
+
+    public static function uploadDocument(array $data, Zaak $zaak): Informatieobject
+    {
+        $oz = new Openzaak;
+        $informatieobject = new Informatieobject(...$oz->documenten()->enkelvoudiginformatieobjecten()->store([
+            'bronorganisatie' => $zaak->openzaak->bronorganisatie,
+            'creatiedatum' => now()->format('Y-m-d'),
+            'vertrouwelijkheidaanduiding' => $data['vertrouwelijkheidaanduiding'],
+            'titel' => $data['titel'],
+            'auteur' => auth()->user()->name,
+            'taal' => 'dut',
+            'bestandsnaam' => $data['file_name'],
+            'bestandsomvang' => Storage::size($data['file']),
+            'formaat' => Storage::mimeType($data['file']),
+            'inhoud' => base64_encode(Storage::get($data['file'])),
+            'informatieobjecttype' => $data['informatieobjecttype'],
+        ]));
+
+        $oz->zaken()->zaakinformatieobjecten()->store([
+            'zaak' => $zaak->openzaak->url,
+            'informatieobject' => $informatieobject->url,
+        ]);
+
+        Storage::delete($data['file']);
+
+        Cache::forget("zaak.{$zaak->id}.documenten");
+
+        return $informatieobject;
+    }
+}

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -11,7 +11,6 @@ class DocumentController extends Controller
 {
     public function __invoke(DocumentRequest $request, Zaak $zaak, string $documentuuid, ?string $type = 'view')
     {
-        /** @phpstan-ignore-next-line */
         $document = $zaak->documenten->where('uuid', $documentuuid)->firstOrFail();
 
         $validated = $request->validated();

--- a/app/Livewire/Thread/Document.php
+++ b/app/Livewire/Thread/Document.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Livewire\Thread;
+
+use App\Models\Zaak;
+use App\ValueObjects\ZGW\Informatieobject;
+use Filament\Actions\Action;
+use Filament\Actions\Concerns\InteractsWithActions;
+use Filament\Actions\Contracts\HasActions;
+use Filament\Schemas\Concerns\InteractsWithSchemas;
+use Filament\Schemas\Contracts\HasSchemas;
+use Livewire\Component;
+use Woweb\Openzaak\Openzaak;
+
+class Document extends Component implements HasActions, HasSchemas
+{
+    use InteractsWithActions;
+    use InteractsWithSchemas;
+
+    public Zaak $zaak;
+
+    public string $documentUrl;
+
+    public int $versie;
+
+    public int $latestVersion;
+
+    private Informatieobject $document;
+
+    public function mount(): void
+    {
+        $this->document = $this->zaak->documenten->firstWhere('url', $this->documentUrl);
+        $this->latestVersion = (int) $this->document->versie;
+
+        if ((int) $this->document->versie !== $this->versie) {
+            $this->document = new Informatieobject(...(new Openzaak)->get($this->documentUrl.'?versie='.$this->versie)->toArray());
+        }
+    }
+
+    public function viewAction(): Action
+    {
+        return Action::make('view')
+            ->label(__('Bekijken'))
+            ->url(fn (): string => route('zaak.documents.view', [
+                'zaak' => $this->zaak->id,
+                'documentuuid' => $this->document->uuid,
+                'type' => 'view',
+                'version' => $this->versie,
+            ]))
+            ->openUrlInNewTab()
+            ->icon('heroicon-o-eye')
+            ->link()
+            ->size('sm');
+    }
+
+    public function downloadAction(): Action
+    {
+        return Action::make('download')
+            ->label(__('Downloaden'))
+            ->url(fn (): string => route('zaak.documents.view', [
+                'zaak' => $this->zaak->id,
+                'documentuuid' => $this->document->uuid,
+                'type' => 'download',
+            ]))
+            ->openUrlInNewTab()
+            ->icon('heroicon-o-arrow-down-tray')
+            ->link()
+            ->size('sm');
+    }
+
+    public function render()
+    {
+        return view('livewire.thread.document');
+    }
+}

--- a/app/Livewire/Thread/MessageForm.php
+++ b/app/Livewire/Thread/MessageForm.php
@@ -5,17 +5,31 @@ namespace App\Livewire\Thread;
 use App\Enums\AdviceStatus;
 use App\Enums\Role;
 use App\Enums\ThreadType;
+use App\Filament\Shared\Resources\Zaken\Actions\NewDocumentVersionAction;
+use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Models\Message;
 use App\Models\Thread;
+use App\ValueObjects\MessageDocument;
+use App\ValueObjects\ZGW\Informatieobject;
+use Filament\Actions\Action;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
 use Filament\Forms\Components\RichEditor;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\ToggleButtons;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Collection;
+use Livewire\Attributes\Computed;
 use Livewire\Component;
+use Woweb\Openzaak\Openzaak;
 
 /**
  * @property \Filament\Schemas\Schema|mixed $form
@@ -29,9 +43,33 @@ class MessageForm extends Component implements HasActions, HasSchemas
 
     public ?array $data = [];
 
+    public array $documents = [];
+
     public function mount(): void
     {
         $this->form->fill();
+    }
+
+    #[Computed]
+    public function resolvedDocuments(): Collection
+    {
+        if (empty($this->documents)) {
+            return collect();
+        }
+
+        return collect($this->documents)->map(function ($documentData) {
+            $document = $this->thread->zaak->documenten->firstWhere('url', $documentData['url']);
+
+            if ($document->versie !== $documentData['versie']) {
+                $document = new Informatieobject(...(new Openzaak)->get($document->url.'?versie='.$documentData['versie'])->toArray());
+            }
+
+            return $document ? [
+                'document' => $document,
+                'versie' => $documentData['versie'],
+                'url' => $documentData['url'],
+            ] : null;
+        })->filter();
     }
 
     public function form(Schema $schema): Schema
@@ -40,7 +78,7 @@ class MessageForm extends Component implements HasActions, HasSchemas
             ->components([
                 RichEditor::make('body')
                     ->label('Plaats een reactie')
-                    ->required()
+                    ->required(fn (): bool => empty($this->documents))
                     ->toolbarButtons([
                         ['bold', 'italic', 'underline', 'strike', 'link'],
                         ['h1', 'h2', 'h3', 'alignStart', 'alignCenter', 'alignEnd'],
@@ -56,17 +94,19 @@ class MessageForm extends Component implements HasActions, HasSchemas
 
         $data = $this->form->getState();
 
-        Message::create([
+        Message::create(array_filter([
             'thread_id' => $this->thread->id,
             'user_id' => auth()->id(),
-            'body' => $data['body'],
-        ]);
+            'body' => $data['body'] == '<p></p>' ? null : $data['body'],
+            'documents' => $this->documents,
+        ]));
 
         if ($this->thread->type == ThreadType::Advice && $this->thread->advice_status === AdviceStatus::Asked && auth()->user()->role === Role::Advisor) {
             $this->thread->update(['advice_status' => AdviceStatus::AdvisoryReplied]);
         }
 
         $this->form->fill(); // reset form state
+        $this->documents = []; // Clear attached documents
 
         $this->dispatch('thread-updated');
 
@@ -74,6 +114,79 @@ class MessageForm extends Component implements HasActions, HasSchemas
             ->title('Reactie toegevoegd')
             ->success()
             ->send();
+    }
+
+    public function attachAction(): Action
+    {
+        $zaak = $this->thread->zaak;
+
+        return Action::make('attach')
+            ->label('Bestand bijvoegen')
+            ->icon('heroicon-o-paper-clip')
+            ->color('gray')
+            ->schema([
+                ToggleButtons::make('type')
+                    ->hiddenLabel()
+                    ->default('new')
+                    ->live()
+                    ->options([
+                        'new' => 'Nieuw bestand',
+                        'version' => 'Nieuwe versie van bestaand bestand',
+                    ])
+                    ->icons([
+                        'new' => Heroicon::OutlinedArrowUpTray,
+                        'version' => Heroicon::OutlinedPlusCircle,
+                    ])
+                    ->inline(),
+
+                Section::make()
+                    ->contained(false)
+                    ->visible(fn (Get $get): bool => $get('type') === 'new')
+                    ->schema(UploadDocumentAction::schema($zaak)),
+
+                Select::make('existing_document')
+                    ->label('Selecteer bestaand document')
+                    ->options(fn () => $zaak->documenten->pluck('titel', 'uuid')->toArray())
+                    ->required()
+                    ->visible(fn (Get $get): bool => $get('type') === 'version')
+                    ->live()
+                    ->afterStateUpdated(function (Get $get, Set $set, $state) use ($zaak) {
+                        if ($state) {
+                            $documentTitle = $zaak->documenten->firstWhere('uuid', $get('existing_document'))?->titel;
+
+                            $set('titel', $documentTitle);
+                        }
+                    }),
+
+                Section::make()
+                    ->contained(false)
+                    ->visible(fn (Get $get): bool => $get('type') === 'version' && $get('existing_document') !== null)
+                    ->schema(NewDocumentVersionAction::schema()),
+
+            ])
+            ->action(function (array $data) {
+                if ($data['type'] === 'new') {
+                    $document = UploadDocumentAction::uploadDocument($data, $this->thread->zaak);
+                    $this->documents[] = MessageDocument::make($document->url, (int) $document->versie)->toArray();
+
+                    Notification::make()
+                        ->title('Document toegevoegd')
+                        ->success()
+                        ->send();
+                } elseif ($data['type'] === 'version') {
+                    NewDocumentVersionAction::createNewDocumentVersion($data['existing_document'], $data, $this->thread->zaak);
+
+                    $this->thread->zaak->refresh(); // Need to refresh to re-initialize documenten
+                    $document = $this->thread->zaak->documenten->firstWhere('uuid', $data['existing_document']);
+
+                    $this->documents[] = MessageDocument::make($document->url, (int) $document->versie)->toArray();
+
+                    Notification::make()
+                        ->title('Nieuwe versie toegevoegd')
+                        ->success()
+                        ->send();
+                }
+            });
     }
 
     public function render(): View

--- a/app/Livewire/Zaken/ZaakDocumentsTable.php
+++ b/app/Livewire/Zaken/ZaakDocumentsTable.php
@@ -2,18 +2,15 @@
 
 namespace App\Livewire\Zaken;
 
-use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Actions\NewDocumentVersionAction;
+use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Models\Zaak;
-use App\ValueObjects\ZGW\Informatieobject;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
 use Filament\Actions\Concerns\InteractsWithActions;
 use Filament\Actions\Contracts\HasActions;
-use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Select;
-use Filament\Forms\Components\TextInput;
-use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Livewire;
 use Filament\Schemas\Concerns\InteractsWithSchemas;
 use Filament\Schemas\Contracts\HasSchemas;
@@ -22,8 +19,6 @@ use Filament\Tables\Concerns\InteractsWithTable;
 use Filament\Tables\Contracts\HasTable;
 use Filament\Tables\Table;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Storage;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
@@ -54,12 +49,14 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
     public function table(Table $table): Table
     {
         return $table
-            /** @phpstan-ignore-next-line */
             ->records(fn (): Collection => $this->zaak->documenten->map(fn ($item) => $item->toArray()))
             ->columns([
                 TextColumn::make('titel'),
+                TextColumn::make('informatieobjecttype')
+                    ->label(__('Type document'))
+                    ->formatStateUsing(fn ($state) => $this->zaak->zaaktype->document_types->firstWhere('url', $state)->omschrijving),
                 TextColumn::make('creatiedatum')
-                    ->date('d-m-Y')
+                    ->date('j M Y')
                     ->sortable(),
                 TextColumn::make('versie')
                     ->sortable(),
@@ -90,54 +87,7 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
                     ->openUrlInNewTab()
                     ->icon('heroicon-o-arrow-down-tray'),
                 ActionGroup::make([
-                    Action::make('new-version')
-                        ->label(__('Nieuwe versie toevoegen'))
-                        ->icon('heroicon-o-plus-circle')
-                        ->modalSubmitAction(fn (Action $action) => $action->label(__('Nieuwe versie toevoegen')))
-                        ->schema(fn (array $record) => [
-                            TextInput::make('titel')
-                                ->label(__('Titel'))
-                                ->required()
-                                ->maxLength(255)
-                                ->default($record['titel']),
-                            FileUpload::make('file')
-                                ->label(__('Bestand'))
-                                ->required()
-                                ->maxSize(20480) // 20MB
-                                ->directory('documents')
-                                ->visibility('private')
-                                ->storeFileNamesIn('file_name'),
-                        ])
-                        ->modalAutofocus(false)
-                        ->action(function (array $record, array $data): void {
-
-                            $oz = new Openzaak;
-                            $lockString = $oz->documenten()->enkelvoudiginformatieobjecten()->lock($record['uuid']);
-                            $oz->documenten()->enkelvoudiginformatieobjecten()->patch($record['uuid'],
-                                [
-                                    'inhoud' => base64_encode(Storage::get($data['file'])),
-                                    'titel' => $data['titel'],
-                                    'auteur' => auth()->user()->name,
-                                    'bestandsnaam' => $data['file_name'],
-                                    'bestandsomvang' => Storage::size($data['file']),
-                                    'formaat' => Storage::mimeType($data['file']),
-                                    'lock' => $lockString,
-                                ]);
-                            // unlock file
-                            $oz->documenten()->enkelvoudiginformatieobjecten()->unlock($record['uuid'], $lockString);
-
-                            Notification::make()
-                                ->title('Nieuwe versie is toegevoegd')
-                                ->success()
-                                ->send();
-
-                            Storage::delete($data['file']);
-
-                            Cache::forget("zaak.{$this->zaak->id}.documenten");
-
-                            $this->dispatch('refreshTable');
-
-                        }),
+                    NewDocumentVersionAction::make($this->zaak),
                     Action::make('audittrail')
                         ->label(__('Audit trail'))
                         ->icon('heroicon-o-clock')
@@ -181,77 +131,7 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
                     ->visible(fn (): bool => auth()->user()->role != Role::Organiser),
             ])
             ->toolbarActions([
-                Action::make('upload')
-                    ->label(__('Nieuw bestand toevoegen'))
-                    ->icon('heroicon-o-arrow-up-tray')
-                    ->modalSubmitAction(fn (Action $action) => $action->label(__('Bestand toevoegen')))
-                    ->schema([
-                        TextInput::make('titel')
-                            ->label(__('Titel'))
-                            ->required()
-                            ->maxLength(255),
-                        Select::make('informatieobjecttype')
-                            ->label(__('Type document'))
-                            ->options(fn () => $this->zaak->zaaktype->document_types->pluck('omschrijving', 'url')->toArray())
-                            ->required(),
-                        Select::make('vertrouwelijkheidaanduiding')
-                            ->label(__('Wie mag dit document inzien?'))
-                            ->options(function () {
-                                /** @phpstan-ignore-next-line */
-                                $vertrouwelijkheden = DocumentVertrouwelijkheden::fromUserRole(auth()->user()->role);
-                                $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
-                                $options = [];
-                                foreach ($rolesByVertrouwelijkheid as $key => $roles) {
-                                    if (in_array($key, $vertrouwelijkheden)) {
-                                        $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
-                                    }
-                                }
-
-                                return $options;
-                            })
-                            ->required(),
-                        FileUpload::make('file')
-                            ->label(__('Bestand'))
-                            ->required()
-                            ->maxSize(20480) // 20MB
-                            ->directory('documents')
-                            ->visibility('private')
-                            ->storeFileNamesIn('file_name'),
-                    ])
-                    ->modalAutofocus(false)
-                    ->action(function (array $data): void {
-
-                        $oz = new Openzaak;
-                        $informatieobject = new Informatieobject(...$oz->documenten()->enkelvoudiginformatieobjecten()->store([
-                            'bronorganisatie' => $this->zaak->openzaak->bronorganisatie,
-                            'creatiedatum' => now()->format('Y-m-d'),
-                            'vertrouwelijkheidaanduiding' => $data['vertrouwelijkheidaanduiding'],
-                            'titel' => $data['titel'],
-                            'auteur' => auth()->user()->name,
-                            'taal' => 'dut',
-                            'bestandsnaam' => $data['file_name'],
-                            'bestandsomvang' => Storage::size($data['file']),
-                            'formaat' => Storage::mimeType($data['file']),
-                            'inhoud' => base64_encode(Storage::get($data['file'])),
-                            'informatieobjecttype' => $data['informatieobjecttype'],
-                        ]));
-
-                        $oz->zaken()->zaakinformatieobjecten()->store([
-                            'zaak' => $this->zaak->openzaak->url,
-                            'informatieobject' => $informatieobject->url,
-                        ]);
-
-                        Notification::make()
-                            ->title('Document is toegevoegd')
-                            ->success()
-                            ->send();
-
-                        Storage::delete($data['file']);
-
-                        Cache::forget("zaak.{$this->zaak->id}.documenten");
-
-                        $this->dispatch('refreshTable');
-                    }),
+                UploadDocumentAction::make($this->zaak),
             ]);
     }
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Observers\MessageObserver;
+use App\ValueObjects\MessageDocument;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,7 +13,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 
 /**
  * @property-read Thread $thread
- * @property-read User $user
+ * @property-read User   $user
  */
 #[ObservedBy(MessageObserver::class)]
 class Message extends Model
@@ -23,7 +25,15 @@ class Message extends Model
         'thread_id',
         'user_id',
         'body',
+        'documents',
     ];
+
+    protected function casts(): array
+    {
+        return [
+            'documents' => AsCollection::of(MessageDocument::class),
+        ];
+    }
 
     public function thread(): BelongsTo
     {

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -18,6 +18,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Woweb\Openzaak\ObjectsApi;
 use Woweb\Openzaak\Openzaak;
@@ -26,6 +27,7 @@ use Woweb\Openzaak\Openzaak;
  * @property-read ZaakReferenceData $reference_data
  * @property-read Organisation $organisation
  * @property-read Municipality $municipality
+ * @property-read Collection<Informatieobject> $documenten
  */
 class Zaak extends Model implements Eventable
 {

--- a/app/ValueObjects/MessageDocument.php
+++ b/app/ValueObjects/MessageDocument.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\ValueObjects;
+
+use Illuminate\Contracts\Support\Arrayable;
+use JsonSerializable;
+
+class MessageDocument implements Arrayable, JsonSerializable
+{
+    public string $url;
+
+    public int $versie;
+
+    public function __construct(array $data)
+    {
+        $this->url = $data['url'];
+        $this->versie = $data['versie'];
+    }
+
+    public static function make(string $url, int $versie): self
+    {
+        return new self(['url' => $url, 'versie' => $versie]);
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'url' => $this->url,
+            'versie' => $this->versie,
+        ];
+    }
+
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/database/migrations/2025_10_01_090006_add_document_columns_to_messages_table.php
+++ b/database/migrations/2025_10_01_090006_add_document_columns_to_messages_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->text('body')->nullable()->change();
+            $table->json('documents')->after('body')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('messages', function (Blueprint $table) {
+            $table->text('body')->nullable(false)->change();
+            $table->dropColumn('documents');
+        });
+    }
+};

--- a/resources/views/filament/infolists/components/thread-messages-entry.blade.php
+++ b/resources/views/filament/infolists/components/thread-messages-entry.blade.php
@@ -31,13 +31,11 @@
 
                                                 @case(\App\Enums\Role::MunicipalityAdmin)
                                                 @case(\App\Enums\Role::ReviewerMunicipalityAdmin)
-                                                    Gemeentelijk beheerder
-                                                    bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
+                                                    Gemeentelijk beheerder bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
                                                     @break
 
                                                 @case(\App\Enums\Role::Reviewer)
-                                                    Behandelaar
-                                                    bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
+                                                    Behandelaar bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
                                                     @break
 
                                                 @case(\App\Enums\Role::Advisor)
@@ -45,8 +43,7 @@
                                                     @break
 
                                                 @case(\App\Enums\Role::Organiser)
-                                                    Organisator
-                                                    bij {{ $message->user->organisations->pluck('name')->join(', ') }}
+                                                    Organisator bij {{ $message->user->organisations->pluck('name')->join(', ') }}
                                                     @break
 
                                                 @default
@@ -56,7 +53,7 @@
                                     </div>
                                     <div>
                                         <time datetime="{{ $message->created_at }}">
-                                            {{ $message->created_at->format('M d H:m') }}
+                                            {{ $message->created_at->translatedFormat('j M Y H:i') }}
                                         </time>
                                     </div>
                                 </div>
@@ -64,6 +61,13 @@
                             <div class="mt-4 prose prose-sm max-w-none">
                                 {!! str($message->body)->sanitizeHtml() !!}
                             </div>
+                            @if(!empty($message->documents))
+                                <div class="mt-4 space-y-2">
+                                    @foreach($message->documents as $document)
+                                        <livewire:thread.document :zaak="$message->thread->zaak" :documentUrl="$document->url" :versie="$document->versie" />
+                                    @endforeach
+                                </div>
+                            @endif
                         </x-filament::section>
                     </li>
                 @endforeach

--- a/resources/views/livewire/thread/document.blade.php
+++ b/resources/views/livewire/thread/document.blade.php
@@ -1,0 +1,28 @@
+<x-filament::card :compact="true">
+    <div class="flex gap-4 flex-col sm:flex-row justify-between">
+        <div class="flex gap-2 items-center">
+            <x-heroicon-s-document class="shrink-0 size-8 text-gray-400"/>
+            <div>
+                <p class="text-sm font-semibold text-gray-900 dark:text-white/80 whitespace-nowrap overflow-hidden text-ellipsis">
+                    {{ $this->document->titel }}
+                </p>
+                <p class="text-sm text-gray-500">
+                    {{ $this->document->bestandsnaam }}
+                </p>
+            </div>
+        </div>
+        <div class="flex gap-3">
+            {{ $this->viewAction }}
+            {{ $this->downloadAction }}
+        </div>
+    </div>
+    <p class="sm:ml-10 text-xs text-gray-500 mt-2 sm:mt-1">
+        Aangemaakt op: {{ \Illuminate\Support\Carbon::parse($this->document->creatiedatum)->translatedFormat('j M Y') }}
+        <span class="inline-block size-0.5 mx-1 bg-gray-400 rounded-full align-middle"></span>
+        Auteur: {{ $this->document->auteur }}
+        <span class="inline-block size-0.5 mx-1 bg-gray-400 rounded-full align-middle"></span>
+        <span>Versie: {{ $this->versie }}@if($this->versie != $this->latestVersion) (Nieuwste versie is {{ $this->latestVersion }})@endif</span>
+        <span class="inline-block size-0.5 mx-1 bg-gray-400 rounded-full align-middle"></span>
+        <span>Type: {{ $this->zaak->zaaktype->document_types->firstWhere('url', $this->document->informatieobjecttype)->omschrijving  }}</span>
+    </p>
+</x-filament::card>

--- a/resources/views/livewire/thread/message-form.blade.php
+++ b/resources/views/livewire/thread/message-form.blade.php
@@ -2,10 +2,33 @@
     <form wire:submit="submit">
         {{ $this->form }}
 
+        @if(!empty($this->documents))
+            <div class="mt-2 space-y-2">
+                @foreach($this->resolvedDocuments as $item)
+                <x-filament::card :compact="true">
+                    <div class="flex gap-4 flex-col sm:flex-row justify-between">
+                        <div class="flex gap-2 items-center">
+                            <x-heroicon-s-document class="shrink-0 size-8 text-gray-400"/>
+                            <div>
+                                <p class="text-sm font-medium text-gray-700 dark:text-white/80 whitespace-nowrap overflow-hidden text-ellipsis">
+                                    {{ $item['document']->titel }}
+                                </p>
+                                <p class="text-sm text-gray-500">
+                                    {{ $item['document']->bestandsnaam }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="flex gap-3">
+
+                        </div>
+                    </div>
+                </x-filament::card>
+                @endforeach
+            </div>
+        @endif
+
         <div class="mt-4 flex items-center justify-end space-x-4">
-            <x-filament::button icon="heroicon-o-paper-clip" color="gray">
-                Bestand bijvoegen
-            </x-filament::button>
+            {{ $this->attachAction }}
 
             <x-filament::button type="submit" icon="heroicon-o-paper-airplane">
                 Comment
@@ -13,5 +36,5 @@
         </div>
     </form>
 
-    <x-filament-actions::modals />
+    <x-filament-actions::modals/>
 </div>


### PR DESCRIPTION
- Introduced the ability to attach documents to thread messages.
- Added support for creating new versions of existing documents in threads.
- Modularized document actions with `UploadDocumentAction` and `NewDocumentVersionAction` classes.
- Updated `MessageForm` to allow users to attach files or link to existing documents.
- Enhanced `Message` model with `document_url` support for associated documents.
- Updated UI components to manage and display attached documents in threads.
- Added migration to include `document_url` column in the `messages` table.
- Improved Dutch translations for document-related actions and UI elements.