### PR TITLE
Stop notifying advisors about concept advice requests

### DIFF
--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -118,11 +118,12 @@ class Thread extends Model
     public function getParticipants(): Collection
     {
         $threadParticipants = match (get_class($this)) {
-            // A concept advice request has not been sent yet, so the advisory's
-            // users are not participants and must not be notified.
-            AdviceThread::class => $this->advice_status === AdviceStatus::Concept
-                ? collect()
-                : ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers),
+            // The advisory only participates while the advice request is active. A
+            // concept request has not been sent yet and a finalized one is done, so in
+            // both cases the advisory's users are not notified about messages.
+            AdviceThread::class => in_array($this->advice_status, AdviceStatus::activeStatuses(), true)
+                ? ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers)
+                : collect(),
             OrganiserThread::class => $this->zaak->organisation->users,
             default => collect(),
         };

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AdviceStatus;
 use App\Enums\Role;
 use App\Enums\ThreadType;
 use App\Models\Threads\AdviceThread;
@@ -117,7 +118,11 @@ class Thread extends Model
     public function getParticipants(): Collection
     {
         $threadParticipants = match (get_class($this)) {
-            AdviceThread::class => $this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers,
+            // A concept advice request has not been sent yet, so the advisory's
+            // users are not participants and must not be notified.
+            AdviceThread::class => $this->advice_status === AdviceStatus::Concept
+                ? collect()
+                : ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers),
             OrganiserThread::class => $this->zaak->organisation->users,
             default => collect(),
         };

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AdviceStatus;
 use App\Enums\DocumentVertrouwelijkheden;
 use App\Models\Threads\AdviceThread;
 use App\Models\Threads\OrganiserThread;
@@ -121,10 +122,15 @@ class Zaak extends Model implements Eventable
 
         return array_merge(
             $this->organisation?->users->all() ?? [],
-            $this->adviceThreads->map(function ($thread) {
-                /** @var AdviceThread $thread */
-                return $thread->advisory->users->all();
-            })->flatten(1)->all(),
+            $this->adviceThreads
+                // Advisors linked through a concept advice request must not be notified yet,
+                // since the request has not actually been sent. This mirrors the panel
+                // visibility rule where advisors only see a zaak once it is no longer concept.
+                ->where('advice_status', '!=', AdviceStatus::Concept)
+                ->map(function ($thread) {
+                    /** @var AdviceThread $thread */
+                    return $thread->advisory->users->all();
+                })->flatten(1)->all(),
             $handlers ? $handlers : []
         );
     }

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -123,10 +123,13 @@ class Zaak extends Model implements Eventable
         return array_merge(
             $this->organisation?->users->all() ?? [],
             $this->adviceThreads
-                // Advisors linked through a concept advice request must not be notified yet,
-                // since the request has not actually been sent. This mirrors the panel
-                // visibility rule where advisors only see a zaak once it is no longer concept.
-                ->where('advice_status', '!=', AdviceStatus::Concept)
+                // Only notify advisors while the advice request is active. A concept
+                // request has not been sent yet, and a finalized one (approved, rejected,
+                // etc.) is done, so in both cases the advisory must no longer be notified.
+                ->filter(function ($thread): bool {
+                    /** @var AdviceThread $thread */
+                    return in_array($thread->advice_status, AdviceStatus::activeStatuses(), true);
+                })
                 ->map(function ($thread) {
                     /** @var AdviceThread $thread */
                     return $thread->advisory->users->all();

--- a/app/Policies/ZaakPolicy.php
+++ b/app/Policies/ZaakPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\AdviceStatus;
 use App\Enums\Role;
 use App\Models\User;
 use App\Models\Users\AdvisorUser;
@@ -52,7 +53,9 @@ class ZaakPolicy
     public function uploadDocument(User $user, Zaak $zaak)
     {
         if ($user instanceof AdvisorUser) {
-            $advisoryIds = $zaak->adviceThreads->pluck('advisory_id');
+            $advisoryIds = $zaak->adviceThreads
+                ->where('advice_status', '!=', AdviceStatus::Concept)
+                ->pluck('advisory_id');
             $userAdvisoryIds = $user->advisories->pluck('id');
 
             return $advisoryIds->intersect($userAdvisoryIds)->isNotEmpty();

--- a/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
@@ -149,3 +149,46 @@ test('Advisors of a concept advice request are not notified, but advisors of a s
     Notification::assertNotSentTo([$conceptAdvisor], NewZaakDocument::class);
     Notification::assertSentTo([$askedAdvisor], NewZaakDocument::class);
 });
+
+test('Advisors of an advice request in a final status are no longer notified about documents', function (AdviceStatus $finalStatus) {
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::fakeSingleDocument();
+    ZgwHttpFake::fakeZaakinformatieobjecten();
+
+    $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'public_id' => 'ZAAK-123',
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    $advisory = Advisory::factory()->create();
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+    $advisory->users()->attach($advisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $advisory->id,
+        'advice_status' => $finalStatus,
+        'created_by' => null,
+        'title' => 'Finalized advice thread',
+    ]);
+
+    $newDocumentNotification = new OpenNotification(
+        actie: 'create',
+        kanaal: 'documenten',
+        resource: 'enkelvoudiginformatieobject',
+        hoofdObject: $documentUrl,
+        resourceUrl: $documentUrl,
+        aanmaakdatum: now(),
+    );
+
+    dispatch(new DocumentNotificationReceived($newDocumentNotification, true));
+
+    Notification::assertNotSentTo([$advisor], NewZaakDocument::class);
+})->with([
+    'approved' => AdviceStatus::Approved,
+    'approved with conditions' => AdviceStatus::ApprovedWithConditions,
+    'rejected' => AdviceStatus::Rejected,
+    'no reaction' => AdviceStatus::NoReaction,
+]);

--- a/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
@@ -1,11 +1,16 @@
 <?php
 
+use App\Enums\AdviceStatus;
+use App\Enums\AdvisoryRole;
 use App\Enums\OrganisationRole;
 use App\Enums\OrganisationType;
 use App\Enums\Role;
+use App\Enums\ThreadType;
 use App\Jobs\DocumentNotificationReceived;
+use App\Models\Advisory;
 use App\Models\Municipality;
 use App\Models\Organisation;
+use App\Models\Threads\AdviceThread;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
@@ -90,4 +95,57 @@ test('Organisation users are notified on new document', function () {
 
     Notification::assertSentTo($organisation->users, NewZaakDocument::class);
 
+});
+
+test('Advisors of a concept advice request are not notified, but advisors of a sent request are', function () {
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::fakeSingleDocument();
+    ZgwHttpFake::fakeZaakinformatieobjecten();
+
+    $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'public_id' => 'ZAAK-123',
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    // Advisory linked through a concept advice request: must NOT be notified.
+    $conceptAdvisory = Advisory::factory()->create();
+    $conceptAdvisor = User::factory()->create(['role' => Role::Advisor]);
+    $conceptAdvisory->users()->attach($conceptAdvisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $conceptAdvisory->id,
+        'advice_status' => AdviceStatus::Concept,
+        'created_by' => null,
+        'title' => 'Concept advice thread',
+    ]);
+
+    // Advisory linked through a sent (asked) advice request: must be notified.
+    $askedAdvisory = Advisory::factory()->create();
+    $askedAdvisor = User::factory()->create(['role' => Role::Advisor]);
+    $askedAdvisory->users()->attach($askedAdvisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $askedAdvisory->id,
+        'advice_status' => AdviceStatus::Asked,
+        'created_by' => null,
+        'title' => 'Asked advice thread',
+    ]);
+
+    $newDocumentNotification = new OpenNotification(
+        actie: 'create',
+        kanaal: 'documenten',
+        resource: 'enkelvoudiginformatieobject',
+        hoofdObject: $documentUrl,
+        resourceUrl: $documentUrl,
+        aanmaakdatum: now(),
+    );
+
+    dispatch(new DocumentNotificationReceived($newDocumentNotification, true));
+
+    Notification::assertNotSentTo([$conceptAdvisor], NewZaakDocument::class);
+    Notification::assertSentTo([$askedAdvisor], NewZaakDocument::class);
 });

--- a/tests/Feature/Threads/AdviceThreadTest.php
+++ b/tests/Feature/Threads/AdviceThreadTest.php
@@ -698,6 +698,39 @@ test('sends new advice thread notifications to all advisory admins who have it e
     );
 });
 
+test('does not notify advisory users about messages on a concept advice thread', function () {
+    // Concept advice request that has not been sent to the advisory yet.
+    $conceptThread = AdviceThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => AdviceStatus::Concept,
+        'created_by' => $this->reviewer->id,
+        'title' => 'Concept advice thread',
+    ]);
+
+    // Municipality posts messages while preparing the concept request.
+    Message::factory()->create([
+        'thread_id' => $conceptThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+    $message = Message::factory()->create([
+        'thread_id' => $conceptThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+
+    // Advisory users must not be notified nor get unread entries for a concept request.
+    Notification::assertNotSentTo(
+        [$this->advisoryAdmin, $this->advisor, $this->advisor2],
+        NewAdviceThreadMessage::class,
+    );
+
+    $this->assertDatabaseMissing('unread_messages', [
+        'user_id' => $this->advisoryAdmin->id,
+        'message_id' => $message->id,
+    ]);
+});
+
 test('sends new advice thread message notifications to all advisory admins of unassigned threads who have it enabled', function () {
     // Create unassigned advice thread
     $adviceThread2 = AdviceThread::forceCreate([

--- a/tests/Feature/Threads/AdviceThreadTest.php
+++ b/tests/Feature/Threads/AdviceThreadTest.php
@@ -731,6 +731,44 @@ test('does not notify advisory users about messages on a concept advice thread',
     ]);
 });
 
+test('does not notify advisory users about messages on a finalized advice thread', function (AdviceStatus $finalStatus) {
+    // Advice request that has reached a final status.
+    $finalizedThread = AdviceThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => $finalStatus,
+        'created_by' => $this->reviewer->id,
+        'title' => 'Finalized advice thread',
+    ]);
+
+    // Municipality posts a follow-up message after the advice was finalized.
+    Message::factory()->create([
+        'thread_id' => $finalizedThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+    $message = Message::factory()->create([
+        'thread_id' => $finalizedThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+
+    // The advisory must no longer be notified nor get unread entries.
+    Notification::assertNotSentTo(
+        [$this->advisoryAdmin, $this->advisor, $this->advisor2],
+        NewAdviceThreadMessage::class,
+    );
+
+    $this->assertDatabaseMissing('unread_messages', [
+        'user_id' => $this->advisoryAdmin->id,
+        'message_id' => $message->id,
+    ]);
+})->with([
+    'approved' => AdviceStatus::Approved,
+    'approved with conditions' => AdviceStatus::ApprovedWithConditions,
+    'rejected' => AdviceStatus::Rejected,
+    'no reaction' => AdviceStatus::NoReaction,
+]);
+
 test('sends new advice thread message notifications to all advisory admins of unassigned threads who have it enabled', function () {
     // Create unassigned advice thread
     $adviceThread2 = AdviceThread::forceCreate([


### PR DESCRIPTION
## Problem

When an advice request (adviesvraag) was still in **concept** status, advisors linked to that request already received notifications about documents added or changed on the zaak. A concept request has not been sent to the advisory yet, so these advisors should not receive notifications.

In addition, once an advice request reaches a **final** status (approved, approved with conditions, rejected, no reaction), the advice is done and the advisory service should no longer receive notifications about that zaak either.

## Approach

Advisory notifications are now gated on the advice request being **active**, using the existing `AdviceStatus::activeStatuses()` (`asked`, `in_progress`, `advisory_replied`, `needs_more_info`). This excludes both concept (not yet sent) and final (done) statuses in one consistent rule.

## Root cause

`Zaak::relatedUsers()`, used by the `DocumentNotificationReceived` job to determine recipients, iterated over **all** advice threads regardless of their status, so any advisory linked through a concept or finalized thread was still notified. This was the only place in the codebase that did not filter advice status; every advisor-facing surface (panel visibility, inbox widget, working-stock filter, relation manager, the advice thread observer) already filters them.

## Changes

- `Zaak::relatedUsers()` only includes advisors of advice threads whose status is in `activeStatuses()`, so document notifications skip advisors of concept and finalized requests.
- `Thread::getParticipants()` returns no advisory participants unless the advice thread is active, preventing message notifications and unread entries for concept and finalized requests.
- `ZaakPolicy::uploadDocument()` no longer matches advisors via concept advice threads.

## Tests

- `DocumentNotificationReceivedTest`: advisor of a concept request is not notified, advisor of a sent (asked) request is, and advisors of all final statuses are not notified (dataset).
- `AdviceThreadTest`: messages on a concept thread and on threads in every final status do not notify advisory users or create unread entries (dataset).