### PR TITLE
Fix documents stored without a file extension

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
@@ -59,15 +59,17 @@ class NewDocumentVersionAction
     public static function createNewDocumentVersion(string $documentUuid, array $data, Zaak $zaak)
     {
         $oz = new Openzaak;
+        $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
+        $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
         $lockString = $oz->documenten()->enkelvoudiginformatieobjecten()->lock($documentUuid);
         $oz->documenten()->enkelvoudiginformatieobjecten()->patch($documentUuid,
             [
                 'inhoud' => base64_encode(Storage::get($data['file'])),
                 'titel' => $data['titel'],
                 'auteur' => auth()->user()->name,
-                'bestandsnaam' => $data['file_name'],
+                'bestandsnaam' => $bestandsnaam,
                 'bestandsomvang' => Storage::size($data['file']),
-                'formaat' => DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null),
+                'formaat' => $formaat,
                 'lock' => $lockString,
                 'indicatieGebruiksrecht' => false,
             ]

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -97,6 +97,9 @@ class UploadDocumentAction
             default => DocumentVertrouwelijkheden::Vertrouwelijk->value,
         };
 
+        $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
+        $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
+
         $informatieobject = new Informatieobject(...$oz->documenten()->enkelvoudiginformatieobjecten()->store([
             'bronorganisatie' => $zaak->openzaak->bronorganisatie,
             'creatiedatum' => now()->format('Y-m-d'),
@@ -104,9 +107,9 @@ class UploadDocumentAction
             'titel' => $data['titel'],
             'auteur' => auth()->user()->name,
             'taal' => 'dut',
-            'bestandsnaam' => $data['file_name'],
+            'bestandsnaam' => $bestandsnaam,
             'bestandsomvang' => Storage::size($data['file']),
-            'formaat' => DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null),
+            'formaat' => $formaat,
             'inhoud' => base64_encode(Storage::get($data['file'])),
             'informatieobjecttype' => $data['informatieobjecttype'],
             'indicatieGebruiksrecht' => false,

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\DocumentRequest;
 use App\Models\Zaak;
+use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Woweb\Openzaak\Openzaak;
 
 class DocumentController extends Controller
@@ -18,12 +20,27 @@ class DocumentController extends Controller
             // get the specified version
             $document = new Informatieobject(...(new Openzaak)->get($document->url.'?versie='.$validated['version'])->toArray());
         }
-        $disposition = $type === 'download' ? 'attachment' : 'inline';
+        $disposition = $type === 'download' ? HeaderUtils::DISPOSITION_ATTACHMENT : HeaderUtils::DISPOSITION_INLINE;
 
-        return response((new Openzaak)->getRaw($document->inhoud))->withHeaders([
-            'Content-disposition' => $disposition.'; filename='.$document->bestandsnaam,
+        $raw = (new Openzaak)->getRaw($document->inhoud);
+
+        // Older / externally created documents may have an empty or missing MIME
+        // type, in which case we detect it from the actual content bytes.
+        $mime = $document->formaat !== '' ? $document->formaat : null;
+        if ($mime === null && $raw !== '') {
+            $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $raw) ?: null;
+        }
+        $mime ??= 'application/octet-stream';
+
+        // Existing documents may have been stored without a file extension in
+        // their bestandsnaam, which makes them impossible to open after download.
+        // We reconstruct a usable filename from the resolved MIME type.
+        $fileName = DocumentUploadType::ensureFileNameHasExtension($document->bestandsnaam, $mime);
+
+        return response($raw)->withHeaders([
+            'Content-Disposition' => HeaderUtils::makeDisposition($disposition, $fileName),
             'Access-Control-Expose-Headers' => 'Content-Disposition',
-            'Content-Type' => $document->formaat,
+            'Content-Type' => $mime,
         ]);
     }
 }

--- a/app/Support/Uploads/DocumentUploadType.php
+++ b/app/Support/Uploads/DocumentUploadType.php
@@ -4,6 +4,7 @@ namespace App\Support\Uploads;
 
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Mime\MimeTypes;
 
 final class DocumentUploadType
 {
@@ -184,6 +185,62 @@ final class DocumentUploadType
         }
 
         return (string) Storage::mimeType($storedPath);
+    }
+
+    /**
+     * Derives a file extension (without leading dot) for a given MIME type.
+     *
+     * Prefers the application's own ext => mime mappings so that custom types
+     * (e.g. message/rfc822 => eml, application/vnd.ms-outlook => msg) round-trip
+     * correctly, then falls back to Symfony's MIME database for standard types.
+     */
+    public static function extensionForMimeType(string $mimeType): ?string
+    {
+        $mimeType = strtolower(trim($mimeType));
+
+        if ($mimeType === '') {
+            return null;
+        }
+
+        $map = config('app.document_mime_type_mappings', []);
+
+        if (is_array($map)) {
+            foreach ($map as $extension => $mappedMime) {
+                if (is_string($mappedMime) && strtolower($mappedMime) === $mimeType) {
+                    return (string) $extension;
+                }
+            }
+        }
+
+        $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
+
+        return $extensions[0] ?? null;
+    }
+
+    /**
+     * Ensures a filename carries an extension, deriving one from the MIME type
+     * when it is missing. Filenames that already have an extension are returned
+     * unchanged; an empty filename falls back to "document".
+     */
+    public static function ensureFileNameHasExtension(string $fileName, string $mimeType): string
+    {
+        $fileName = trim($fileName);
+
+        if ($fileName === '') {
+            $fileName = 'document';
+        }
+
+        if (pathinfo($fileName, PATHINFO_EXTENSION) !== '') {
+            return $fileName;
+        }
+
+        $extension = self::extensionForMimeType($mimeType);
+
+        if ($extension === null || $extension === '') {
+            return $fileName;
+        }
+
+        return $fileName.'.'.$extension;
     }
 
     private static function looksLikeRfc822Email(UploadedFile $file): bool

--- a/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
+++ b/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
@@ -408,3 +408,62 @@ test('reviewer can manually choose confidentiality level', function () {
         && $request->data()['vertrouwelijkheidaanduiding'] === DocumentVertrouwelijkheden::Confidentieel->value
     );
 });
+
+test('upload action appends an extension to the bestandsnaam when the uploaded file has none', function () {
+    Storage::fake('local');
+
+    $filePath = 'documents/extensieloos';
+    Storage::put($filePath, '%PDF-1.4 fake pdf content for testing');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+    $documentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/new-doc-noext';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => $documentUrl,
+            'uuid' => 'new-doc-noext',
+            'identificatie' => 'DOC-NOEXT',
+            'titel' => 'Extensieloos',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => $this->organiser->name,
+            'versie' => 1,
+            'bestandsnaam' => 'extensieloos.pdf',
+            'inhoud' => '',
+            'beschrijving' => '',
+            'formaat' => 'application/pdf',
+            'locked' => false,
+            'bestandsgrootte' => 0,
+            'creatiedatum' => now()->format('Y-m-d'),
+            'wijzigingsdatum' => now()->toIso8601String(),
+            'informatieobjecttype' => $documentTypeUrl,
+            'indicatieGebruiksrecht' => false,
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/6',
+            'zaak' => $zgwZaakUrl,
+            'informatieobject' => $documentUrl,
+        ], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    UploadDocumentAction::uploadDocument([
+        'titel' => 'Extensieloos',
+        'informatieobjecttype' => $documentTypeUrl,
+        'file' => $filePath,
+        'file_name' => 'extensieloos',
+    ], $zaak);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
+        && $request->method() === 'POST'
+        && $request->data()['bestandsnaam'] === 'extensieloos.pdf'
+        && $request->data()['formaat'] === 'application/pdf'
+    );
+});

--- a/tests/Feature/Http/Controllers/DocumentControllerTest.php
+++ b/tests/Feature/Http/Controllers/DocumentControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+/**
+ * Builds a zaak whose single document has an extensionless bestandsnaam,
+ * mirroring the broken documents that already exist in production.
+ */
+function fakeZaakWithExtensionlessDocument(string $bestandsnaam, string $formaat): array
+{
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/no-ext';
+    $contentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/no-ext/download';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+                'zaak' => $zgwZaakUrl,
+                'informatieobject' => $documentUrl,
+            ],
+        ], 200),
+        $documentUrl => Http::response([
+            'url' => $documentUrl,
+            'uuid' => 'no-ext',
+            'identificatie' => 'DOC-NOEXT',
+            'creatiedatum' => now()->format('Y-m-d'),
+            'titel' => 'Extensieloos document',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => 'Test',
+            'versie' => 1,
+            'bestandsnaam' => $bestandsnaam,
+            'inhoud' => $contentUrl,
+            'beschrijving' => '',
+            'informatieobjecttype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+            'formaat' => $formaat,
+            'locked' => false,
+        ], 200),
+        $contentUrl => Http::response('%PDF-1.4 raw pdf bytes', 200),
+    ]);
+
+    return [$zgwZaakUrl, $documentUrl];
+}
+
+test('view appends a derived extension to the filename and sets the content type', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', 'application/pdf');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'view',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('application/pdf');
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('inline')
+        ->toContain('Vergunningaanvraag.pdf');
+});
+
+test('download serves an extensionless document as an attachment with extension', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', 'application/pdf');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'download',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('attachment')
+        ->toContain('Vergunningaanvraag.pdf');
+});
+
+test('view falls back to detecting the mime type from content when formaat is empty', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', '');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'view',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('application/pdf');
+    expect($response->headers->get('Content-Disposition'))->toContain('Vergunningaanvraag.pdf');
+});

--- a/tests/Unit/Support/Uploads/DocumentUploadTypeTest.php
+++ b/tests/Unit/Support/Uploads/DocumentUploadTypeTest.php
@@ -127,3 +127,18 @@ test('determineFormaat prefers extension mapping over storage mime detection', f
 
     expect($formaat)->toBe('message/rfc822');
 });
+
+test('extensionForMimeType resolves standard and custom mime types', function () {
+    expect(DocumentUploadType::extensionForMimeType('application/pdf'))->toBe('pdf')
+        ->and(DocumentUploadType::extensionForMimeType('message/rfc822'))->toBe('eml')
+        ->and(DocumentUploadType::extensionForMimeType('application/vnd.ms-outlook'))->toBe('msg')
+        ->and(DocumentUploadType::extensionForMimeType('application/octet-stream-unknown'))->toBeNull()
+        ->and(DocumentUploadType::extensionForMimeType(''))->toBeNull();
+});
+
+test('ensureFileNameHasExtension appends an extension only when missing', function () {
+    expect(DocumentUploadType::ensureFileNameHasExtension('Vergunningaanvraag', 'application/pdf'))->toBe('Vergunningaanvraag.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('rapport.pdf', 'application/pdf'))->toBe('rapport.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('', 'application/pdf'))->toBe('document.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('naamloos', 'application/octet-stream-unknown'))->toBe('naamloos');
+});


### PR DESCRIPTION
## Problem

Some documents in production have a `bestandsnaam` without a file extension (e.g. a PDF whose name is not `*.pdf`). These documents cannot be opened, neither via the **Bekijken** (view) action nor via **Download**.

The upload validation in `DocumentUploadType::isAllowed` accepts files based on their **content** (`getMimeType()` sniffs the magic bytes), not on the extension in the name. So a PDF literally named `Vergunningaanvraag` (without `.pdf`) is accepted. Filament stores that extensionless name via `storeFileNamesIn('file_name')` and it is sent unchanged as `bestandsnaam` to OpenZaak.

On serve, `DocumentController` set `Content-Disposition: ...; filename=<bestandsnaam>` (without extension, unquoted) and `Content-Type: <formaat>`. As a result downloads were saved as an extensionless file (the OS cannot open it), and inline view failed whenever `formaat` was empty or generic.

## Changes

**Prevention (new uploads)**
- Added two reusable helpers to `DocumentUploadType`: `extensionForMimeType()` (config mapping first, then Symfony's MIME database) and `ensureFileNameHasExtension()`.
- `UploadDocumentAction` and `NewDocumentVersionAction` now append the extension derived from the detected MIME type to `bestandsnaam` before sending it to OpenZaak. This also covers uploads from the thread `MessageForm`, which reuses these methods.

**Remediation for existing documents (serve time, no mutation in OpenZaak)**
- `DocumentController` now resolves the MIME type from the stored `formaat`, falling back to content sniffing (`finfo_buffer`) when it is empty, and reconstructs a filename with extension. Existing extensionless documents become viewable (inline) and downloadable (with extension) again.
- The `Content-Disposition` header is now built with `HeaderUtils::makeDisposition()` for correct quoting/encoding, which also handles filenames with spaces or UTF-8 characters.

Note on scope: for existing documents the `bestandsnaam` column in the table keeps showing the old (extensionless) name, because the canonical data in OpenZaak is intentionally not mutated. Opening the files works again regardless.

## Tests

- Unit tests for both helpers (`extensionForMimeType`, `ensureFileNameHasExtension`).
- Upload-path test asserting an extensionless `file_name` results in a `bestandsnaam` ending in `.pdf`.
- Feature tests for the serve path: view, download, and the empty-`formaat` content-sniffing fallback.