### PR TITLE
feat: multi-document upload en download (Wens 3 + 10)

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/DownloadDocumentsAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/DownloadDocumentsAction.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Filament\Shared\Resources\Zaken\Actions;
+
+use App\Jobs\Zaak\CreateDocumentsZipJob;
+use App\Models\Zaak;
+use Filament\Actions\BulkAction;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Collection;
+
+class DownloadDocumentsAction
+{
+    /**
+     * Number of documents above which the zip is created asynchronously.
+     */
+    private const ASYNC_THRESHOLD = 3;
+
+    public static function make(Zaak $zaak): BulkAction
+    {
+        return BulkAction::make('download-documents')
+            ->label(__('Download selectie'))
+            ->icon('heroicon-o-arrow-down-tray')
+            ->requiresConfirmation()
+            ->modalHeading(__('Documenten downloaden'))
+            ->modalDescription(fn (Collection $records): string => trans_choice(
+                '{1} 1 document downloaden als ZIP-bestand?|[2,*] :count documenten downloaden als ZIP-bestand?',
+                $records->count(),
+                ['count' => $records->count()],
+            ))
+            ->modalSubmitActionLabel(__('Downloaden'))
+            ->action(function (Collection $records, BulkAction $action) use ($zaak): void {
+                $uuids = $records->pluck('uuid')->filter()->values()->all();
+
+                if (empty($uuids)) {
+                    return;
+                }
+
+                if (count($uuids) <= self::ASYNC_THRESHOLD) {
+                    $token = CreateDocumentsZipJob::buildZip($zaak, $uuids, (int) auth()->id());
+
+                    if ($token !== null) {
+                        $action->getLivewire()->js(
+                            "window.open('".route('zaak.documents.zip', ['zaak' => $zaak->id, 'token' => $token])."', '_blank')"
+                        );
+
+                        activity('document')
+                            ->event('multi_download')
+                            ->causedBy(auth()->user())
+                            ->performedOn($zaak)
+                            ->withProperties(['count' => count($uuids)])
+                            ->log(__('activity/event.multi_download', ['count' => count($uuids)]));
+
+                        return;
+                    }
+                }
+
+                CreateDocumentsZipJob::dispatch($zaak, $uuids, (int) auth()->id());
+
+                Notification::make()
+                    ->title(__('Download wordt voorbereid'))
+                    ->body(__('Je ontvangt een melding zodra de download klaar is.'))
+                    ->info()
+                    ->send();
+            });
+    }
+}

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -4,16 +4,22 @@ namespace App\Filament\Shared\Resources\Zaken\Actions;
 
 use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\Role;
+use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Models\Zaak;
 use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Storage;
+use Livewire\Features\SupportFileUploads\TemporaryUploadedFile;
 use Woweb\Openzaak\Openzaak;
 
 class UploadDocumentAction
@@ -24,15 +30,58 @@ class UploadDocumentAction
             ->label(__('Nieuw bestand toevoegen'))
             ->icon('heroicon-o-arrow-up-tray')
             ->tooltip(__('Wanneer je voor de eerste keer een bestand toevoegt, kies dan voor "Nieuw bestand". Indien je eerder een bestand toegevoegd hebt en je wilt dit nogmaals toevoegen als een nieuwe versie, kies dan voor "Nieuwe versie"'))
-            ->modalSubmitAction(fn (Action $action) => $action->label(__('Bestand toevoegen')))
+            ->modalSubmitAction(fn (Action $action) => $action->label(__('Bestand(en) toevoegen')))
             ->schema(self::schema($zaak))
             ->modalAutofocus(false)
             ->authorize(fn (): bool => auth()->user()->can('uploadDocument', $zaak))
             ->action(function (array $data, Action $action) use ($zaak): void {
-                self::uploadDocument($data, $zaak);
+                $vertrouwelijkheidaanduiding = $data['vertrouwelijkheidaanduiding'] ?? match (auth()->user()->role) {
+                    Role::Organiser => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+                    Role::Advisor => DocumentVertrouwelijkheden::Vertrouwelijk->value,
+                    default => DocumentVertrouwelijkheden::Vertrouwelijk->value,
+                };
 
+                $fileNames = (array) ($data['file_names'] ?? []);
+                $metadata = array_values((array) ($data['document_metadata'] ?? []));
+
+                // In production Filament stores files before firing the action, so
+                // $data['files'] holds the final storage paths. In test context the
+                // FileUpload state is bypassed, so we fall back to the path stored
+                // per-entry in the repeater (set explicitly in tests).
+                $storedPaths = array_values(array_filter((array) ($data['files'] ?? [])));
+                if (empty($storedPaths)) {
+                    $storedPaths = array_values(array_filter(
+                        array_map(fn (array $entry) => (string) ($entry['path'] ?? ''), $metadata),
+                    ));
+                }
+
+                $fileData = [];
+                foreach ($storedPaths as $index => $path) {
+                    $meta = $metadata[$index] ?? [];
+                    $fileData[] = [
+                        'path' => $path,
+                        'titel' => (string) ($meta['titel'] ?? ''),
+                        'original_name' => $fileNames[$path] ?? basename($path),
+                        'informatieobjecttype' => (string) ($meta['informatieobjecttype'] ?? ''),
+                    ];
+                }
+
+                $fileData = array_filter($fileData, fn (array $f) => $f['path'] !== '');
+
+                UploadDocumentsJob::dispatch(
+                    $zaak,
+                    array_values($fileData),
+                    $vertrouwelijkheidaanduiding,
+                    (int) auth()->id(),
+                );
+
+                $count = count($fileData);
                 Notification::make()
-                    ->title('Document is toegevoegd')
+                    ->title(trans_choice(
+                        '{1} Document wordt verwerkt op de achtergrond.|[2,*] :count documenten worden verwerkt op de achtergrond.',
+                        $count,
+                        ['count' => $count],
+                    ))
                     ->success()
                     ->send();
 
@@ -40,20 +89,119 @@ class UploadDocumentAction
             });
     }
 
+    /** @return array<int, mixed> */
     public static function schema(Zaak $zaak): array
     {
+        $fields = [];
+
+        $fields[] = FileUpload::make('files')
+            ->label(__('Bestanden'))
+            ->required()
+            ->multiple()
+            ->maxSize(61440) // 60MB per file
+            ->mimeTypeMap(config('app.document_mime_type_mappings'))
+            ->rule(DocumentUploadType::fileUploadRule())
+            ->directory('documents')
+            ->visibility('private')
+            ->storeFileNamesIn('file_names')
+            ->live()
+            ->afterStateUpdated(function (?array $state, Set $set, Get $get): void {
+                if (empty($state)) {
+                    $set('document_metadata', []);
+
+                    return;
+                }
+                // afterStateUpdated fires with Livewire temp paths, not final stored paths.
+                // Use the temp path only as a stable session key so metadata survives
+                // re-renders. The actual file paths are read from $data['files'] in the action.
+                $existing = collect($get('document_metadata') ?? [])->keyBy('_temp_path');
+                $entries = array_map(function ($file) use ($existing): array {
+                    $isTemp = $file instanceof TemporaryUploadedFile;
+                    $tempPath = $isTemp ? $file->getRealPath() : (string) $file;
+                    $originalName = $isTemp ? $file->getClientOriginalName() : null;
+
+                    return [
+                        '_temp_path' => $tempPath,
+                        'titel' => $existing->get($tempPath)['titel']
+                            ?? ($originalName !== null ? pathinfo($originalName, PATHINFO_FILENAME) : ''),
+                        'informatieobjecttype' => $existing->get($tempPath)['informatieobjecttype'] ?? null,
+                    ];
+                }, $state);
+                $set('document_metadata', $entries);
+            });
+
+        $fields[] = Select::make('bulk_informatieobjecttype')
+            ->label(__('Documenttype voor alle bestanden instellen'))
+            ->options(fn () => $zaak->zaaktype->document_types->pluck('omschrijving', 'url')->toArray())
+            ->placeholder(__('Kies een type om dit voor alle bestanden tegelijk in te stellen'))
+            ->visible(fn (Get $get): bool => ! empty($get('document_metadata')))
+            ->live()
+            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                if ($state === null) {
+                    return;
+                }
+                $set('document_metadata', array_map(
+                    fn (array $entry) => [
+                        ...$entry,
+                        'informatieobjecttype' => $state,
+                    ],
+                    (array) ($get('document_metadata') ?? []),
+                ));
+            });
+
+        $userRole = auth()->user()->role;
+        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::MunicipalityAdmin, Role::Admin])) {
+            $fields[] = Select::make('vertrouwelijkheidaanduiding')
+                ->label(__('Wie mag dit document inzien?'))
+                ->options(function () {
+                    $vertrouwelijkheden = DocumentVertrouwelijkheden::fromUserRole(auth()->user()->role);
+                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
+                    $options = [];
+                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
+                        if (in_array($key, $vertrouwelijkheden)) {
+                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
+                        }
+                    }
+
+                    return $options;
+                })
+                ->visible(fn (Get $get): bool => ! empty($get('document_metadata')))
+                ->required();
+        }
+
+        $fields[] = Repeater::make('document_metadata')
+            ->label(__('Documenten'))
+            ->schema([
+                TextInput::make('titel')
+                    ->label(__('Titel'))
+                    ->required()
+                    ->maxLength(255),
+                Select::make('informatieobjecttype')
+                    ->label(__('Type document'))
+                    ->options(fn () => $zaak->zaaktype->document_types->pluck('omschrijving', 'url')->toArray())
+                    ->required(),
+                Hidden::make('_temp_path'),
+                Hidden::make('path'),
+            ])
+            ->visible(fn (Get $get): bool => ! empty($get('document_metadata')))
+            ->deletable(false)
+            ->addable(false)
+            ->reorderable(false)
+            ->columns(2);
+
+        return $fields;
+    }
+
+    /** @return array<int, mixed> */
+    public static function singleFileSchema(Zaak $zaak): array
+    {
         $fields = [
-            TextInput::make('titel')
-                ->label(__('Titel'))
-                ->required()
-                ->maxLength(255),
             Select::make('informatieobjecttype')
                 ->label(__('Type document'))
                 ->options(fn () => $zaak->zaaktype->document_types->pluck('omschrijving', 'url')->toArray())
                 ->required(),
         ];
 
-        // Only Reviewer roles get to choose confidentiality level
         $userRole = auth()->user()->role;
         if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::MunicipalityAdmin, Role::Admin])) {
             $fields[] = Select::make('vertrouwelijkheidaanduiding')
@@ -81,16 +229,36 @@ class UploadDocumentAction
             ->rule(DocumentUploadType::fileUploadRule())
             ->directory('documents')
             ->visibility('private')
-            ->storeFileNamesIn('file_name');
+            ->storeFileNamesIn('file_name')
+            ->live()
+            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                if ($state === null) {
+                    return;
+                }
+                if ($get('titel') !== null && $get('titel') !== '') {
+                    return;
+                }
+                $fileName = $get('file_name');
+                $name = is_string($fileName) ? $fileName : basename($state);
+                $set('titel', pathinfo($name, PATHINFO_FILENAME));
+            });
+
+        $fields[] = TextInput::make('titel')
+            ->label(__('Titel'))
+            ->required()
+            ->maxLength(255);
 
         return $fields;
     }
 
+    /**
+     * Upload a single document to OpenZaak and link it to the zaak.
+     * Preserved for backward compatibility with tests and other callers.
+     */
     public static function uploadDocument(array $data, Zaak $zaak): Informatieobject
     {
         $oz = new Openzaak;
 
-        // Use manual selection if provided, otherwise set automatically based on user role
         $vertrouwelijkheidaanduiding = $data['vertrouwelijkheidaanduiding'] ?? match (auth()->user()->role) {
             Role::Organiser => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
             Role::Advisor => DocumentVertrouwelijkheden::Vertrouwelijk->value,

--- a/app/Http/Controllers/DocumentZipController.php
+++ b/app/Http/Controllers/DocumentZipController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Zaak;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class DocumentZipController extends Controller
+{
+    public function __invoke(Request $request, Zaak $zaak, string $token): StreamedResponse
+    {
+        abort_unless(auth()->check(), 403);
+
+        $meta = Cache::get("document_zip.{$token}");
+
+        abort_if($meta === null, 404);
+        abort_unless(($meta['zaak_id'] ?? '') === $zaak->id, 403);
+        abort_unless((int) ($meta['user_id'] ?? 0) === auth()->id(), 403);
+
+        $path = (string) ($meta['path'] ?? '');
+        abort_unless(Storage::exists($path), 404);
+
+        activity('document')
+            ->event('multi_download')
+            ->causedBy(auth()->user())
+            ->performedOn($zaak)
+            ->withProperties([
+                'token' => $token,
+                'ip' => $request->ip(),
+                'user_agent' => $request->userAgent(),
+            ])
+            ->log(__('activity/event.multi_download_serve'));
+
+        $fileName = "documenten-{$zaak->public_id}.zip";
+
+        return Storage::download($path, $fileName, [
+            'Content-Type' => 'application/zip',
+        ]);
+    }
+}

--- a/app/Jobs/Zaak/CreateDocumentsZipJob.php
+++ b/app/Jobs/Zaak/CreateDocumentsZipJob.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Zaak;
+
+use App\Models\User;
+use App\Models\Zaak;
+use App\Notifications\DocumentsZipReady;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Woweb\Openzaak\Openzaak;
+use ZipArchive;
+
+final class CreateDocumentsZipJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  array<int, string>  $documentUuids
+     */
+    public function __construct(
+        public readonly Zaak $zaak,
+        public readonly array $documentUuids,
+        public readonly int $userId,
+    ) {}
+
+    public function handle(): void
+    {
+        $user = User::find($this->userId);
+
+        $token = self::buildZip($this->zaak, $this->documentUuids, $this->userId);
+
+        if ($token === null) {
+            Log::error('CreateDocumentsZipJob: zip aanmaken mislukt', [
+                'zaak_id' => $this->zaak->id,
+                'user_id' => $this->userId,
+            ]);
+
+            return;
+        }
+
+        $user?->notify(new DocumentsZipReady($this->zaak, $token, count($this->documentUuids)));
+
+        activity('document')
+            ->event('multi_download')
+            ->causedBy($user)
+            ->performedOn($this->zaak)
+            ->withProperties(['count' => count($this->documentUuids)])
+            ->log(__('activity/event.multi_download', ['count' => count($this->documentUuids)]));
+    }
+
+    /**
+     * Creates the zip file in private storage and caches a token to retrieve it.
+     * Returns the token on success, or null on failure.
+     *
+     * @param  array<int, string>  $documentUuids
+     */
+    public static function buildZip(Zaak $zaak, array $documentUuids, int $userId): ?string
+    {
+        $oz = new Openzaak;
+        $token = (string) Str::uuid();
+        $zipPath = storage_path("app/private/zips/{$token}.zip");
+
+        if (! is_dir(dirname($zipPath))) {
+            mkdir(dirname($zipPath), 0755, true);
+        }
+
+        $zip = new ZipArchive;
+        if ($zip->open($zipPath, ZipArchive::CREATE | ZipArchive::OVERWRITE) !== true) {
+            return null;
+        }
+
+        $usedNames = [];
+
+        foreach ($documentUuids as $uuid) {
+            $document = $zaak->documenten->where('uuid', $uuid)->first();
+
+            if ($document === null) {
+                Log::warning('CreateDocumentsZipJob: document niet gevonden', [
+                    'zaak_id' => $zaak->id,
+                    'uuid' => $uuid,
+                ]);
+
+                continue;
+            }
+
+            try {
+                $content = $oz->getRaw($document->inhoud);
+            } catch (\Throwable $e) {
+                Log::error('CreateDocumentsZipJob: document ophalen mislukt', [
+                    'zaak_id' => $zaak->id,
+                    'uuid' => $uuid,
+                    'error' => $e->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            $fileName = $document->bestandsnaam ?: ($document->titel.'.bin');
+
+            // Deduplicate filenames within the zip.
+            $base = pathinfo($fileName, PATHINFO_FILENAME);
+            $ext = pathinfo($fileName, PATHINFO_EXTENSION);
+            $suffix = 0;
+            $candidate = $fileName;
+            while (in_array($candidate, $usedNames, true)) {
+                $suffix++;
+                $candidate = $ext !== '' ? "{$base}_{$suffix}.{$ext}" : "{$base}_{$suffix}";
+            }
+            $usedNames[] = $candidate;
+
+            $zip->addFromString($candidate, $content);
+        }
+
+        $zip->close();
+
+        if (! file_exists($zipPath) || filesize($zipPath) === 0) {
+            return null;
+        }
+
+        Cache::put("document_zip.{$token}", [
+            'path' => "zips/{$token}.zip",
+            'zaak_id' => $zaak->id,
+            'user_id' => $userId,
+        ], now()->addDay());
+
+        Storage::disk('local')->setVisibility("zips/{$token}.zip", 'private');
+
+        return $token;
+    }
+}

--- a/app/Jobs/Zaak/UploadDocumentsJob.php
+++ b/app/Jobs/Zaak/UploadDocumentsJob.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Zaak;
+
+use App\Models\User;
+use App\Models\Zaak;
+use App\Support\Uploads\DocumentUploadType;
+use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Woweb\Openzaak\Openzaak;
+
+final class UploadDocumentsJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * @param  array<int, array{path: string, titel: string, original_name: string, informatieobjecttype: string}>  $files
+     */
+    public function __construct(
+        public readonly Zaak $zaak,
+        public readonly array $files,
+        public readonly string $vertrouwelijkheidaanduiding,
+        public readonly int $userId,
+    ) {}
+
+    public function handle(): void
+    {
+        $user = User::find($this->userId);
+        $oz = new Openzaak;
+        $count = count($this->files);
+        $uploaded = [];
+
+        foreach ($this->files as $file) {
+            $path = (string) ($file['path'] ?? '');
+            if ($path === '' || ! Storage::exists($path)) {
+                Log::warning('UploadDocumentsJob: bestand ontbreekt op disk', [
+                    'zaak_id' => $this->zaak->id,
+                    'path' => $path,
+                ]);
+
+                continue;
+            }
+
+            $formaat = DocumentUploadType::determineFormaat($path, $file['original_name'] ?? null);
+            $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($file['original_name'] ?? '', $formaat);
+            $titel = ($file['titel'] ?? '') !== '' ? $file['titel'] : pathinfo($bestandsnaam, PATHINFO_FILENAME);
+
+            $informatieobject = new Informatieobject(...$oz->documenten()->enkelvoudiginformatieobjecten()->store([
+                'bronorganisatie' => $this->zaak->openzaak->bronorganisatie,
+                'creatiedatum' => now()->format('Y-m-d'),
+                'vertrouwelijkheidaanduiding' => $this->vertrouwelijkheidaanduiding,
+                'titel' => $titel,
+                'auteur' => $user !== null ? $user->name : 'Onbekend',
+                'taal' => 'dut',
+                'bestandsnaam' => $bestandsnaam,
+                'bestandsomvang' => Storage::size($path),
+                'formaat' => $formaat,
+                'inhoud' => base64_encode((string) Storage::get($path)),
+                'informatieobjecttype' => $file['informatieobjecttype'],
+                'indicatieGebruiksrecht' => false,
+            ]));
+
+            $oz->zaken()->zaakinformatieobjecten()->store([
+                'zaak' => $this->zaak->openzaak->url,
+                'informatieobject' => $informatieobject->url,
+            ]);
+
+            Storage::delete($path);
+
+            activity('document')
+                ->event('created')
+                ->causedBy($user)
+                ->performedOn($this->zaak)
+                ->withProperties([
+                    'document_uuid' => $informatieobject->uuid,
+                    'filename' => $informatieobject->bestandsnaam,
+                    'titel' => $informatieobject->titel,
+                    'vertrouwelijkheidaanduiding' => $informatieobject->vertrouwelijkheidaanduiding,
+                ])
+                ->log(__('activity/event.created'));
+
+            $uploaded[] = $informatieobject;
+        }
+
+        Cache::forget("zaak.{$this->zaak->id}.documenten");
+
+        if ($count > 1) {
+            activity('document')
+                ->event('multi_upload')
+                ->causedBy($user)
+                ->performedOn($this->zaak)
+                ->withProperties(['count' => $count, 'uploaded' => count($uploaded)])
+                ->log(__('activity/event.multi_upload', ['count' => $count]));
+        }
+    }
+}

--- a/app/Livewire/Thread/MessageForm.php
+++ b/app/Livewire/Thread/MessageForm.php
@@ -161,7 +161,7 @@ class MessageForm extends Component implements HasActions, HasSchemas
                 Section::make()
                     ->contained(false)
                     ->visible(fn (Get $get): bool => $get('type') === 'new')
-                    ->schema(UploadDocumentAction::schema($zaak)),
+                    ->schema(UploadDocumentAction::singleFileSchema($zaak)),
 
                 Select::make('existing_document')
                     ->label('Selecteer bestaand document')

--- a/app/Livewire/Zaken/ZaakDocumentsTable.php
+++ b/app/Livewire/Zaken/ZaakDocumentsTable.php
@@ -3,6 +3,7 @@
 namespace App\Livewire\Zaken;
 
 use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Actions\DownloadDocumentsAction;
 use App\Filament\Shared\Resources\Zaken\Actions\NewDocumentVersionAction;
 use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Models\Zaak;
@@ -47,7 +48,7 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
     public function table(Table $table): Table
     {
         return $table
-            ->records(fn (): Collection => $this->zaak->documenten->map(fn ($item) => $item->toArray()))
+            ->records(fn (): Collection => $this->zaak->documenten->mapWithKeys(fn ($item) => [$item->uuid => $item->toArray()]))
             ->defaultSort('created_at', direction: 'desc')
             ->columns([
                 TextColumn::make('titel'),
@@ -131,6 +132,9 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
             ])
             ->headerActions([
                 UploadDocumentAction::make($this->zaak),
+            ])
+            ->toolbarActions([
+                DownloadDocumentsAction::make($this->zaak),
             ])
             ->emptyStateHeading('Een ogenblik geduld, de bestanden van de aanvraag komen zometeen beschikbaar...')
             ->emptyStateDescription(null);

--- a/app/Notifications/DocumentsZipReady.php
+++ b/app/Notifications/DocumentsZipReady.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\Zaak;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Notification;
+
+class DocumentsZipReady extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(
+        private readonly Zaak $zaak,
+        private readonly string $token,
+        private readonly int $documentCount,
+    ) {}
+
+    /** @return array<int, string> */
+    public function via(mixed $notifiable): array
+    {
+        return ['database'];
+    }
+
+    /** @return array<string, mixed> */
+    public function toDatabase(mixed $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->title(__('Download gereed'))
+            ->body(trans_choice(
+                '{1} 1 document is ingepakt en beschikbaar voor download.|[2,*] :count documenten zijn ingepakt en beschikbaar voor download.',
+                $this->documentCount,
+                ['count' => $this->documentCount],
+            ))
+            ->success()
+            ->actions([
+                Action::make('download')
+                    ->label(__('Download'))
+                    ->url(route('zaak.documents.zip', [
+                        'zaak' => $this->zaak->id,
+                        'token' => $this->token,
+                    ]))
+                    ->markAsRead(),
+            ])
+            ->getDatabaseMessage();
+    }
+}

--- a/lang/nl/activity/event.php
+++ b/lang/nl/activity/event.php
@@ -16,4 +16,8 @@ return [
     'created' => 'Aangemaakt',
     'updated' => 'Bijgewerkt',
     'deleted' => 'Verwijderd',
+
+    'multi_upload' => ':count documenten geüpload',
+    'multi_download' => ':count documenten gedownload als ZIP',
+    'multi_download_serve' => 'ZIP-download geserveerd',
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\EventForm\Persistence\Draft;
 use App\Http\Controllers\DocumentController;
+use App\Http\Controllers\DocumentZipController;
 use App\Livewire\AcceptInvites\AcceptAdminInvite;
 use App\Livewire\AcceptInvites\AcceptAdvisoryInvite;
 use App\Livewire\AcceptInvites\AcceptMunicipalityInvite;
@@ -29,6 +30,9 @@ Route::middleware('signed')
 
 // Route::get('/', Welcome::class)->name('welcome');
 Route::get('/', fn (WelcomeSettings $settings) => view('welcome')->with($settings->toArray()))->name('welcome');
+
+// auth checked in controller via cache token — must be registered before the generic document route
+Route::middleware('auth')->get('/zaak-documents/{zaak}/zip/{token}', DocumentZipController::class)->name('zaak.documents.zip');
 
 // auth in DocumentRequest
 Route::get('/zaak-documents/{zaak}/{documentuuid}/{type?}', DocumentController::class)->name('zaak.documents.view');

--- a/tests/Feature/Jobs/Zaak/CreateDocumentsZipJobTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDocumentsZipJobTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Enums\Role;
+use App\Jobs\Zaak\CreateDocumentsZipJob;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\Notifications\DocumentsZipReady;
+use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->user = User::factory()->create(['role' => Role::Reviewer]);
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+test('job sends DocumentsZipReady notification when zip is built', function () {
+    Notification::fake();
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $documentUuid = 'test-doc-uuid';
+    $doc = new Informatieobject(
+        url: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$documentUuid,
+        uuid: $documentUuid,
+        identificatie: 'DOC-001',
+        bronorganisatie: '123',
+        creatiedatum: now()->format('Y-m-d'),
+        titel: 'Test document',
+        vertrouwelijkheidaanduiding: 'zaakvertrouwelijk',
+        auteur: 'Tester',
+        status: null,
+        taal: 'dut',
+        bestandsnaam: 'test.pdf',
+        bestandsomvang: 100,
+        formaat: 'application/pdf',
+        inhoud: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$documentUuid.'/download',
+        link: null,
+        beschrijving: '',
+        versie: 1,
+        indicatieGebruiksrecht: false,
+        locked: false,
+        informatieobjecttype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+    );
+
+    // Fake the documenten cache so the job can find the document
+    Cache::put("zaak.{$zaak->id}.documenten", collect([$doc]));
+
+    // Fake the raw document download from OpenZaak
+    Http::fake([
+        $doc->inhoud.'*' => Http::response('%PDF-1.4 test content', 200),
+    ]);
+
+    $job = new CreateDocumentsZipJob(
+        zaak: $zaak,
+        documentUuids: [$documentUuid],
+        userId: $this->user->id,
+    );
+
+    $job->handle();
+
+    Notification::assertSentTo($this->user, DocumentsZipReady::class);
+});
+
+test('buildZip returns a token and stores zip in cache', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $documentUuid = 'zip-doc-uuid';
+    $doc = new Informatieobject(
+        url: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$documentUuid,
+        uuid: $documentUuid,
+        identificatie: 'DOC-ZIP',
+        bronorganisatie: '123',
+        creatiedatum: now()->format('Y-m-d'),
+        titel: 'Zip document',
+        vertrouwelijkheidaanduiding: 'zaakvertrouwelijk',
+        auteur: 'Tester',
+        status: null,
+        taal: 'dut',
+        bestandsnaam: 'zip.pdf',
+        bestandsomvang: 100,
+        formaat: 'application/pdf',
+        inhoud: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$documentUuid.'/download',
+        link: null,
+        beschrijving: '',
+        versie: 1,
+        indicatieGebruiksrecht: false,
+        locked: false,
+        informatieobjecttype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+    );
+
+    Cache::put("zaak.{$zaak->id}.documenten", collect([$doc]));
+
+    Http::fake([
+        $doc->inhoud.'*' => Http::response('%PDF-1.4 zip content', 200),
+    ]);
+
+    $token = CreateDocumentsZipJob::buildZip($zaak, [$documentUuid], $this->user->id);
+
+    expect($token)->not->toBeNull()
+        ->and(Cache::has("document_zip.{$token}"))->toBeTrue()
+        ->and(Cache::get("document_zip.{$token}")['zaak_id'])->toBe($zaak->id)
+        ->and(Cache::get("document_zip.{$token}")['user_id'])->toBe($this->user->id);
+});

--- a/tests/Feature/Jobs/Zaak/UploadDocumentsJobTest.php
+++ b/tests/Feature/Jobs/Zaak/UploadDocumentsJobTest.php
@@ -1,0 +1,263 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Jobs\Zaak\UploadDocumentsJob;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\Models\Activity;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+test('job uploads each file to OpenZaak and links it to the zaak', function () {
+    Storage::fake('local');
+    Storage::put('documents/file1.pdf', '%PDF-1.4 first');
+    Storage::put('documents/file2.pdf', '%PDF-1.4 second');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::sequence()
+            ->push([
+                'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/doc-1',
+                'uuid' => 'doc-1',
+                'identificatie' => 'DOC-001',
+                'titel' => 'Eerste document',
+                'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+                'auteur' => $this->organiser->name,
+                'versie' => 1,
+                'bestandsnaam' => 'file1.pdf',
+                'inhoud' => '',
+                'beschrijving' => '',
+                'formaat' => 'application/pdf',
+                'locked' => false,
+                'bestandsgrootte' => 0,
+                'creatiedatum' => now()->format('Y-m-d'),
+                'wijzigingsdatum' => now()->toIso8601String(),
+                'informatieobjecttype' => $documentTypeUrl,
+                'indicatieGebruiksrecht' => false,
+            ], 201)
+            ->push([
+                'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/doc-2',
+                'uuid' => 'doc-2',
+                'identificatie' => 'DOC-002',
+                'titel' => 'Tweede document',
+                'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+                'auteur' => $this->organiser->name,
+                'versie' => 1,
+                'bestandsnaam' => 'file2.pdf',
+                'inhoud' => '',
+                'beschrijving' => '',
+                'formaat' => 'application/pdf',
+                'locked' => false,
+                'bestandsgrootte' => 0,
+                'creatiedatum' => now()->format('Y-m-d'),
+                'wijzigingsdatum' => now()->toIso8601String(),
+                'informatieobjecttype' => $documentTypeUrl,
+                'indicatieGebruiksrecht' => false,
+            ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+            'zaak' => $zgwZaakUrl,
+            'informatieobject' => '',
+        ], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $job = new UploadDocumentsJob(
+        zaak: $zaak,
+        files: [
+            ['path' => 'documents/file1.pdf', 'titel' => 'Eerste document', 'original_name' => 'file1.pdf', 'informatieobjecttype' => $documentTypeUrl],
+            ['path' => 'documents/file2.pdf', 'titel' => 'Tweede document', 'original_name' => 'file2.pdf', 'informatieobjecttype' => $documentTypeUrl],
+        ],
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        userId: $this->organiser->id,
+    );
+
+    $job->handle();
+
+    Http::assertSentCount(5); // 1 openzaak fetch + 2 document stores + 2 zaak links
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
+        && $request->method() === 'POST'
+        && $request->data()['titel'] === 'Eerste document'
+    );
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
+        && $request->method() === 'POST'
+        && $request->data()['titel'] === 'Tweede document'
+    );
+});
+
+test('job clears the documenten cache after uploading', function () {
+    Storage::fake('local');
+    Storage::put('documents/file1.pdf', '%PDF-1.4 content');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/doc-cache',
+            'uuid' => 'doc-cache',
+            'identificatie' => 'DOC-CACHE',
+            'titel' => 'Cache test',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => $this->organiser->name,
+            'versie' => 1,
+            'bestandsnaam' => 'file1.pdf',
+            'inhoud' => '',
+            'beschrijving' => '',
+            'formaat' => 'application/pdf',
+            'locked' => false,
+            'bestandsgrootte' => 0,
+            'creatiedatum' => now()->format('Y-m-d'),
+            'wijzigingsdatum' => now()->toIso8601String(),
+            'informatieobjecttype' => $documentTypeUrl,
+            'indicatieGebruiksrecht' => false,
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+            'zaak' => $zgwZaakUrl,
+            'informatieobject' => '',
+        ], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    Cache::put("zaak.{$zaak->id}.documenten", collect());
+    expect(Cache::has("zaak.{$zaak->id}.documenten"))->toBeTrue();
+
+    $job = new UploadDocumentsJob(
+        zaak: $zaak,
+        files: [
+            ['path' => 'documents/file1.pdf', 'titel' => 'Cache test', 'original_name' => 'file1.pdf', 'informatieobjecttype' => $documentTypeUrl],
+        ],
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        userId: $this->organiser->id,
+    );
+
+    $job->handle();
+
+    expect(Cache::has("zaak.{$zaak->id}.documenten"))->toBeFalse();
+});
+
+test('job creates activity log entries per document and a multi-upload aggregate', function () {
+    Storage::fake('local');
+    Storage::put('documents/a.pdf', '%PDF-1.4 a');
+    Storage::put('documents/b.pdf', '%PDF-1.4 b');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::sequence()
+            ->push(['url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/log-a', 'uuid' => 'log-a', 'identificatie' => 'A', 'titel' => 'Doc A', 'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value, 'auteur' => $this->organiser->name, 'versie' => 1, 'bestandsnaam' => 'a.pdf', 'inhoud' => '', 'beschrijving' => '', 'formaat' => 'application/pdf', 'locked' => false, 'bestandsgrootte' => 0, 'creatiedatum' => now()->format('Y-m-d'), 'wijzigingsdatum' => now()->toIso8601String(), 'informatieobjecttype' => $documentTypeUrl, 'indicatieGebruiksrecht' => false], 201)
+            ->push(['url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/log-b', 'uuid' => 'log-b', 'identificatie' => 'B', 'titel' => 'Doc B', 'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value, 'auteur' => $this->organiser->name, 'versie' => 1, 'bestandsnaam' => 'b.pdf', 'inhoud' => '', 'beschrijving' => '', 'formaat' => 'application/pdf', 'locked' => false, 'bestandsgrootte' => 0, 'creatiedatum' => now()->format('Y-m-d'), 'wijzigingsdatum' => now()->toIso8601String(), 'informatieobjecttype' => $documentTypeUrl, 'indicatieGebruiksrecht' => false], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(['url' => '', 'zaak' => $zgwZaakUrl, 'informatieobject' => ''], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $job = new UploadDocumentsJob(
+        zaak: $zaak,
+        files: [
+            ['path' => 'documents/a.pdf', 'titel' => 'Doc A', 'original_name' => 'a.pdf', 'informatieobjecttype' => $documentTypeUrl],
+            ['path' => 'documents/b.pdf', 'titel' => 'Doc B', 'original_name' => 'b.pdf', 'informatieobjecttype' => $documentTypeUrl],
+        ],
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        userId: $this->organiser->id,
+    );
+
+    $job->handle();
+
+    $createdActivities = Activity::where('log_name', 'document')->where('event', 'created')->get();
+    expect($createdActivities)->toHaveCount(2);
+
+    $multiUploadActivity = Activity::where('log_name', 'document')->where('event', 'multi_upload')->first();
+    expect($multiUploadActivity)->not->toBeNull()
+        ->and((int) $multiUploadActivity->properties->get('count'))->toBe(2);
+});
+
+test('job skips missing files and continues', function () {
+    Storage::fake('local');
+    Storage::put('documents/exists.pdf', '%PDF-1.4 content');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/skip-doc',
+            'uuid' => 'skip-doc',
+            'identificatie' => 'DOC-SKIP',
+            'titel' => 'Bestaand',
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+            'auteur' => $this->organiser->name,
+            'versie' => 1,
+            'bestandsnaam' => 'exists.pdf',
+            'inhoud' => '',
+            'beschrijving' => '',
+            'formaat' => 'application/pdf',
+            'locked' => false,
+            'bestandsgrootte' => 0,
+            'creatiedatum' => now()->format('Y-m-d'),
+            'wijzigingsdatum' => now()->toIso8601String(),
+            'informatieobjecttype' => $documentTypeUrl,
+            'indicatieGebruiksrecht' => false,
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(['url' => '', 'zaak' => $zgwZaakUrl, 'informatieobject' => ''], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $job = new UploadDocumentsJob(
+        zaak: $zaak,
+        files: [
+            ['path' => 'documents/missing.pdf', 'titel' => 'Ontbreekt', 'original_name' => 'missing.pdf', 'informatieobjecttype' => $documentTypeUrl],
+            ['path' => 'documents/exists.pdf', 'titel' => 'Bestaand', 'original_name' => 'exists.pdf', 'informatieobjecttype' => $documentTypeUrl],
+        ],
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        userId: $this->organiser->id,
+    );
+
+    $job->handle();
+
+    // Only 1 openzaak fetch + 1 upload + 1 link (the missing file is skipped)
+    Http::assertSentCount(3);
+});

--- a/tests/Feature/MultiUploadDocumentActionTest.php
+++ b/tests/Feature/MultiUploadDocumentActionTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Jobs\Zaak\UploadDocumentsJob;
+use App\Livewire\Zaken\ZaakDocumentsTable;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Storage;
+use Tests\Fakes\ZgwHttpFake;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+test('upload action exists on ZaakDocumentsTable', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->assertTableActionExists('upload');
+});
+
+test('upload action dispatches UploadDocumentsJob with file data', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $paths = ['documents/file1.pdf', 'documents/file2.pdf'];
+    Storage::put($paths[0], '%PDF-1.4 first file');
+    Storage::put($paths[1], '%PDF-1.4 second file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen*' => Http::response([
+            [
+                'uuid' => '1',
+                'url' => $documentTypeUrl,
+                'omschrijving' => 'Bijlage',
+                'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+            ],
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => $paths,
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $paths[0], 'titel' => 'Contract', 'informatieobjecttype' => $documentTypeUrl],
+                ['_temp_path' => '/tmp/php2', 'path' => $paths[1], 'titel' => 'Bijlage', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(UploadDocumentsJob::class, function (UploadDocumentsJob $job) use ($zaak, $paths, $documentTypeUrl) {
+        return $job->zaak->id === $zaak->id
+            && count($job->files) === 2
+            && $job->files[0]['path'] === $paths[0]
+            && $job->files[0]['titel'] === 'Contract'
+            && $job->files[0]['original_name'] === basename($paths[0]) // basename: storeFileNamesIn is not processed in test context
+            && $job->files[0]['informatieobjecttype'] === $documentTypeUrl
+            && $job->files[1]['path'] === $paths[1]
+            && $job->files[1]['titel'] === 'Bijlage'
+            && $job->files[1]['original_name'] === basename($paths[1])
+            && $job->files[1]['informatieobjecttype'] === $documentTypeUrl;
+    });
+});
+
+test('download documents bulk action exists on ZaakDocumentsTable', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->assertTableBulkActionExists('download-documents');
+});


### PR DESCRIPTION
## Samenvatting

- **Multi-upload**: uploaden van meerdere documenten tegelijk via drag-and-drop of multi-select. Per document een bewerkbare titel (standaard = bestandsnaam), gezamenlijk documenttype. Verwerking via `UploadDocumentsJob` in de achtergrond.
- **Bulk download**: selectievakjes in de documententabel. ZIP-verpakking: ≤3 documenten synchroon (ZIP direct in nieuw tabblad), meer dan 3 documenten asynchroon via `CreateDocumentsZipJob` met een notificatie in het notificatiecentrum met downloadlink.
- Activity logging per document (`created`) plus een aggregate log (`multi_upload` / `multi_download`) bij meerdere bestanden.

## Afbeeldingen
<img width="444" height="301" alt="image" src="https://github.com/user-attachments/assets/dfb8ae26-5b22-4ab8-8c12-b383585044db" />
<img width="461" height="247" alt="image" src="https://github.com/user-attachments/assets/087f4221-135f-4668-a118-e7bfd36475ed" />
<img width="453" height="161" alt="image" src="https://github.com/user-attachments/assets/25499faf-5620-44d4-9fa2-0c7ed1d1f817" />
<img width="920" height="1008" alt="image" src="https://github.com/user-attachments/assets/68b9819d-a095-4b05-88d4-64e7fc107051" />

