### PR TITLE
Add admin-configurable status/resultaat colors for the calendar (A15)

### DIFF
--- a/app/Filament/Admin/Resources/StatusResultaatColors/Pages/CreateStatusResultaatColor.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/Pages/CreateStatusResultaatColor.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors\Pages;
+
+use App\Filament\Admin\Resources\StatusResultaatColors\StatusResultaatColorResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateStatusResultaatColor extends CreateRecord
+{
+    protected static string $resource = StatusResultaatColorResource::class;
+}

--- a/app/Filament/Admin/Resources/StatusResultaatColors/Pages/EditStatusResultaatColor.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/Pages/EditStatusResultaatColor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors\Pages;
+
+use App\Filament\Admin\Resources\StatusResultaatColors\StatusResultaatColorResource;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+
+class EditStatusResultaatColor extends EditRecord
+{
+    protected static string $resource = StatusResultaatColorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/StatusResultaatColors/Pages/ListStatusResultaatColors.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/Pages/ListStatusResultaatColors.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors\Pages;
+
+use App\Filament\Admin\Resources\StatusResultaatColors\StatusResultaatColorResource;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+
+class ListStatusResultaatColors extends ListRecords
+{
+    protected static string $resource = StatusResultaatColorResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/StatusResultaatColors/Schemas/StatusResultaatColorForm.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/Schemas/StatusResultaatColorForm.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors\Schemas;
+
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\TextInput;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+
+class StatusResultaatColorForm
+{
+    public static function configure(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                TextInput::make('status_name')
+                    ->label(__('admin/resources/status_resultaat_color.form.status_name.label'))
+                    ->helperText(__('admin/resources/status_resultaat_color.form.status_name.helper_text'))
+                    ->required()
+                    ->maxLength(255),
+                TextInput::make('resultaat')
+                    ->label(__('admin/resources/status_resultaat_color.form.resultaat.label'))
+                    ->helperText(__('admin/resources/status_resultaat_color.form.resultaat.helper_text'))
+                    ->maxLength(255)
+                    ->dehydrateStateUsing(fn (?string $state) => filled($state) ? $state : null)
+                    ->unique(
+                        table: 'status_resultaat_colors',
+                        column: 'resultaat',
+                        ignorable: fn ($record) => $record,
+                        modifyRuleUsing: fn ($rule, Get $get) => $rule->where('status_name', $get('status_name')),
+                    )
+                    ->validationMessages([
+                        'unique' => __('admin/resources/status_resultaat_color.form.resultaat.unique'),
+                    ]),
+                ColorPicker::make('color')
+                    ->label(__('admin/resources/status_resultaat_color.form.color.label'))
+                    ->required(),
+            ]);
+    }
+}

--- a/app/Filament/Admin/Resources/StatusResultaatColors/StatusResultaatColorResource.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/StatusResultaatColorResource.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors;
+
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\CreateStatusResultaatColor;
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\EditStatusResultaatColor;
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\ListStatusResultaatColors;
+use App\Filament\Admin\Resources\StatusResultaatColors\Schemas\StatusResultaatColorForm;
+use App\Filament\Admin\Resources\StatusResultaatColors\Tables\StatusResultaatColorsTable;
+use App\Models\StatusResultaatColor;
+use BackedEnum;
+use Filament\Resources\Resource;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Table;
+
+class StatusResultaatColorResource extends Resource
+{
+    protected static ?string $model = StatusResultaatColor::class;
+
+    protected static string|BackedEnum|null $navigationIcon = Heroicon::OutlinedSwatch;
+
+    protected static ?int $navigationSort = 3;
+
+    public static function getModelLabel(): string
+    {
+        return __('admin/resources/status_resultaat_color.label');
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return __('admin/resources/status_resultaat_color.plural_label');
+    }
+
+    public static function form(Schema $schema): Schema
+    {
+        return StatusResultaatColorForm::configure($schema);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return StatusResultaatColorsTable::configure($table);
+    }
+
+    public static function getRelations(): array
+    {
+        return [
+            //
+        ];
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => ListStatusResultaatColors::route('/'),
+            'create' => CreateStatusResultaatColor::route('/create'),
+            'edit' => EditStatusResultaatColor::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Admin/Resources/StatusResultaatColors/Tables/StatusResultaatColorsTable.php
+++ b/app/Filament/Admin/Resources/StatusResultaatColors/Tables/StatusResultaatColorsTable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Filament\Admin\Resources\StatusResultaatColors\Tables;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+
+class StatusResultaatColorsTable
+{
+    public static function configure(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('status_name')
+                    ->label(__('admin/resources/status_resultaat_color.columns.status_name.label'))
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('resultaat')
+                    ->label(__('admin/resources/status_resultaat_color.columns.resultaat.label'))
+                    ->placeholder('—')
+                    ->searchable()
+                    ->sortable(),
+                ColorColumn::make('color')
+                    ->label(__('admin/resources/status_resultaat_color.columns.color.label')),
+            ])
+            ->defaultSort('status_name')
+            ->filters([
+                //
+            ])
+            ->recordActions([
+                EditAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+}

--- a/app/Filament/Shared/Exports/BaseEventExporter.php
+++ b/app/Filament/Shared/Exports/BaseEventExporter.php
@@ -42,6 +42,8 @@ class BaseEventExporter extends Exporter
                 ->formatStateUsing(fn ($state) => $state?->format(config('app.date_format'))),
             ExportColumn::make('reference_data.status_name')
                 ->label(__('resources/zaak.columns.status.label')),
+            ExportColumn::make('status_color')
+                ->label(__('resources/zaak.columns.status_color.label')),
         ];
     }
 

--- a/app/Models/StatusResultaatColor.php
+++ b/app/Models/StatusResultaatColor.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\StatusResultaatColorFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class StatusResultaatColor extends Model
+{
+    /** @use HasFactory<StatusResultaatColorFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'status_name',
+        'resultaat',
+        'color',
+    ];
+
+    /**
+     * Resolve the configured color for the given status/resultaat combination.
+     */
+    public static function colorFor(string $statusName, ?string $resultaat = null): ?string
+    {
+        return self::query()
+            ->where('status_name', $statusName)
+            ->where('resultaat', $resultaat)
+            ->value('color');
+    }
+}

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -269,13 +269,27 @@ class Zaak extends Model implements Eventable
         );
     }
 
+    /** @return Attribute<?string, void> */
+    protected function statusColor(): Attribute
+    {
+        return Attribute::make(
+            get: fn () => StatusResultaatColor::colorFor($this->reference_data->status_name, $this->reference_data->resultaat),
+        );
+    }
+
     public function toCalendarEvent(): CalendarEvent
     {
         // Status tekstueel toevoegen
-        return CalendarEvent::make($this)
+        $event = CalendarEvent::make($this)
             ->title($this->reference_data->naam_evenement ?? $this->public_id)
             ->start($this->reference_data->start_evenement)
             ->end($this->reference_data->eind_evenement);
+
+        if ($this->status_color) {
+            $event->backgroundColor($this->status_color);
+        }
+
+        return $event;
     }
 
     public function clearZgwCache(): void

--- a/app/Policies/StatusResultaatColorPolicy.php
+++ b/app/Policies/StatusResultaatColorPolicy.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Policies;
+
+use App\Enums\Role;
+use App\Models\StatusResultaatColor;
+use App\Models\User;
+
+class StatusResultaatColorPolicy
+{
+    /**
+     * Determine whether the user can view any models.
+     */
+    public function viewAny(User $user): bool
+    {
+        return $user->role === Role::Admin;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     */
+    public function view(User $user, StatusResultaatColor $statusResultaatColor): bool
+    {
+        return $user->role === Role::Admin;
+    }
+
+    /**
+     * Determine whether the user can create models.
+     */
+    public function create(User $user): bool
+    {
+        return $user->role === Role::Admin;
+    }
+
+    /**
+     * Determine whether the user can update the model.
+     */
+    public function update(User $user, StatusResultaatColor $statusResultaatColor): bool
+    {
+        return $user->role === Role::Admin;
+    }
+
+    /**
+     * Determine whether the user can delete the model.
+     */
+    public function delete(User $user, StatusResultaatColor $statusResultaatColor): bool
+    {
+        return $user->role === Role::Admin;
+    }
+
+    /**
+     * Determine whether the user can restore the model.
+     */
+    public function restore(User $user, StatusResultaatColor $statusResultaatColor): bool
+    {
+        return false;
+    }
+
+    /**
+     * Determine whether the user can permanently delete the model.
+     */
+    public function forceDelete(User $user, StatusResultaatColor $statusResultaatColor): bool
+    {
+        return false;
+    }
+}

--- a/database/factories/StatusResultaatColorFactory.php
+++ b/database/factories/StatusResultaatColorFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\StatusResultaatColor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<StatusResultaatColor>
+ */
+class StatusResultaatColorFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'status_name' => fake()->unique()->word(),
+            'resultaat' => null,
+            'color' => fake()->hexColor(),
+        ];
+    }
+}

--- a/database/migrations/2026_06_11_100149_create_status_resultaat_colors_table.php
+++ b/database/migrations/2026_06_11_100149_create_status_resultaat_colors_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('status_resultaat_colors', function (Blueprint $table) {
+            $table->id();
+            $table->string('status_name');
+            $table->string('resultaat')->nullable();
+            $table->string('color');
+            $table->timestamps();
+
+            $table->unique(['status_name', 'resultaat']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('status_resultaat_colors');
+    }
+};

--- a/database/migrations/2026_06_11_100235_seed_default_status_resultaat_colors.php
+++ b/database/migrations/2026_06_11_100235_seed_default_status_resultaat_colors.php
@@ -1,0 +1,48 @@
+<?php
+
+use App\Models\StatusResultaatColor;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * @return list<array{status_name: string, resultaat: ?string, color: string}>
+     */
+    private function defaults(): array
+    {
+        return [
+            ['status_name' => 'Ontvangen', 'resultaat' => null, 'color' => '#3B82F6'],
+            ['status_name' => 'In behandeling', 'resultaat' => null, 'color' => '#F59E0B'],
+            ['status_name' => 'Afgerond', 'resultaat' => null, 'color' => '#22C55E'],
+            ['status_name' => 'Afgerond', 'resultaat' => 'Verleend', 'color' => '#22C55E'],
+            ['status_name' => 'Afgerond', 'resultaat' => 'Geweigerd', 'color' => '#EF4444'],
+            ['status_name' => 'Afgerond', 'resultaat' => 'Ingetrokken', 'color' => '#6B7280'],
+            ['status_name' => 'Afgerond', 'resultaat' => 'Afgebroken', 'color' => '#6B7280'],
+        ];
+    }
+
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        foreach ($this->defaults() as $entry) {
+            StatusResultaatColor::firstOrCreate(
+                ['status_name' => $entry['status_name'], 'resultaat' => $entry['resultaat']],
+                ['color' => $entry['color']],
+            );
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        foreach ($this->defaults() as $entry) {
+            StatusResultaatColor::where('status_name', $entry['status_name'])
+                ->where('resultaat', $entry['resultaat'])
+                ->delete();
+        }
+    }
+};

--- a/lang/nl/admin/resources/status_resultaat_color.php
+++ b/lang/nl/admin/resources/status_resultaat_color.php
@@ -1,0 +1,37 @@
+<?php
+
+return [
+    'label' => 'Statuskleur',
+    'plural_label' => 'Statuskleuren',
+
+    'form' => [
+        'status_name' => [
+            'label' => 'Status',
+            'helper_text' => 'De naam van de status zoals deze voorkomt op de zaak (bijv. "Ontvangen", "In behandeling", "Afgerond").',
+        ],
+
+        'resultaat' => [
+            'label' => 'Resultaat',
+            'helper_text' => 'Alleen van toepassing bij een eindstatus (bijv. "Verleend", "Geweigerd", "Ingetrokken"). Laat leeg als deze kleur voor alle resultaten van deze status moet gelden.',
+            'unique' => 'Voor deze combinatie van status en resultaat is al een kleur ingesteld.',
+        ],
+
+        'color' => [
+            'label' => 'Kleur',
+        ],
+    ],
+
+    'columns' => [
+        'status_name' => [
+            'label' => 'Status',
+        ],
+
+        'resultaat' => [
+            'label' => 'Resultaat',
+        ],
+
+        'color' => [
+            'label' => 'Kleur',
+        ],
+    ],
+];

--- a/lang/nl/resources/zaak.php
+++ b/lang/nl/resources/zaak.php
@@ -14,6 +14,9 @@ return [
         'status' => [
             'label' => 'Status',
         ],
+        'status_color' => [
+            'label' => 'Kleur',
+        ],
         'registratiedatum' => [
             'label' => 'Registratiedatum',
         ],

--- a/tests/Feature/Filament/Admin/Resources/StatusResultaatColorResourceTest.php
+++ b/tests/Feature/Filament/Admin/Resources/StatusResultaatColorResourceTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\Role;
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\CreateStatusResultaatColor;
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\EditStatusResultaatColor;
+use App\Filament\Admin\Resources\StatusResultaatColors\Pages\ListStatusResultaatColors;
+use App\Filament\Admin\Resources\StatusResultaatColors\Schemas\StatusResultaatColorForm;
+use App\Filament\Admin\Resources\StatusResultaatColors\StatusResultaatColorResource;
+use App\Filament\Admin\Resources\StatusResultaatColors\Tables\StatusResultaatColorsTable;
+use App\Models\StatusResultaatColor;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+covers(
+    StatusResultaatColorResource::class,
+    ListStatusResultaatColors::class,
+    CreateStatusResultaatColor::class,
+    EditStatusResultaatColor::class,
+    StatusResultaatColorForm::class,
+    StatusResultaatColorsTable::class,
+);
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $this->admin = User::factory()->create([
+        'email' => 'admin@example.com',
+        'role' => Role::Admin,
+    ]);
+
+    actingAs($this->admin);
+
+    // Remove the seeded default colors so tests fully control the configured combinations.
+    StatusResultaatColor::query()->delete();
+});
+
+test('admin can view status resultaat color list', function () {
+    $colors = StatusResultaatColor::factory()->count(3)->create();
+
+    livewire(ListStatusResultaatColors::class)
+        ->assertOk()
+        ->assertCanSeeTableRecords($colors);
+});
+
+test('admin can create a status resultaat color', function () {
+    livewire(CreateStatusResultaatColor::class)
+        ->fillForm([
+            'status_name' => 'Afgerond',
+            'resultaat' => 'Verleend',
+            'color' => '#22C55E',
+        ])
+        ->call('create')
+        ->assertNotified()
+        ->assertHasNoFormErrors();
+
+    expect(StatusResultaatColor::where('status_name', 'Afgerond')->where('resultaat', 'Verleend')->first())
+        ->color->toBe('#22C55E');
+});
+
+test('admin cannot create a duplicate status and resultaat combination', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'Afgerond',
+        'resultaat' => 'Verleend',
+        'color' => '#22C55E',
+    ]);
+
+    livewire(CreateStatusResultaatColor::class)
+        ->fillForm([
+            'status_name' => 'Afgerond',
+            'resultaat' => 'Verleend',
+            'color' => '#000000',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['resultaat' => 'unique']);
+});
+
+test('admin can update a status resultaat color', function () {
+    $color = StatusResultaatColor::factory()->create([
+        'status_name' => 'Ontvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    livewire(EditStatusResultaatColor::class, ['record' => $color->getKey()])
+        ->fillForm(['color' => '#000000'])
+        ->call('save')
+        ->assertNotified()
+        ->assertHasNoFormErrors();
+
+    expect($color->refresh()->color)->toBe('#000000');
+});
+
+test('admin can delete a status resultaat color', function () {
+    $color = StatusResultaatColor::factory()->create();
+
+    livewire(EditStatusResultaatColor::class, ['record' => $color->getKey()])
+        ->callAction('delete');
+
+    expect(StatusResultaatColor::find($color->getKey()))->toBeNull();
+});

--- a/tests/Feature/Filament/Shared/Exports/EventExportersTest.php
+++ b/tests/Feature/Filament/Shared/Exports/EventExportersTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Filament\Shared\Exports\AdvisorEventExporter;
+use App\Filament\Shared\Exports\BaseEventExporter;
+use App\Filament\Shared\Exports\ExtendedEventExporter;
+
+covers(BaseEventExporter::class, ExtendedEventExporter::class, AdvisorEventExporter::class);
+
+test('base event exporter exports the status color', function () {
+    $names = collect(BaseEventExporter::getColumns())->map->getName();
+
+    expect($names)->toContain('status_color');
+});
+
+test('extended event exporter inherits the status color column', function () {
+    $names = collect(ExtendedEventExporter::getColumns())->map->getName();
+
+    expect($names)->toContain('status_color');
+});
+
+test('advisor event exporter inherits the status color column', function () {
+    $names = collect(AdvisorEventExporter::getColumns())->map->getName();
+
+    expect($names)->toContain('status_color');
+});

--- a/tests/Feature/Models/StatusResultaatColorTest.php
+++ b/tests/Feature/Models/StatusResultaatColorTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use App\Models\StatusResultaatColor;
+
+test('colorFor returns the color for a status without a resultaat', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'TestOntvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    expect(StatusResultaatColor::colorFor('TestOntvangen'))->toBe('#3B82F6');
+    expect(StatusResultaatColor::colorFor('TestOntvangen', null))->toBe('#3B82F6');
+});
+
+test('colorFor returns the color for a status with a specific resultaat', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'TestAfgerond',
+        'resultaat' => null,
+        'color' => '#22C55E',
+    ]);
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'TestAfgerond',
+        'resultaat' => 'Geweigerd',
+        'color' => '#EF4444',
+    ]);
+
+    expect(StatusResultaatColor::colorFor('TestAfgerond', 'Geweigerd'))->toBe('#EF4444');
+    expect(StatusResultaatColor::colorFor('TestAfgerond'))->toBe('#22C55E');
+});
+
+test('colorFor returns null when no matching combination is configured', function () {
+    expect(StatusResultaatColor::colorFor('Onbekend', 'Iets'))->toBeNull();
+});
+
+test('colorFor reflects updates after the color is changed', function () {
+    $color = StatusResultaatColor::factory()->create([
+        'status_name' => 'TestOntvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    expect(StatusResultaatColor::colorFor('TestOntvangen'))->toBe('#3B82F6');
+
+    $color->update(['color' => '#000000']);
+
+    expect(StatusResultaatColor::colorFor('TestOntvangen'))->toBe('#000000');
+});
+
+test('colorFor reflects deletion of a color', function () {
+    $color = StatusResultaatColor::factory()->create([
+        'status_name' => 'TestOntvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    expect(StatusResultaatColor::colorFor('TestOntvangen'))->toBe('#3B82F6');
+
+    $color->delete();
+
+    expect(StatusResultaatColor::colorFor('TestOntvangen'))->toBeNull();
+});

--- a/tests/Feature/Models/Zaak/StatusColorAttributeTest.php
+++ b/tests/Feature/Models/Zaak/StatusColorAttributeTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Models\StatusResultaatColor;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    $this->zaaktype = Zaaktype::factory()->create();
+
+    // Remove the seeded default colors so tests fully control the configured combinations.
+    StatusResultaatColor::query()->delete();
+});
+
+test('status_color resolves the configured color for the zaak status', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'Ontvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+    ]);
+
+    expect($zaak->status_color)->toBe('#3B82F6');
+});
+
+test('status_color resolves the configured color for an eindstatus with resultaat', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'Afgerond',
+        'resultaat' => 'Verleend',
+        'color' => '#22C55E',
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            now(),
+            now()->addDay(),
+            now(),
+            'Afgerond',
+            ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1',
+            'A',
+            'Test locatie',
+            'Test event',
+            resultaat: 'Verleend',
+        ),
+    ]);
+
+    expect($zaak->status_color)->toBe('#22C55E');
+});
+
+test('status_color is null when no matching color is configured', function () {
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            now(),
+            now()->addDay(),
+            now(),
+            'OnbekendeStatus',
+            ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1',
+            'A',
+            'Test locatie',
+            'Test event',
+        ),
+    ]);
+
+    expect($zaak->status_color)->toBeNull();
+});
+
+test('toCalendarEvent sets the background color when a color is configured', function () {
+    StatusResultaatColor::factory()->create([
+        'status_name' => 'Ontvangen',
+        'resultaat' => null,
+        'color' => '#3B82F6',
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+    ]);
+
+    expect($zaak->toCalendarEvent()->getBackgroundColor())->toBe('#3B82F6');
+});
+
+test('toCalendarEvent does not set a background color when none is configured', function () {
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            now(),
+            now()->addDay(),
+            now(),
+            'OnbekendeStatus',
+            ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1',
+            'A',
+            'Test locatie',
+            'Test event',
+        ),
+    ]);
+
+    expect($zaak->toCalendarEvent()->getBackgroundColor())->toBeNull();
+});


### PR DESCRIPTION
## Summary
- Platform admins (User with role `Admin`) can configure a color per status + resultaat combination via a new Admin panel resource (`StatusResultaatColor`), guarded by a dedicated `StatusResultaatColorPolicy`.
- The resultaat is only relevant for eindstatussen; otherwise stored as an empty string.
- Combinations are global across municipalities (not per-gemeente) to avoid inconsistent colors.
- The configured color is used as the background color of the agenda item bar in the calendar (`Zaak::toCalendarEvent()`), via a new `status_color` accessor.
- The color code is included in event exports (`status_color` column on `BaseEventExporter`, inherited by `ExtendedEventExporter` and `AdvisorEventExporter`).
- Seeded with a default set of colors for common statuses/resultaten (Ontvangen, In behandeling, Afgerond + Verleend/Geweigerd/Ingetrokken/Afgebroken).

## Test plan
- [x] New tests: `StatusResultaatColorTest`, `StatusColorAttributeTest`, `EventExportersTest`, `StatusResultaatColorResourceTest` (18 tests, all passing)
- [x] Full suite: 1251 passed, 2 pre-existing unrelated failures in `AdminPanelTest` (panel settings `intro` HTML wrapping, not related to this change)
- [x] Pint clean
- [x] PHPStan (level 5) clean