### PR TITLE
Merge main into next/v1

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
@@ -59,15 +59,17 @@ class NewDocumentVersionAction
     public static function createNewDocumentVersion(string $documentUuid, array $data, Zaak $zaak)
     {
         $oz = new Openzaak;
+        $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
+        $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
         $lockString = $oz->documenten()->enkelvoudiginformatieobjecten()->lock($documentUuid);
         $oz->documenten()->enkelvoudiginformatieobjecten()->patch($documentUuid,
             [
                 'inhoud' => base64_encode(Storage::get($data['file'])),
                 'titel' => $data['titel'],
                 'auteur' => auth()->user()->name,
-                'bestandsnaam' => $data['file_name'],
+                'bestandsnaam' => $bestandsnaam,
                 'bestandsomvang' => Storage::size($data['file']),
-                'formaat' => DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null),
+                'formaat' => $formaat,
                 'lock' => $lockString,
                 'indicatieGebruiksrecht' => false,
             ]

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -97,6 +97,9 @@ class UploadDocumentAction
             default => DocumentVertrouwelijkheden::Vertrouwelijk->value,
         };
 
+        $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
+        $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
+
         $informatieobject = new Informatieobject(...$oz->documenten()->enkelvoudiginformatieobjecten()->store([
             'bronorganisatie' => $zaak->openzaak->bronorganisatie,
             'creatiedatum' => now()->format('Y-m-d'),
@@ -104,9 +107,9 @@ class UploadDocumentAction
             'titel' => $data['titel'],
             'auteur' => auth()->user()->name,
             'taal' => 'dut',
-            'bestandsnaam' => $data['file_name'],
+            'bestandsnaam' => $bestandsnaam,
             'bestandsomvang' => Storage::size($data['file']),
-            'formaat' => DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null),
+            'formaat' => $formaat,
             'inhoud' => base64_encode(Storage::get($data['file'])),
             'informatieobjecttype' => $data['informatieobjecttype'],
             'indicatieGebruiksrecht' => false,

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -4,7 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Http\Requests\DocumentRequest;
 use App\Models\Zaak;
+use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
+use Symfony\Component\HttpFoundation\HeaderUtils;
 use Woweb\Openzaak\Openzaak;
 
 class DocumentController extends Controller
@@ -18,12 +20,27 @@ class DocumentController extends Controller
             // get the specified version
             $document = new Informatieobject(...(new Openzaak)->get($document->url.'?versie='.$validated['version'])->toArray());
         }
-        $disposition = $type === 'download' ? 'attachment' : 'inline';
+        $disposition = $type === 'download' ? HeaderUtils::DISPOSITION_ATTACHMENT : HeaderUtils::DISPOSITION_INLINE;
 
-        return response((new Openzaak)->getRaw($document->inhoud))->withHeaders([
-            'Content-disposition' => $disposition.'; filename='.$document->bestandsnaam,
+        $raw = (new Openzaak)->getRaw($document->inhoud);
+
+        // Older / externally created documents may have an empty or missing MIME
+        // type, in which case we detect it from the actual content bytes.
+        $mime = $document->formaat !== '' ? $document->formaat : null;
+        if ($mime === null && $raw !== '') {
+            $mime = finfo_buffer(finfo_open(FILEINFO_MIME_TYPE), $raw) ?: null;
+        }
+        $mime ??= 'application/octet-stream';
+
+        // Existing documents may have been stored without a file extension in
+        // their bestandsnaam, which makes them impossible to open after download.
+        // We reconstruct a usable filename from the resolved MIME type.
+        $fileName = DocumentUploadType::ensureFileNameHasExtension($document->bestandsnaam, $mime);
+
+        return response($raw)->withHeaders([
+            'Content-Disposition' => HeaderUtils::makeDisposition($disposition, $fileName),
             'Access-Control-Expose-Headers' => 'Content-Disposition',
-            'Content-Type' => $document->formaat,
+            'Content-Type' => $mime,
         ]);
     }
 }

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -118,11 +118,12 @@ class Thread extends Model
     public function getParticipants(): Collection
     {
         $threadParticipants = match (get_class($this)) {
-            // A concept advice request has not been sent yet, so the advisory's
-            // users are not participants and must not be notified.
-            AdviceThread::class => $this->advice_status === AdviceStatus::Concept
-                ? collect()
-                : ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers),
+            // The advisory only participates while the advice request is active. A
+            // concept request has not been sent yet and a finalized one is done, so in
+            // both cases the advisory's users are not notified about messages.
+            AdviceThread::class => in_array($this->advice_status, AdviceStatus::activeStatuses(), true)
+                ? ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers)
+                : collect(),
             OrganiserThread::class => $this->zaak->organisation->users,
             default => collect(),
         };

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AdviceStatus;
 use App\Enums\Role;
 use App\Enums\ThreadType;
 use App\Models\Threads\AdviceThread;
@@ -117,7 +118,11 @@ class Thread extends Model
     public function getParticipants(): Collection
     {
         $threadParticipants = match (get_class($this)) {
-            AdviceThread::class => $this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers,
+            // A concept advice request has not been sent yet, so the advisory's
+            // users are not participants and must not be notified.
+            AdviceThread::class => $this->advice_status === AdviceStatus::Concept
+                ? collect()
+                : ($this->assignedUsers->count() ? $this->assignedUsers : $this->advisory->adminUsers),
             OrganiserThread::class => $this->zaak->organisation->users,
             default => collect(),
         };

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\AdviceStatus;
 use App\Enums\DocumentVertrouwelijkheden;
 use App\Models\Threads\AdviceThread;
 use App\Models\Threads\OrganiserThread;
@@ -121,10 +122,15 @@ class Zaak extends Model implements Eventable
 
         return array_merge(
             $this->organisation?->users->all() ?? [],
-            $this->adviceThreads->map(function ($thread) {
-                /** @var AdviceThread $thread */
-                return $thread->advisory->users->all();
-            })->flatten(1)->all(),
+            $this->adviceThreads
+                // Advisors linked through a concept advice request must not be notified yet,
+                // since the request has not actually been sent. This mirrors the panel
+                // visibility rule where advisors only see a zaak once it is no longer concept.
+                ->where('advice_status', '!=', AdviceStatus::Concept)
+                ->map(function ($thread) {
+                    /** @var AdviceThread $thread */
+                    return $thread->advisory->users->all();
+                })->flatten(1)->all(),
             $handlers ? $handlers : []
         );
     }

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -123,10 +123,13 @@ class Zaak extends Model implements Eventable
         return array_merge(
             $this->organisation?->users->all() ?? [],
             $this->adviceThreads
-                // Advisors linked through a concept advice request must not be notified yet,
-                // since the request has not actually been sent. This mirrors the panel
-                // visibility rule where advisors only see a zaak once it is no longer concept.
-                ->where('advice_status', '!=', AdviceStatus::Concept)
+                // Only notify advisors while the advice request is active. A concept
+                // request has not been sent yet, and a finalized one (approved, rejected,
+                // etc.) is done, so in both cases the advisory must no longer be notified.
+                ->filter(function ($thread): bool {
+                    /** @var AdviceThread $thread */
+                    return in_array($thread->advice_status, AdviceStatus::activeStatuses(), true);
+                })
                 ->map(function ($thread) {
                     /** @var AdviceThread $thread */
                     return $thread->advisory->users->all();

--- a/app/Policies/ZaakPolicy.php
+++ b/app/Policies/ZaakPolicy.php
@@ -2,6 +2,7 @@
 
 namespace App\Policies;
 
+use App\Enums\AdviceStatus;
 use App\Enums\Role;
 use App\Models\User;
 use App\Models\Users\AdvisorUser;
@@ -52,7 +53,9 @@ class ZaakPolicy
     public function uploadDocument(User $user, Zaak $zaak)
     {
         if ($user instanceof AdvisorUser) {
-            $advisoryIds = $zaak->adviceThreads->pluck('advisory_id');
+            $advisoryIds = $zaak->adviceThreads
+                ->where('advice_status', '!=', AdviceStatus::Concept)
+                ->pluck('advisory_id');
             $userAdvisoryIds = $user->advisories->pluck('id');
 
             return $advisoryIds->intersect($userAdvisoryIds)->isNotEmpty();

--- a/app/Support/Uploads/DocumentUploadType.php
+++ b/app/Support/Uploads/DocumentUploadType.php
@@ -4,6 +4,7 @@ namespace App\Support\Uploads;
 
 use Illuminate\Support\Facades\Storage;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Mime\MimeTypes;
 
 final class DocumentUploadType
 {
@@ -184,6 +185,62 @@ final class DocumentUploadType
         }
 
         return (string) Storage::mimeType($storedPath);
+    }
+
+    /**
+     * Derives a file extension (without leading dot) for a given MIME type.
+     *
+     * Prefers the application's own ext => mime mappings so that custom types
+     * (e.g. message/rfc822 => eml, application/vnd.ms-outlook => msg) round-trip
+     * correctly, then falls back to Symfony's MIME database for standard types.
+     */
+    public static function extensionForMimeType(string $mimeType): ?string
+    {
+        $mimeType = strtolower(trim($mimeType));
+
+        if ($mimeType === '') {
+            return null;
+        }
+
+        $map = config('app.document_mime_type_mappings', []);
+
+        if (is_array($map)) {
+            foreach ($map as $extension => $mappedMime) {
+                if (is_string($mappedMime) && strtolower($mappedMime) === $mimeType) {
+                    return (string) $extension;
+                }
+            }
+        }
+
+        $extensions = MimeTypes::getDefault()->getExtensions($mimeType);
+
+        return $extensions[0] ?? null;
+    }
+
+    /**
+     * Ensures a filename carries an extension, deriving one from the MIME type
+     * when it is missing. Filenames that already have an extension are returned
+     * unchanged; an empty filename falls back to "document".
+     */
+    public static function ensureFileNameHasExtension(string $fileName, string $mimeType): string
+    {
+        $fileName = trim($fileName);
+
+        if ($fileName === '') {
+            $fileName = 'document';
+        }
+
+        if (pathinfo($fileName, PATHINFO_EXTENSION) !== '') {
+            return $fileName;
+        }
+
+        $extension = self::extensionForMimeType($mimeType);
+
+        if ($extension === null || $extension === '') {
+            return $fileName;
+        }
+
+        return $fileName.'.'.$extension;
     }
 
     private static function looksLikeRfc822Email(UploadedFile $file): bool

--- a/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
+++ b/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
@@ -408,3 +408,62 @@ test('reviewer can manually choose confidentiality level', function () {
         && $request->data()['vertrouwelijkheidaanduiding'] === DocumentVertrouwelijkheden::Confidentieel->value
     );
 });
+
+test('upload action appends an extension to the bestandsnaam when the uploaded file has none', function () {
+    Storage::fake('local');
+
+    $filePath = 'documents/extensieloos';
+    Storage::put($filePath, '%PDF-1.4 fake pdf content for testing');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+    $documentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/new-doc-noext';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => $documentUrl,
+            'uuid' => 'new-doc-noext',
+            'identificatie' => 'DOC-NOEXT',
+            'titel' => 'Extensieloos',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => $this->organiser->name,
+            'versie' => 1,
+            'bestandsnaam' => 'extensieloos.pdf',
+            'inhoud' => '',
+            'beschrijving' => '',
+            'formaat' => 'application/pdf',
+            'locked' => false,
+            'bestandsgrootte' => 0,
+            'creatiedatum' => now()->format('Y-m-d'),
+            'wijzigingsdatum' => now()->toIso8601String(),
+            'informatieobjecttype' => $documentTypeUrl,
+            'indicatieGebruiksrecht' => false,
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/6',
+            'zaak' => $zgwZaakUrl,
+            'informatieobject' => $documentUrl,
+        ], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    UploadDocumentAction::uploadDocument([
+        'titel' => 'Extensieloos',
+        'informatieobjecttype' => $documentTypeUrl,
+        'file' => $filePath,
+        'file_name' => 'extensieloos',
+    ], $zaak);
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
+        && $request->method() === 'POST'
+        && $request->data()['bestandsnaam'] === 'extensieloos.pdf'
+        && $request->data()['formaat'] === 'application/pdf'
+    );
+});

--- a/tests/Feature/Http/Controllers/DocumentControllerTest.php
+++ b/tests/Feature/Http/Controllers/DocumentControllerTest.php
@@ -1,0 +1,134 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+/**
+ * Builds a zaak whose single document has an extensionless bestandsnaam,
+ * mirroring the broken documents that already exist in production.
+ */
+function fakeZaakWithExtensionlessDocument(string $bestandsnaam, string $formaat): array
+{
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/no-ext';
+    $contentUrl = ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/no-ext/download';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+                'zaak' => $zgwZaakUrl,
+                'informatieobject' => $documentUrl,
+            ],
+        ], 200),
+        $documentUrl => Http::response([
+            'url' => $documentUrl,
+            'uuid' => 'no-ext',
+            'identificatie' => 'DOC-NOEXT',
+            'creatiedatum' => now()->format('Y-m-d'),
+            'titel' => 'Extensieloos document',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => 'Test',
+            'versie' => 1,
+            'bestandsnaam' => $bestandsnaam,
+            'inhoud' => $contentUrl,
+            'beschrijving' => '',
+            'informatieobjecttype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+            'formaat' => $formaat,
+            'locked' => false,
+        ], 200),
+        $contentUrl => Http::response('%PDF-1.4 raw pdf bytes', 200),
+    ]);
+
+    return [$zgwZaakUrl, $documentUrl];
+}
+
+test('view appends a derived extension to the filename and sets the content type', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', 'application/pdf');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'view',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('application/pdf');
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('inline')
+        ->toContain('Vergunningaanvraag.pdf');
+});
+
+test('download serves an extensionless document as an attachment with extension', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', 'application/pdf');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'download',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('attachment')
+        ->toContain('Vergunningaanvraag.pdf');
+});
+
+test('view falls back to detecting the mime type from content when formaat is empty', function () {
+    fakeZaakWithExtensionlessDocument('Vergunningaanvraag', '');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'view',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Type'))->toContain('application/pdf');
+    expect($response->headers->get('Content-Disposition'))->toContain('Vergunningaanvraag.pdf');
+});

--- a/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
@@ -149,3 +149,46 @@ test('Advisors of a concept advice request are not notified, but advisors of a s
     Notification::assertNotSentTo([$conceptAdvisor], NewZaakDocument::class);
     Notification::assertSentTo([$askedAdvisor], NewZaakDocument::class);
 });
+
+test('Advisors of an advice request in a final status are no longer notified about documents', function (AdviceStatus $finalStatus) {
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::fakeSingleDocument();
+    ZgwHttpFake::fakeZaakinformatieobjecten();
+
+    $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'public_id' => 'ZAAK-123',
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    $advisory = Advisory::factory()->create();
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+    $advisory->users()->attach($advisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $advisory->id,
+        'advice_status' => $finalStatus,
+        'created_by' => null,
+        'title' => 'Finalized advice thread',
+    ]);
+
+    $newDocumentNotification = new OpenNotification(
+        actie: 'create',
+        kanaal: 'documenten',
+        resource: 'enkelvoudiginformatieobject',
+        hoofdObject: $documentUrl,
+        resourceUrl: $documentUrl,
+        aanmaakdatum: now(),
+    );
+
+    dispatch(new DocumentNotificationReceived($newDocumentNotification, true));
+
+    Notification::assertNotSentTo([$advisor], NewZaakDocument::class);
+})->with([
+    'approved' => AdviceStatus::Approved,
+    'approved with conditions' => AdviceStatus::ApprovedWithConditions,
+    'rejected' => AdviceStatus::Rejected,
+    'no reaction' => AdviceStatus::NoReaction,
+]);

--- a/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/DocumentNotificationReceivedTest.php
@@ -1,11 +1,16 @@
 <?php
 
+use App\Enums\AdviceStatus;
+use App\Enums\AdvisoryRole;
 use App\Enums\OrganisationRole;
 use App\Enums\OrganisationType;
 use App\Enums\Role;
+use App\Enums\ThreadType;
 use App\Jobs\DocumentNotificationReceived;
+use App\Models\Advisory;
 use App\Models\Municipality;
 use App\Models\Organisation;
+use App\Models\Threads\AdviceThread;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
@@ -90,4 +95,57 @@ test('Organisation users are notified on new document', function () {
 
     Notification::assertSentTo($organisation->users, NewZaakDocument::class);
 
+});
+
+test('Advisors of a concept advice request are not notified, but advisors of a sent request are', function () {
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentUrl = ZgwHttpFake::fakeSingleDocument();
+    ZgwHttpFake::fakeZaakinformatieobjecten();
+
+    $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'public_id' => 'ZAAK-123',
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    // Advisory linked through a concept advice request: must NOT be notified.
+    $conceptAdvisory = Advisory::factory()->create();
+    $conceptAdvisor = User::factory()->create(['role' => Role::Advisor]);
+    $conceptAdvisory->users()->attach($conceptAdvisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $conceptAdvisory->id,
+        'advice_status' => AdviceStatus::Concept,
+        'created_by' => null,
+        'title' => 'Concept advice thread',
+    ]);
+
+    // Advisory linked through a sent (asked) advice request: must be notified.
+    $askedAdvisory = Advisory::factory()->create();
+    $askedAdvisor = User::factory()->create(['role' => Role::Advisor]);
+    $askedAdvisory->users()->attach($askedAdvisor, ['role' => AdvisoryRole::Admin]);
+    AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $askedAdvisory->id,
+        'advice_status' => AdviceStatus::Asked,
+        'created_by' => null,
+        'title' => 'Asked advice thread',
+    ]);
+
+    $newDocumentNotification = new OpenNotification(
+        actie: 'create',
+        kanaal: 'documenten',
+        resource: 'enkelvoudiginformatieobject',
+        hoofdObject: $documentUrl,
+        resourceUrl: $documentUrl,
+        aanmaakdatum: now(),
+    );
+
+    dispatch(new DocumentNotificationReceived($newDocumentNotification, true));
+
+    Notification::assertNotSentTo([$conceptAdvisor], NewZaakDocument::class);
+    Notification::assertSentTo([$askedAdvisor], NewZaakDocument::class);
 });

--- a/tests/Feature/Threads/AdviceThreadTest.php
+++ b/tests/Feature/Threads/AdviceThreadTest.php
@@ -698,6 +698,39 @@ test('sends new advice thread notifications to all advisory admins who have it e
     );
 });
 
+test('does not notify advisory users about messages on a concept advice thread', function () {
+    // Concept advice request that has not been sent to the advisory yet.
+    $conceptThread = AdviceThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => AdviceStatus::Concept,
+        'created_by' => $this->reviewer->id,
+        'title' => 'Concept advice thread',
+    ]);
+
+    // Municipality posts messages while preparing the concept request.
+    Message::factory()->create([
+        'thread_id' => $conceptThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+    $message = Message::factory()->create([
+        'thread_id' => $conceptThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+
+    // Advisory users must not be notified nor get unread entries for a concept request.
+    Notification::assertNotSentTo(
+        [$this->advisoryAdmin, $this->advisor, $this->advisor2],
+        NewAdviceThreadMessage::class,
+    );
+
+    $this->assertDatabaseMissing('unread_messages', [
+        'user_id' => $this->advisoryAdmin->id,
+        'message_id' => $message->id,
+    ]);
+});
+
 test('sends new advice thread message notifications to all advisory admins of unassigned threads who have it enabled', function () {
     // Create unassigned advice thread
     $adviceThread2 = AdviceThread::forceCreate([

--- a/tests/Feature/Threads/AdviceThreadTest.php
+++ b/tests/Feature/Threads/AdviceThreadTest.php
@@ -731,6 +731,44 @@ test('does not notify advisory users about messages on a concept advice thread',
     ]);
 });
 
+test('does not notify advisory users about messages on a finalized advice thread', function (AdviceStatus $finalStatus) {
+    // Advice request that has reached a final status.
+    $finalizedThread = AdviceThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => $finalStatus,
+        'created_by' => $this->reviewer->id,
+        'title' => 'Finalized advice thread',
+    ]);
+
+    // Municipality posts a follow-up message after the advice was finalized.
+    Message::factory()->create([
+        'thread_id' => $finalizedThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+    $message = Message::factory()->create([
+        'thread_id' => $finalizedThread->id,
+        'user_id' => $this->reviewer->id,
+    ]);
+
+    // The advisory must no longer be notified nor get unread entries.
+    Notification::assertNotSentTo(
+        [$this->advisoryAdmin, $this->advisor, $this->advisor2],
+        NewAdviceThreadMessage::class,
+    );
+
+    $this->assertDatabaseMissing('unread_messages', [
+        'user_id' => $this->advisoryAdmin->id,
+        'message_id' => $message->id,
+    ]);
+})->with([
+    'approved' => AdviceStatus::Approved,
+    'approved with conditions' => AdviceStatus::ApprovedWithConditions,
+    'rejected' => AdviceStatus::Rejected,
+    'no reaction' => AdviceStatus::NoReaction,
+]);
+
 test('sends new advice thread message notifications to all advisory admins of unassigned threads who have it enabled', function () {
     // Create unassigned advice thread
     $adviceThread2 = AdviceThread::forceCreate([

--- a/tests/Unit/Support/Uploads/DocumentUploadTypeTest.php
+++ b/tests/Unit/Support/Uploads/DocumentUploadTypeTest.php
@@ -127,3 +127,18 @@ test('determineFormaat prefers extension mapping over storage mime detection', f
 
     expect($formaat)->toBe('message/rfc822');
 });
+
+test('extensionForMimeType resolves standard and custom mime types', function () {
+    expect(DocumentUploadType::extensionForMimeType('application/pdf'))->toBe('pdf')
+        ->and(DocumentUploadType::extensionForMimeType('message/rfc822'))->toBe('eml')
+        ->and(DocumentUploadType::extensionForMimeType('application/vnd.ms-outlook'))->toBe('msg')
+        ->and(DocumentUploadType::extensionForMimeType('application/octet-stream-unknown'))->toBeNull()
+        ->and(DocumentUploadType::extensionForMimeType(''))->toBeNull();
+});
+
+test('ensureFileNameHasExtension appends an extension only when missing', function () {
+    expect(DocumentUploadType::ensureFileNameHasExtension('Vergunningaanvraag', 'application/pdf'))->toBe('Vergunningaanvraag.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('rapport.pdf', 'application/pdf'))->toBe('rapport.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('', 'application/pdf'))->toBe('document.pdf')
+        ->and(DocumentUploadType::ensureFileNameHasExtension('naamloos', 'application/octet-stream-unknown'))->toBe('naamloos');
+});


### PR DESCRIPTION
Brings the latest changes from `main` into `next/v1`.

## Included changes from main

- **Fix documents stored without a file extension** (#380): prevent extensionless `bestandsnaam` on upload and reconstruct a usable filename with extension at serve time for existing documents.
- **Stop notifying advisors about concept advice requests** and **also stop advisor notifications when an advice request is finalized** (#379).

## Merge conflict resolution

Three files conflicted and were resolved by combining both sides:

- `app/Http/Controllers/DocumentController.php`: kept the `next/v1` activity logging and the `storedMimeTypeIsAllowed()` allowlist check, and layered the `main` filename-extension reconstruction on top. The MIME type is only trusted (and used to derive an extension) when it is on the upload allowlist; anything else is still served as `application/octet-stream`, so the security behaviour from `next/v1` is preserved.
- `tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php`: kept both the activity-log test and the extension-append test as separate cases.
- `tests/Feature/Jobs/DocumentNotificationReceivedTest.php`: kept the test suites from both branches.

The full test suite passes (pre-commit hook ran Pint, PHPStan, Rector and Pest).