### PR TITLE
Persist table filter, sort, search and column settings per user

### DIFF
--- a/app/Livewire/PersistTableStateHook.php
+++ b/app/Livewire/PersistTableStateHook.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Services\TableStatePersister;
+use Livewire\ComponentHook;
+
+/**
+ * Global Livewire hook that wires database persistence into every Filament
+ * table component automatically - no trait or base class required.
+ *
+ * Lifecycle ordering:
+ *   - boot()      fires before the component's own `bootedInteractsWithTable()`
+ *                  reads the session, so we seed database -> session here and
+ *                  Filament then restores from it.
+ *   - dehydrate() fires at the end of the request, after Filament has written
+ *                  the latest state to the session. We snapshot session -> database.
+ */
+class PersistTableStateHook extends ComponentHook
+{
+    public function boot(): void
+    {
+        $this->persister()->seed($this->component);
+    }
+
+    public function dehydrate(): void
+    {
+        $this->persister()->snapshot($this->component);
+    }
+
+    protected function persister(): TableStatePersister
+    {
+        return app(TableStatePersister::class);
+    }
+}

--- a/app/Models/TableState.php
+++ b/app/Models/TableState.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\TableStateFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property array<string, mixed> $state
+ */
+class TableState extends Model
+{
+    /** @use HasFactory<TableStateFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'user_id',
+        'table_key',
+        'state',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'state' => 'array',
+        ];
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use App\EventForm\Template\LabelRenderer;
 use App\Filament\Admin\Resources\ApplicationResource\Pages\ListApplications;
 use App\Jobs\ProcessOpenNotification;
 use App\Listeners\NotifySlackOfFailedJob;
+use App\Livewire\PersistTableStateHook;
 use App\Models\Export;
 use App\Models\Import;
 use App\Support\CarbonBusinessDaysMixin;
@@ -29,6 +30,7 @@ use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
 use Laravel\Passport\Passport;
+use Livewire\Livewire;
 use Woweb\Openzaak\Openzaak;
 
 class AppServiceProvider extends ServiceProvider
@@ -61,6 +63,13 @@ class AppServiceProvider extends ServiceProvider
         // schema-component-renders — anders zou de WeakMap-cache leeg
         // zijn bij elke Filament-resolution.
         $this->app->singleton(LabelRenderer::class);
+
+        // Mirrors the session-persisted table state (filters, sort, search,
+        // columns) into the database per user, so it survives a new session.
+        // Must be registered before LivewireServiceProvider::boot() calls
+        // ComponentHookRegistry::boot(), which only wires up hooks known at
+        // that point - hence registering here rather than in boot().
+        Livewire::componentHook(PersistTableStateHook::class);
     }
 
     /**

--- a/app/Services/TableStatePersister.php
+++ b/app/Services/TableStatePersister.php
@@ -1,0 +1,185 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\TableState;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Throwable;
+
+/**
+ * Mirrors Filament's per-table session state into the database, scoped to the
+ * authenticated user, so filters/sort/search/columns survive a new session.
+ *
+ * Filament persists this state to the session when the matching
+ * `->persist*InSession()` table options are enabled (see
+ * `AppServiceProvider::boot()`). This service simply:
+ *   - seed():     database -> session, before Filament reads the session
+ *   - snapshot(): session -> database, after Filament has written to it
+ *
+ * All public entry points are fail-safe: persistence must never break a page.
+ */
+class TableStatePersister
+{
+    /**
+     * Session-key resolver methods exposed by Filament's InteractsWithTable.
+     * Each returns the unique session key for one slice of table state. The
+     * filters key is additionally scoped per tenant (md5(class|tenant)) while
+     * all other keys hash the component class only.
+     *
+     * @var list<string>
+     */
+    protected const KEY_METHODS = [
+        'getTableFiltersSessionKey',
+        'getTableSortSessionKey',
+        'getTableSearchSessionKey',
+        'getTableColumnSearchesSessionKey',
+        'getTableColumnsSessionKey',
+        'getHasReorderedTableColumnsSessionKey',
+        'getTablePerPageSessionKey',
+    ];
+
+    /**
+     * Whether this Livewire component is a Filament table we can persist.
+     */
+    public function appliesTo(object $component): bool
+    {
+        return method_exists($component, 'getTableFiltersSessionKey');
+    }
+
+    /**
+     * Restore the user's saved state into the session for the keys this table
+     * uses, without overwriting anything already present in the session.
+     */
+    public function seed(object $component): void
+    {
+        if (! $this->appliesTo($component)) {
+            return;
+        }
+
+        try {
+            $user = $this->user();
+
+            if ($user === null) {
+                return;
+            }
+
+            $record = $this->record($user, $this->tableKey($component));
+            $stored = $record !== null ? $record->state : [];
+
+            if ($stored === []) {
+                return;
+            }
+
+            foreach ($this->sessionKeys($component) as $key) {
+                if (array_key_exists($key, $stored) && ! session()->has($key)) {
+                    session()->put($key, $stored[$key]);
+                }
+            }
+        } catch (Throwable) {
+            // Fail-safe: never break the page over persistence.
+        }
+    }
+
+    /**
+     * Persist the current session state for this table into the user's row,
+     * merging with previously saved state. Only writes when changed.
+     */
+    public function snapshot(object $component): void
+    {
+        if (! $this->appliesTo($component)) {
+            return;
+        }
+
+        try {
+            $user = $this->user();
+
+            if ($user === null) {
+                return;
+            }
+
+            $current = [];
+
+            foreach ($this->sessionKeys($component) as $key) {
+                if (session()->has($key)) {
+                    $current[$key] = session()->get($key);
+                }
+            }
+
+            if ($current === []) {
+                return;
+            }
+
+            $tableKey = $this->tableKey($component);
+            $record = $this->record($user, $tableKey);
+            $existing = $record !== null ? $record->state : [];
+            $merged = array_merge($existing, $current);
+
+            if ($merged == $existing) {
+                return;
+            }
+
+            TableState::query()->updateOrCreate(
+                ['user_id' => $user->id, 'table_key' => $tableKey],
+                ['state' => $merged],
+            );
+        } catch (Throwable) {
+            // Fail-safe: never break the page over persistence.
+        }
+    }
+
+    /**
+     * Resolve the session keys this component uses for its persisted state.
+     *
+     * @return list<string>
+     */
+    protected function sessionKeys(object $component): array
+    {
+        $keys = [];
+
+        foreach (self::KEY_METHODS as $method) {
+            if (! method_exists($component, $method)) {
+                continue;
+            }
+
+            try {
+                $key = $component->{$method}();
+            } catch (Throwable) {
+                // Key not resolvable yet (e.g. table not configured) - skip it.
+                continue;
+            }
+
+            if (is_string($key) && $key !== '') {
+                $keys[] = $key;
+            }
+        }
+
+        return $keys;
+    }
+
+    protected function record(User $user, string $tableKey): ?TableState
+    {
+        return TableState::query()
+            ->where('user_id', $user->id)
+            ->where('table_key', $tableKey)
+            ->first();
+    }
+
+    /**
+     * Stable per-table identifier: the Livewire component class hosting the
+     * table. Session-key prefixes are unusable here - Filament hashes the
+     * filters key per tenant but every other key per class, so under
+     * multi-tenancy no single prefix identifies the table.
+     */
+    protected function tableKey(object $component): string
+    {
+        return $component::class;
+    }
+
+    protected function user(): ?User
+    {
+        $user = Auth::user();
+
+        return $user instanceof User ? $user : null;
+    }
+}

--- a/database/factories/TableStateFactory.php
+++ b/database/factories/TableStateFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\TableState;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<TableState>
+ */
+class TableStateFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'table_key' => fake()->word(),
+            'state' => [],
+        ];
+    }
+}

--- a/database/migrations/2026_06_10_000000_create_table_states_table.php
+++ b/database/migrations/2026_06_10_000000_create_table_states_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('table_states', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('table_key');
+            $table->json('state');
+            $table->timestamps();
+
+            $table->unique(['user_id', 'table_key']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('table_states');
+    }
+};

--- a/tests/Feature/TableStatePersistenceTest.php
+++ b/tests/Feature/TableStatePersistenceTest.php
@@ -1,0 +1,88 @@
+<?php
+
+use App\Enums\Role;
+use App\Filament\Admin\Resources\UserResource\Pages\ListUsers;
+use App\Models\TableState;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $this->admin = User::factory()->create([
+        'email' => 'admin@example.com',
+        'role' => Role::Admin,
+    ]);
+
+    actingAs($this->admin);
+
+    $this->sortSessionKey = (new ListUsers)->getTableSortSessionKey();
+    $this->filtersSessionKey = (new ListUsers)->getTableFiltersSessionKey();
+});
+
+test('sorting a table persists the state to the database for the user', function () {
+    livewire(ListUsers::class)
+        ->sortTable('email', 'desc');
+
+    $state = TableState::query()
+        ->where('user_id', $this->admin->id)
+        ->where('table_key', ListUsers::class)
+        ->first();
+
+    expect($state)->not->toBeNull()
+        ->and($state->state)->toHaveKey($this->sortSessionKey, 'email:desc');
+});
+
+test('table state is restored from the database into a fresh session', function () {
+    TableState::factory()->create([
+        'user_id' => $this->admin->id,
+        'table_key' => ListUsers::class,
+        'state' => [
+            $this->sortSessionKey => 'email:desc',
+        ],
+    ]);
+
+    expect(session()->has($this->sortSessionKey))->toBeFalse();
+
+    livewire(ListUsers::class)
+        ->assertSet('tableSort', 'email:desc');
+
+    expect(session($this->sortSessionKey))->toBe('email:desc');
+});
+
+test('seeding from the database does not overwrite an existing session value', function () {
+    session()->put($this->sortSessionKey, 'role:asc');
+
+    TableState::factory()->create([
+        'user_id' => $this->admin->id,
+        'table_key' => ListUsers::class,
+        'state' => [
+            $this->sortSessionKey => 'email:desc',
+        ],
+    ]);
+
+    livewire(ListUsers::class)
+        ->assertSet('tableSort', 'role:asc');
+
+    expect(session($this->sortSessionKey))->toBe('role:asc');
+});
+
+test('persisting new table state is merged with previously stored state', function () {
+    livewire(ListUsers::class)
+        ->sortTable('email', 'desc');
+
+    livewire(ListUsers::class)
+        ->filterTable('trashed', true);
+
+    $state = TableState::query()
+        ->where('user_id', $this->admin->id)
+        ->where('table_key', ListUsers::class)
+        ->first();
+
+    expect($state->state)
+        ->toHaveKey($this->sortSessionKey, 'email:desc')
+        ->toHaveKey($this->filtersSessionKey);
+});


### PR DESCRIPTION
## Summary
- Adds a `table_states` table storing one row per `(user, table_key)`, where `table_key` is the Livewire component class hosting the Filament table
- A global `PersistTableStateHook` (registered via `Livewire::componentHook()`) wires database persistence into every Filament table component automatically — no trait or base class required
- On `boot()` (before Filament reads the session), saved state is seeded from the database into the session, without overwriting anything already present
- On `dehydrate()` (after Filament has written to the session), the current session state for that table's keys is snapshotted into the database, merged with previously saved state

## Approach / vooronderzoek
Filament persists table filters/sort/search/columns to per-component session keys (`getTableFiltersSessionKey()`, `getTableSortSessionKey()`, etc. on `InteractsWithTable`), already enabled globally via `Table::configureUsing()` in `AppServiceProvider`.

Initial approaches hooked into `Logout` or a global request middleware, but reworked this to follow the architecture from [kisame76/filament-db-table-state](https://github.com/kisame76/filament-db-table-state) (reimplemented natively, not pulled in as a dependency): a Livewire `ComponentHook` seeds/snapshots state per table on every request, scoped per `(user, component class)`. This covers session expiry as well as explicit logout, and keeps each table's state independently merged rather than syncing one big session blob.

Note: `Livewire::componentHook()` must be registered in `AppServiceProvider::register()`, not `boot()` — `LivewireServiceProvider::boot()` wires up `mount`/`hydrate`/`dehydrate` listeners only for hooks already present in the registry at that point, and all providers' `register()` phases run before any `boot()`.

## Test plan
- [x] New feature tests in `tests/Feature/TableStatePersistenceTest.php` cover: state persisted on sort/filter, state restored from DB into a fresh session, seeding doesn't overwrite an existing session value, and persisted state is merged across multiple updates
- [x] Full Pest suite passes (no new failures)
- [x] `./vendor/bin/pint` and `./vendor/bin/phpstan analyse` pass on changed files
- [x] Manual check: set table filters/columns/search as a user, let session expire (or log out and back in), confirm they're restored
