### PR TITLE
Restrict new document versions to the originating party

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Shared\Resources\Zaken\Actions;
 
 use App\Models\Zaak;
+use App\Support\Documents\DocumentVersionAuthorizer;
 use App\Support\Uploads\DocumentUploadType;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
@@ -23,6 +24,7 @@ class NewDocumentVersionAction
             ->schema(fn (array $record) => self::schema($record['titel']))
             ->modalAutofocus(false)
             ->authorize(fn (): bool => auth()->user()->can('uploadDocument', $zaak))
+            ->visible(fn (array $record): bool => DocumentVersionAuthorizer::canAddVersion(auth()->user(), $zaak, $record['uuid']))
             ->action(function (array $record, array $data, Action $action) use ($zaak): void {
 
                 self::createNewDocumentVersion($record['uuid'], $data, $zaak);

--- a/app/Jobs/Submit/UploadFormBijlagenToZGW.php
+++ b/app/Jobs/Submit/UploadFormBijlagenToZGW.php
@@ -158,6 +158,17 @@ final class UploadFormBijlagenToZGW implements ShouldQueue
                 'zaak' => $this->zaak->zgw_zaak_url,
                 'informatieobject' => $info->url,
             ]);
+
+            activity('document')
+                ->event('created')
+                ->causedBy($this->zaak->organiserUser)
+                ->performedOn($this->zaak)
+                ->withProperties([
+                    'document_uuid' => $info->uuid,
+                    'filename' => $info->bestandsnaam,
+                    'titel' => $info->titel,
+                ])
+                ->log(__('activity/event.created'));
         }
 
         $this->zaak->clearZgwCache();

--- a/app/Jobs/Submit/UploadSubmissionPdfToZGW.php
+++ b/app/Jobs/Submit/UploadSubmissionPdfToZGW.php
@@ -76,6 +76,17 @@ final class UploadSubmissionPdfToZGW implements ShouldQueue
             'informatieobject' => $info->url,
         ]);
 
+        activity('document')
+            ->event('created')
+            ->causedBy($this->zaak->organiserUser)
+            ->performedOn($this->zaak)
+            ->withProperties([
+                'document_uuid' => $info->uuid,
+                'filename' => $info->bestandsnaam,
+                'titel' => $info->titel,
+            ])
+            ->log(__('activity/event.created'));
+
         $this->zaak->clearZgwCache();
     }
 

--- a/app/Livewire/Zaken/ZaakDocumentsTable.php
+++ b/app/Livewire/Zaken/ZaakDocumentsTable.php
@@ -58,7 +58,8 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
                     ->date(config('app.date_format'))
                     ->sortable(),
                 TextColumn::make('versie')
-                    ->sortable(),
+                    ->sortable()
+                    ->visible(fn (): bool => auth()->user()->role !== Role::Organiser),
                 TextColumn::make('auteur')
                     ->sortable(),
                 TextColumn::make('bestandsnaam'),

--- a/app/Support/Documents/DocumentVersionAuthorizer.php
+++ b/app/Support/Documents/DocumentVersionAuthorizer.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support\Documents;
+
+use App\Enums\Role;
+use App\Models\User;
+use App\Models\Users\AdvisorUser;
+use App\Models\Users\MunicipalityUser;
+use App\Models\Users\OrganiserUser;
+use App\Models\Zaak;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Bepaalt of een gebruiker een nieuwe versie van een document mag toevoegen.
+ *
+ * Een nieuwe versie mag alleen worden toegevoegd wanneer de eerste versie van
+ * het document is aangemaakt door iemand binnen dezelfde groep als de huidige
+ * gebruiker (organisatie, gemeente of adviesdienst). De maker van de eerste
+ * versie wordt afgeleid uit de activity log ('created'-event met document_uuid).
+ *
+ * Of de gebruiker überhaupt documenten aan de zaak mag toevoegen wordt
+ * elders bepaald (ZaakPolicy::uploadDocument); deze checker voegt daar de
+ * per-document groepsregel aan toe.
+ *
+ * Wanneer de maker niet te bepalen is, wordt het toevoegen conservatief
+ * geblokkeerd om cross-group bewerkingen te voorkomen. Gemeentegebruikers
+ * vormen hierop een uitzondering: zij mogen dan wél een nieuwe versie
+ * toevoegen.
+ */
+class DocumentVersionAuthorizer
+{
+    public static function canAddVersion(User $user, Zaak $zaak, string $documentUuid): bool
+    {
+        if ($user->role === Role::Admin) {
+            return true;
+        }
+
+        $creator = self::resolveCreator($documentUuid);
+
+        if ($creator === null) {
+            return $user instanceof MunicipalityUser;
+        }
+
+        return self::inSameGroup($user, $creator);
+    }
+
+    private static function resolveCreator(string $documentUuid): ?User
+    {
+        $activity = Activity::query()
+            ->where('log_name', 'document')
+            ->where('event', 'created')
+            ->where('properties->document_uuid', $documentUuid)
+            ->whereNotNull('causer_id')
+            ->oldest()
+            ->first();
+
+        $causer = $activity?->causer;
+
+        return $causer instanceof User ? $causer : null;
+    }
+
+    private static function inSameGroup(User $user, User $creator): bool
+    {
+        return match (true) {
+            $user instanceof OrganiserUser => $creator instanceof OrganiserUser,
+            $user instanceof MunicipalityUser => $creator instanceof MunicipalityUser,
+            $user instanceof AdvisorUser => $creator instanceof AdvisorUser
+                && $user->advisories->pluck('id')
+                    ->intersect($creator->advisories->pluck('id'))
+                    ->isNotEmpty(),
+            default => false,
+        };
+    }
+}

--- a/tests/Feature/Livewire/ZaakDocumentsTableTest.php
+++ b/tests/Feature/Livewire/ZaakDocumentsTableTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Livewire\Zaken\ZaakDocumentsTable;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->municipality = Municipality::factory()->create();
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->municipality->id]);
+
+    // Geen zgw_zaak_url: documenten blijft leeg, geen ZGW-call nodig om de
+    // kolomconfiguratie te kunnen testen.
+    $this->zaak = Zaak::factory()->create([
+        'organisation_id' => $this->organisation->id,
+        'zaaktype_id' => $this->zaaktype->id,
+        'zgw_zaak_url' => null,
+    ]);
+});
+
+test('organiser does not see the version column', function () {
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($organiser, ['role' => OrganisationRole::Admin->value]);
+
+    $this->actingAs($organiser);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertTableColumnHidden('versie');
+});
+
+test('reviewer does see the version column', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+
+    $this->actingAs($reviewer);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertTableColumnVisible('versie');
+});

--- a/tests/Feature/Support/DocumentVersionAuthorizerTest.php
+++ b/tests/Feature/Support/DocumentVersionAuthorizerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\AdvisoryRole;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Models\Advisory;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\Support\Documents\DocumentVersionAuthorizer;
+
+beforeEach(function () {
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->municipality = Municipality::factory()->create();
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->municipality->id]);
+    $this->zaak = Zaak::factory()->create([
+        'organisation_id' => $this->organisation->id,
+        'zaaktype_id' => $this->zaaktype->id,
+    ]);
+});
+
+/**
+ * Log a 'created' document activity attributing $creator as the author of the
+ * first version of the given document uuid.
+ */
+function logDocumentCreatedBy(User $creator, Zaak $zaak, string $documentUuid): void
+{
+    activity('document')
+        ->event('created')
+        ->causedBy($creator)
+        ->performedOn($zaak)
+        ->withProperties(['document_uuid' => $documentUuid])
+        ->log('created');
+}
+
+test('admin can always add a new version', function () {
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($admin, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('organiser is blocked when the original creator is unknown', function () {
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($organiser, ['role' => OrganisationRole::Admin->value]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($organiser, $this->zaak, 'doc-uuid'))->toBeFalse();
+});
+
+test('advisor is blocked when the original creator is unknown', function () {
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($advisor, $this->zaak, 'doc-uuid'))->toBeFalse();
+});
+
+test('municipality user can add a new version when the original creator is unknown', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('organiser can add a new version of a document created by an organiser', function () {
+    $creator = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($creator, ['role' => OrganisationRole::Admin->value]);
+    logDocumentCreatedBy($creator, $this->zaak, 'doc-uuid');
+
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($organiser, ['role' => OrganisationRole::Admin->value]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($organiser, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('organiser cannot add a new version of a document created by a reviewer', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    logDocumentCreatedBy($reviewer, $this->zaak, 'doc-uuid');
+
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($organiser, ['role' => OrganisationRole::Admin->value]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($organiser, $this->zaak, 'doc-uuid'))->toBeFalse();
+});
+
+test('reviewer can add a new version of a document created by a reviewer', function () {
+    $creator = User::factory()->create(['role' => Role::Reviewer]);
+    logDocumentCreatedBy($creator, $this->zaak, 'doc-uuid');
+
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('reviewer cannot add a new version of a document created by an organiser', function () {
+    $creator = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($creator, ['role' => OrganisationRole::Admin->value]);
+    logDocumentCreatedBy($creator, $this->zaak, 'doc-uuid');
+
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'doc-uuid'))->toBeFalse();
+});
+
+test('advisor can add a new version when sharing the same advisory as the creator', function () {
+    $advisory = Advisory::factory()->create();
+
+    $creator = User::factory()->create(['role' => Role::Advisor]);
+    $creator->advisories()->attach($advisory, ['role' => AdvisoryRole::Member]);
+    logDocumentCreatedBy($creator, $this->zaak, 'doc-uuid');
+
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+    $advisor->advisories()->attach($advisory, ['role' => AdvisoryRole::Member]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($advisor, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('advisor cannot add a new version of a document created by a different advisory', function () {
+    $advisory = Advisory::factory()->create();
+    $otherAdvisory = Advisory::factory()->create();
+
+    $creator = User::factory()->create(['role' => Role::Advisor]);
+    $creator->advisories()->attach($advisory, ['role' => AdvisoryRole::Member]);
+    logDocumentCreatedBy($creator, $this->zaak, 'doc-uuid');
+
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+    $advisor->advisories()->attach($otherAdvisory, ['role' => AdvisoryRole::Member]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($advisor, $this->zaak, 'doc-uuid'))->toBeFalse();
+});


### PR DESCRIPTION
## What & why

Fixes two bugs around document versions in the files tab of a case.

### 1. New versions only by the originating party
Previously any user could add a new version to any document. Now this is only allowed when the first version was created by someone within the user's own group:

- **Organiser**: only if the first version was created by someone within the organisation.
- **Municipality**: only if the first version was created by someone within the same municipality.
- **Advisory service**: only if the first version was created by someone within the same advisory service.

The original author is resolved from the `created` entry in the document's activity log. Documents created during form submission (`UploadFormBijlagenToZGW`, `UploadSubmissionPdfToZGW`) now also log that `created` activity, attributed to the organiser.

When the original author cannot be determined, adding a new version is blocked for organisers and advisory services (conservative, to prevent cross-group edits). Municipality users are an exception here and may still add a new version in that case.

The general permission check for whether a user may add documents to the case at all stays with `ZaakPolicy::uploadDocument`. The new rule is layered on top of it per document.

### 2. Version column hidden for organisers
Organisers no longer see the current version of documents in the files table, as this was confusing for them. All other users keep seeing the version column.

## Implementation
- New `App\Support\Documents\DocumentVersionAuthorizer` holding the group logic.
- `NewDocumentVersionAction` uses this checker via `->visible()` per document.
- `ZaakDocumentsTable` hides the `versie` column for organisers.
- Activity logging added to the two submission jobs.

## Tests
- `DocumentVersionAuthorizerTest`: all role combinations, including unknown author and the municipality exception.
- `ZaakDocumentsTableTest`: version column visibility per role.