### PR TITLE
Feature/calendar improvements

### DIFF
--- a/app/Filament/Admin/Widgets/AdminCalendarWidget.php
+++ b/app/Filament/Admin/Widgets/AdminCalendarWidget.php
@@ -4,49 +4,18 @@ namespace App\Filament\Admin\Widgets;
 
 use App\Filament\Shared\Resources\Zaken\Schemas\Components\RisicoClassificatiesSelect;
 use App\Filament\Shared\Widgets\CalendarWidget;
-use App\Models\Municipality;
-use App\Models\Organisation;
-use Filament\Forms\Components\Select;
-use Guava\Calendar\ValueObjects\FetchInfo;
-use Illuminate\Database\Eloquent\Builder;
 
 class AdminCalendarWidget extends CalendarWidget
 {
     protected function getFilterSchema(): array
     {
         return [
-            Select::make('municipalities')
-                ->label(__('admin/resources/municipality.plural_label'))
-                ->options(fn () => Municipality::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
-            Select::make('organisations')
-                ->label(__('admin/resources/organisation.plural_label'))
-                ->options(fn () => Organisation::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
+            $this->municipalitiesFilter(),
+            $this->zaaktypesFilter(),
+            $this->statusNameFilter(),
+            $this->organisationsFilter(),
             RisicoClassificatiesSelect::make(),
+            $this->searchFilter(),
         ];
-    }
-
-    protected function applyContextFilters(Builder $query, FetchInfo $info): Builder
-    {
-        $filters = $this->filters ?? [];
-
-        if (! empty($filters['municipalities'])) {
-            $query->whereHas('zaaktype', fn (Builder $q) => $q->whereIn('municipality_id', $filters['municipalities']));
-        }
-
-        if (! empty($filters['organisations'])) {
-            $query->whereIn('organisation_id', $filters['organisations']);
-        }
-
-        if (! empty($filters['risico_classificaties'])) {
-            $query->whereIn('reference_data->risico_classificatie', $filters['risico_classificaties']);
-        }
-
-        return $query;
     }
 }

--- a/app/Filament/Advisor/Widgets/AdvisorCalendarWidget.php
+++ b/app/Filament/Advisor/Widgets/AdvisorCalendarWidget.php
@@ -4,49 +4,17 @@ namespace App\Filament\Advisor\Widgets;
 
 use App\Filament\Shared\Resources\Zaken\Schemas\Components\RisicoClassificatiesSelect;
 use App\Filament\Shared\Widgets\CalendarWidget;
-use App\Models\Municipality;
-use App\Models\Organisation;
-use Filament\Forms\Components\Select;
-use Guava\Calendar\ValueObjects\FetchInfo;
-use Illuminate\Database\Eloquent\Builder;
 
 class AdvisorCalendarWidget extends CalendarWidget
 {
     protected function getFilterSchema(): array
     {
         return [
-            Select::make('municipalities')
-                ->label(__('admin/resources/municipality.plural_label'))
-                ->options(fn () => Municipality::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
-            Select::make('organisations')
-                ->label(__('admin/resources/organisation.plural_label'))
-                ->options(fn () => Organisation::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
+            $this->municipalitiesFilter(),
+            $this->statusNameFilter(),
+            $this->organisationsFilter(),
             RisicoClassificatiesSelect::make(),
+            $this->searchFilter(),
         ];
-    }
-
-    protected function applyContextFilters(Builder $query, FetchInfo $info): Builder
-    {
-        $filters = $this->filters ?? [];
-
-        if (! empty($filters['municipalities'])) {
-            $query->whereHas('zaaktype', fn (Builder $q) => $q->whereIn('municipality_id', $filters['municipalities']));
-        }
-
-        if (! empty($filters['organisations'])) {
-            $query->whereIn('organisation_id', $filters['organisations']);
-        }
-
-        if (! empty($filters['risico_classificaties'])) {
-            $query->whereIn('reference_data->risico_classificatie', $filters['risico_classificaties']);
-        }
-
-        return $query;
     }
 }

--- a/app/Filament/Exports/EventExporter.php
+++ b/app/Filament/Exports/EventExporter.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Filament\Exports;
+
+use App\Models\Event;
+use Filament\Actions\Exports\ExportColumn;
+use Filament\Actions\Exports\Exporter;
+use Filament\Actions\Exports\Models\Export;
+use Illuminate\Support\Number;
+
+class EventExporter extends Exporter
+{
+    protected static ?string $model = Event::class;
+
+    public static function getColumns(): array
+    {
+        return [
+            //            ExportColumn::make('public_id'),
+            //            ExportColumn::make('zaaktype.name'),
+            //            ExportColumn::make('organisation.name'),
+            //            ExportColumn::make('reference_data.risico_classificatie'),
+            ExportColumn::make('reference_data.naam_evenement')
+                ->label('Naam evenement'),
+            ExportColumn::make('reference_data.naam_locatie_eveneme')
+                ->label('Locatie'),
+            ExportColumn::make('reference_data.start_evenement')
+                ->label('Start evenement'),
+            ExportColumn::make('reference_data.eind_evenement')
+                ->label('Eind evenement'),
+            ExportColumn::make('reference_data.organisator')
+                ->label('Organisator'),
+            ExportColumn::make('reference_data.registratiedatum')
+                ->label('Registratiedatum'),
+            ExportColumn::make('reference_data.status_name')
+                ->label('Status'),
+            //            ExportColumn::make('created_at'),
+            //            ExportColumn::make('updated_at'),
+        ];
+    }
+
+    public static function getCompletedNotificationBody(Export $export): string
+    {
+        $body = 'Je evenementen export is afgerond en '.Number::format($export->successful_rows).' '.str('rij')->plural($export->successful_rows).' zijn geëxporteerd.';
+
+        if ($failedRowsCount = $export->getFailedRowsCount()) {
+            $body .= ' '.Number::format($failedRowsCount).' '.str('rij')->plural($failedRowsCount).' konden niet worden geëxporteerd.';
+        }
+
+        return $body;
+    }
+}

--- a/app/Filament/Municipality/Widgets/MunicipalityCalendarWidget.php
+++ b/app/Filament/Municipality/Widgets/MunicipalityCalendarWidget.php
@@ -4,9 +4,7 @@ namespace App\Filament\Municipality\Widgets;
 
 use App\Filament\Shared\Resources\Zaken\Schemas\Components\RisicoClassificatiesSelect;
 use App\Filament\Shared\Widgets\CalendarWidget;
-use App\Models\Organisation;
 use Filament\Facades\Filament;
-use Filament\Forms\Components\Select;
 use Guava\Calendar\ValueObjects\FetchInfo;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -15,32 +13,22 @@ class MunicipalityCalendarWidget extends CalendarWidget
     protected function getFilterSchema(): array
     {
         return [
-            Select::make('organisations')
-                ->label(__('admin/resources/organisation.plural_label'))
-                ->options(fn () => Organisation::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
+            $this->zaaktypesFilter(),
+            $this->statusNameFilter(),
+            $this->organisationsFilter(),
             RisicoClassificatiesSelect::make(),
+            $this->searchFilter(),
         ];
     }
 
     protected function applyContextFilters(Builder $query, FetchInfo $info): Builder
     {
+        $query = parent::applyContextFilters($query, $info);
+
         /** @var \App\Models\Municipality $municipality */
         $municipality = Filament::getTenant();
 
         $query->whereHas('zaaktype', fn (Builder $q) => $q->where('municipality_id', $municipality->id));
-
-        $filters = $this->filters ?? [];
-
-        if (! empty($filters['organisations'])) {
-            $query->whereIn('organisation_id', $filters['organisations']);
-        }
-
-        if (! empty($filters['risico_classificaties'])) {
-            $query->whereIn('reference_data->risico_classificatie', $filters['risico_classificaties']);
-        }
 
         return $query;
     }

--- a/app/Filament/Organiser/Widgets/OrganiserCalendarWidget.php
+++ b/app/Filament/Organiser/Widgets/OrganiserCalendarWidget.php
@@ -4,8 +4,6 @@ namespace App\Filament\Organiser\Widgets;
 
 use App\Filament\Shared\Resources\Zaken\Schemas\Components\RisicoClassificatiesSelect;
 use App\Filament\Shared\Widgets\CalendarWidget;
-use App\Models\Municipality;
-use Filament\Forms\Components\Select;
 use Guava\Calendar\ValueObjects\FetchInfo;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -14,29 +12,18 @@ class OrganiserCalendarWidget extends CalendarWidget
     protected function getFilterSchema(): array
     {
         return [
-            Select::make('municipalities')
-                ->label(__('admin/resources/municipality.plural_label'))
-                ->options(fn () => Municipality::query()->orderBy('name')->pluck('name', 'id'))
-                ->multiple()
-                ->searchable()
-                ->preload(),
+            $this->municipalitiesFilter(),
+            $this->statusNameFilter(),
             RisicoClassificatiesSelect::make(),
+            $this->searchFilter(),
         ];
     }
 
     protected function applyContextFilters(Builder $query, FetchInfo $info): Builder
     {
+        $query = parent::applyContextFilters($query, $info);
+
         // TODO Lorenso: Filter toevoegen voor alleen goed gekeurde zaken.
-
-        $filters = $this->filters ?? [];
-
-        if (! empty($filters['municipalities'])) {
-            $query->whereHas('zaaktype', fn (Builder $q) => $q->whereIn('municipality_id', $filters['municipalities']));
-        }
-
-        if (! empty($filters['risico_classificaties'])) {
-            $query->whereIn('reference_data->risico_classificatie', $filters['risico_classificaties']);
-        }
 
         return $query;
     }

--- a/app/Filament/Shared/Widgets/CalendarWidget.php
+++ b/app/Filament/Shared/Widgets/CalendarWidget.php
@@ -12,6 +12,7 @@ use Filament\Pages\Dashboard\Actions\FilterAction;
 use Filament\Pages\Dashboard\Concerns\HasFilters;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Guava\Calendar\Filament\Actions\ViewAction;
 use Guava\Calendar\ValueObjects\FetchInfo;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
@@ -34,24 +35,29 @@ class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget
 
     protected ?string $defaultEventClickAction = 'view';
 
+    public function viewAction(): ViewAction
+    {
+        return ViewAction::make()
+            ->modelLabel(__('resources/zaak.label'))
+            ->pluralModelLabel(__('resources/zaak.plural_label'))
+            ->extraModalFooterActions([
+                Action::make('view')
+                    ->label(__('shared/widgets/calendar.view_case'))
+                    ->icon('heroicon-o-arrow-top-right-on-square')
+                    ->url(fn (Zaak $record): string => route('filament.municipality.resources.zaken.view', ['tenant' => Filament::getTenant(), 'record' => $record]))
+                    ->color('primary')
+                    ->button()
+                    ->visible(fn () => in_array(auth()->user()->role, [Role::ReviewerMunicipalityAdmin, Role::MunicipalityAdmin, Role::Reviewer])),
+            ]);
+    }
+
     public function defaultSchema(Schema $schema): Schema
     {
-
         return $schema->components([
             Section::make()
                 ->columns(2)
                 ->schema(ZaakInfolist::informationschema())
-                ->columnSpan(8)
-                ->footer([
-                    Action::make('view')
-                        ->label(__('shared/widgets/calendar.view_case'))
-                        ->icon('heroicon-o-arrow-top-right-on-square')
-                        ->url(fn (Zaak $record): string => route('filament.municipality.resources.zaken.view', ['tenant' => Filament::getTenant(), 'record' => $record]))
-                        ->color('primary')
-                        ->button()
-                        ->visible(fn () => in_array(auth()->user()->role, [Role::ReviewerMunicipalityAdmin, Role::MunicipalityAdmin, Role::Reviewer])),
-                ]),
-
+                ->columnSpan(8),
         ]);
     }
 

--- a/app/Filament/Shared/Widgets/CalendarWidget.php
+++ b/app/Filament/Shared/Widgets/CalendarWidget.php
@@ -6,10 +6,15 @@ use App\Enums\Role;
 use App\Filament\Exports\EventExporter;
 use App\Filament\Shared\Resources\Zaken\Schemas\ZaakInfolist;
 use App\Models\Event;
+use App\Models\Municipality;
+use App\Models\Organisation;
 use App\Models\Zaak;
+use App\Models\Zaaktype;
 use Filament\Actions\Action;
 use Filament\Actions\ExportAction;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\TextInput;
 use Filament\Pages\Dashboard\Actions\FilterAction;
 use Filament\Pages\Dashboard\Concerns\HasFilters;
 use Filament\Schemas\Components\Section;
@@ -18,6 +23,8 @@ use Guava\Calendar\Filament\Actions\ViewAction;
 use Guava\Calendar\ValueObjects\FetchInfo;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\HtmlString;
 
 class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget
@@ -98,6 +105,124 @@ class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget
     // Let child widgets add their own constraints.
     protected function applyContextFilters(Builder $query, FetchInfo $info): Builder
     {
+        $filters = $this->filters ?? [];
+
+        $this->applyMunicipalitiesFilter($query, $filters);
+
+        $this->applyStatusNameFilter($query, $filters);
+
+        $this->applyOrganisationsFilter($query, $filters);
+
+        $this->applySearchFilter($query, $filters);
+
+        $this->applyRisicoClassificatiesFilter($query, $filters);
+
+        $this->applyZaaktypesFilter($query, $filters);
+
         return $query;
+    }
+
+    protected function municipalitiesFilter()
+    {
+        return Select::make('municipalities')
+            ->label(__('admin/resources/municipality.plural_label'))
+            ->options(fn () => Municipality::query()->orderBy('name')->pluck('name', 'id'))
+            ->multiple()
+            ->searchable()
+            ->preload();
+    }
+
+    protected function applyMunicipalitiesFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['municipalities'])) {
+            $query->whereHas('zaaktype', fn (Builder $q) => $q->whereIn('municipality_id', $filters['municipalities']));
+        }
+    }
+
+    protected function organisationsFilter()
+    {
+        return Select::make('organisations')
+            ->label(__('admin/resources/organisation.plural_label'))
+            ->options(fn () => Organisation::query()->orderBy('name')->pluck('name', 'id'))
+            ->multiple()
+            ->searchable()
+            ->preload();
+    }
+
+    protected function applyOrganisationsFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['organisations'])) {
+            $query->whereIn('organisation_id', $filters['organisations']);
+        }
+    }
+
+    protected function statusNameFilter()
+    {
+        return Select::make('reference_data.status_name')
+            ->label('Status')
+            ->options(function () {
+                return Cache::remember('zaak_status_name_options', 60 * 60 * 24, function () {
+                    return Zaak::query()
+                        ->select(DB::raw("DISTINCT JSON_UNQUOTE(JSON_EXTRACT(reference_data, '$.status_name')) as status_name"))
+                        ->pluck('status_name')
+                        ->mapWithKeys(fn ($status_name) => [$status_name => $status_name]);
+                });
+            })
+            ->multiple()
+            ->searchable()
+            ->preload();
+    }
+
+    protected function applyStatusNameFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['reference_data.status_name'])) {
+            $query->whereIn('reference_data->status_name', $filters['reference_data.status_name']);
+        }
+    }
+
+    protected function applyRisicoClassificatiesFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['risico_classificaties'])) {
+            $query->whereIn('reference_data->risico_classificatie', $filters['risico_classificaties']);
+        }
+    }
+
+    protected function searchFilter()
+    {
+        return TextInput::make('search')
+            ->label(__('Search'))
+            ->helperText('Zoek op evenement naam of naam van de indiener');
+    }
+
+    protected function applySearchFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['search'])) {
+            $term = trim($filters['search']);
+
+            $query->where(function (Builder $q) use ($term) {
+                $q->where('reference_data->naam_evenement', 'like', "%{$term}%")
+//                    ->orWhere('reference_data->indiener_naam', 'like', "%{$term}%") // TODO: Implement when indiener fields are added
+//                    ->orWhere('reference_data->indiener_email', 'like', "%{$term}%")
+                    ->orWhere('public_id', 'like', "%{$term}%")
+                    ->orWhereHas('organisation', fn (Builder $oq) => $oq->where('name', 'like', "%{$term}%"));
+            });
+        }
+    }
+
+    protected function zaaktypesFilter()
+    {
+        return Select::make('zaaktypes')
+            ->label(__('resources/zaak.columns.zaaktype.label'))
+            ->options(fn () => Zaaktype::query()->orderBy('name')->pluck('name', 'id'))
+            ->multiple()
+            ->searchable()
+            ->preload();
+    }
+
+    protected function applyZaaktypesFilter(Builder $query, array $filters)
+    {
+        if (! empty($filters['zaaktypes'])) {
+            $query->whereIn('zaaktype_id', $filters['zaaktypes']);
+        }
     }
 }

--- a/app/Filament/Shared/Widgets/CalendarWidget.php
+++ b/app/Filament/Shared/Widgets/CalendarWidget.php
@@ -3,10 +3,12 @@
 namespace App\Filament\Shared\Widgets;
 
 use App\Enums\Role;
+use App\Filament\Exports\EventExporter;
 use App\Filament\Shared\Resources\Zaken\Schemas\ZaakInfolist;
 use App\Models\Event;
 use App\Models\Zaak;
 use Filament\Actions\Action;
+use Filament\Actions\ExportAction;
 use Filament\Facades\Filament;
 use Filament\Pages\Dashboard\Actions\FilterAction;
 use Filament\Pages\Dashboard\Concerns\HasFilters;
@@ -68,6 +70,15 @@ class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget
                 ->schema($this->getFilterSchema())
                 ->badge(fn () => count(array_filter($this->filters ?? [])))
                 ->after(fn () => $this->dispatch('calendar--refresh')),
+            ExportAction::make()
+                ->exporter(EventExporter::class)
+                ->label('Evenementen exporteren')
+                ->modalHeading('Evenementen exporteren')
+                ->columnMapping(false)
+                ->modifyQueryUsing(fn (Builder $query, array $options) => $this->applyContextFilters($query, new FetchInfo([
+                    'startStr' => now()->subYears(100),
+                    'endStr' => now()->addYears(100),
+                ]))),
         ];
     }
 

--- a/app/Jobs/CleanupExports.php
+++ b/app/Jobs/CleanupExports.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Jobs;
+
+use Filament\Actions\Exports\Models\Export;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class CleanupExports implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        foreach (Export::where('created_at', '<', now()->subDays(7))->get() as $export) {
+            $export->deleteFileDirectory();
+            $export->delete();
+        }
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -34,6 +34,11 @@ class User extends Authenticatable implements HasAppAuthentication, HasAppAuthen
         return 'user_id';
     }
 
+    public function getMorphClass()
+    {
+        return User::class;
+    }
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/Providers/Filament/AdminPanelProvider.php
+++ b/app/Providers/Filament/AdminPanelProvider.php
@@ -41,6 +41,7 @@ class AdminPanelProvider extends PanelProvider
             ->pages([
                 Dashboard::class,
             ])
+            ->databaseNotifications()
             ->login()
             ->passwordReset()
             ->profile(EditProfile::class)

--- a/app/Providers/Filament/AdvisorPanelProvider.php
+++ b/app/Providers/Filament/AdvisorPanelProvider.php
@@ -42,6 +42,7 @@ class AdvisorPanelProvider extends PanelProvider
             ->pages([
                 Dashboard::class,
             ])
+            ->databaseNotifications()
             ->login()
             ->passwordReset()
             ->profile()

--- a/app/Providers/Filament/MunicipalityPanelProvider.php
+++ b/app/Providers/Filament/MunicipalityPanelProvider.php
@@ -44,6 +44,7 @@ class MunicipalityPanelProvider extends PanelProvider
             ->pages([
                 Dashboard::class,
             ])
+            ->databaseNotifications()
             ->login()
             ->passwordReset()
             ->profile(EditProfile::class)

--- a/app/Providers/Filament/OrganiserPanelProvider.php
+++ b/app/Providers/Filament/OrganiserPanelProvider.php
@@ -48,6 +48,7 @@ class OrganiserPanelProvider extends PanelProvider
             ->pages([
                 Dashboard::class,
             ])
+            ->databaseNotifications()
             ->discoverClusters(in: app_path('Filament/Organiser/Clusters'), for: 'App\\Filament\\Organiser\\Clusters')
             ->login()
             ->registration(Register::class)

--- a/config/app.php
+++ b/config/app.php
@@ -135,7 +135,7 @@ return [
     'api' => [
         'token_expire_in_days' => env('APP_API_TOKEN_EXPIRE_IN_DAYS', 365),
     ],
-  
+
     'date_format' => env('APP_DATE_FORMAT', 'd-m-Y'),
     'datetime_format' => env('APP_DATETIME_FORMAT', 'd-m-Y H:i'),
 

--- a/database/migrations/2025_10_02_115844_create_job_batches_table.php
+++ b/database/migrations/2025_10_02_115844_create_job_batches_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('job_batches', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->longText('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('job_batches');
+    }
+};

--- a/database/migrations/2025_10_02_115849_create_notifications_table.php
+++ b/database/migrations/2025_10_02_115849_create_notifications_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('type');
+            $table->morphs('notifiable');
+            $table->text('data');
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/2025_10_02_115857_create_exports_table.php
+++ b/database/migrations/2025_10_02_115857_create_exports_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('exports', function (Blueprint $table): void {
+            $table->id();
+            $table->timestamp('completed_at')->nullable();
+            $table->string('file_disk');
+            $table->string('file_name')->nullable();
+            $table->string('exporter');
+            $table->unsignedInteger('processed_rows')->default(0);
+            $table->unsignedInteger('total_rows');
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('exports');
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -10,5 +10,6 @@ Schedule::call(function () {
 })->weekly();
 
 Schedule::job(new \App\Jobs\CleanupExpiredInvites)->daily();
+Schedule::job(new \App\Jobs\CleanupExports)->daily();
 
 Schedule::command('sync:zaaktypen')->dailyAt('02:00');


### PR DESCRIPTION
Als je op een kalender event klikt krijg je nu onderstaande popup te zien. De titel is aangepast naar "Zaak bekijken" en de "Bekijk zaak" staat nu naast de Sluiten knop zodat het consistent is met alle andere modals in Filament.
<img width="908" height="412" alt="image" src="https://github.com/user-attachments/assets/a7a03d91-3836-402f-b6b2-4e1cf5bc2e29" />

De "Evenementen exporteren" functie werkt nu heel simpel: Hij exporteert alle evenementen waar je bij kan in de kalender. Laat maar weten of ik nog een time range filter ofzo toe moet voegen.
<img width="1245" height="692" alt="image" src="https://github.com/user-attachments/assets/3f3f0fd1-9b40-49bb-a999-19b643f360af" />

Voor de exports maak ik gebruik van Filament exports. Deze zijn altijd async en via queued jobs (vandaar de migraties). Op alle panels staan database notifications nu dus aan zodat je een bericht kan ontvangen waarmee je de export kan downloaden:
<img width="542" height="407" alt="image" src="https://github.com/user-attachments/assets/bdf8a253-f297-4cb5-871a-1328cdbffb3b" />

Tot slot heb ik de kalender widget filters herbruikbaar gemaakt en uitgebreid. Per panel kalender widget heb ik ingesteld welke filters beschikbaar moeten zijn. Admin heeft ze allemaal:
<img width="465" height="723" alt="image" src="https://github.com/user-attachments/assets/1bc39553-afcd-42fd-96b8-88765c3a62e1" />

