### PR TITLE
Fix document download for filenames with non-ASCII characters

### DIFF
--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -6,6 +6,7 @@ use App\Http\Requests\DocumentRequest;
 use App\Models\Zaak;
 use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\HeaderUtils;
 use Woweb\Openzaak\Openzaak;
 
@@ -51,9 +52,34 @@ class DocumentController extends Controller
             : $document->bestandsnaam;
 
         return response((new Openzaak)->getRaw($document->inhoud))->withHeaders([
-            'Content-Disposition' => HeaderUtils::makeDisposition($dispositionType, $fileName),
+            'Content-Disposition' => HeaderUtils::makeDisposition(
+                $dispositionType,
+                $fileName,
+                $this->asciiFileNameFallback($fileName),
+            ),
             'Access-Control-Expose-Headers' => 'Content-Disposition',
             'Content-Type' => $contentType,
         ]);
+    }
+
+    /**
+     * Builds an ASCII-only fallback filename for the Content-Disposition header.
+     *
+     * HTTP headers may only carry ASCII, so a bestandsnaam containing characters
+     * such as "ö" makes {@see HeaderUtils::makeDisposition()} throw unless an ASCII
+     * fallback is supplied. The full UTF-8 name is still sent via the RFC 6266
+     * "filename*" field, so modern browsers keep the original characters; this
+     * fallback is only used by legacy clients.
+     */
+    private function asciiFileNameFallback(string $fileName): string
+    {
+        // Transliterate accented characters (ö -> o), then strip anything Symfony
+        // rejects in the fallback: non-printable ASCII, "%", and path separators.
+        $fallback = Str::ascii($fileName);
+        $fallback = (string) preg_replace('/[^\x20-\x7e]/', '', $fallback);
+        $fallback = str_replace(['%', '/', '\\'], '', $fallback);
+        $fallback = trim($fallback);
+
+        return $fallback !== '' ? $fallback : 'document';
     }
 }

--- a/tests/Feature/Http/Controllers/DocumentControllerTest.php
+++ b/tests/Feature/Http/Controllers/DocumentControllerTest.php
@@ -111,6 +111,58 @@ test('download serves an extensionless document as an attachment with extension'
         ->toContain('Vergunningaanvraag.pdf');
 });
 
+test('a filename with non-ascii characters keeps the utf-8 name and gets an ascii fallback', function () {
+    fakeZaakWithExtensionlessDocument('Vergunning Café Zürich.pdf', 'application/pdf');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'download',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))
+        ->toContain('attachment')
+        // ASCII fallback for legacy clients (ö/é transliterated).
+        ->toContain('filename="Vergunning Cafe Zurich.pdf"')
+        // RFC 6266 UTF-8 name preserves the original characters for modern browsers.
+        ->toContain("filename*=utf-8''Vergunning%20Caf%C3%A9%20Z%C3%BCrich.pdf");
+});
+
+test('a fully non-ascii filename falls back to a neutral document name', function () {
+    // Empty formaat means no extension is reconstructed, so the bestandsnaam is
+    // used as-is. Transliterating "日本語" yields nothing, exercising the default.
+    fakeZaakWithExtensionlessDocument('日本語', '');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $response = $this->get(route('zaak.documents.view', [
+        'zaak' => $zaak->id,
+        'documentuuid' => 'no-ext',
+        'type' => 'download',
+    ]));
+
+    $response->assertOk();
+    expect($response->headers->get('Content-Disposition'))
+        // A bare token without spaces is emitted unquoted by Symfony.
+        ->toContain('filename=document')
+        ->toContain("filename*=utf-8''%E6%97%A5%E6%9C%AC%E8%AA%9E");
+});
+
 test('an untrusted or empty formaat is served as octet-stream without inventing an extension', function () {
     fakeZaakWithExtensionlessDocument('Vergunningaanvraag', '');
 


### PR DESCRIPTION
## Summary

Downloading or viewing a document whose `bestandsnaam` contained a non-ASCII character (for example `ö`, `é`, `ü`) failed. The `Content-Disposition` header was built without an ASCII fallback filename, so Symfony's `HeaderUtils::makeDisposition()` used the UTF-8 name as fallback and threw `InvalidArgumentException` because HTTP headers may only carry ASCII.

## Changes

* Added a private `asciiFileNameFallback()` helper in `DocumentController` that transliterates the filename (`Str::ascii`, so `ö` becomes `o`), strips anything Symfony rejects in the fallback (non-printable ASCII, `%`, path separators) and defaults to `document` when nothing printable remains.
* Pass that fallback as the third argument to `makeDisposition()`. The original UTF-8 name is still sent through the RFC 6266 `filename*` field, so modern browsers keep the real characters while legacy clients use the ASCII fallback.

## Safety

No raw input reaches the header unescaped. The fallback is reduced to safe printable ASCII, so header injection (CRLF, control characters) stays impossible. Existing ASCII filenames behave exactly as before.

## Tests

Added two feature tests covering a download with `Vergunning Café Zürich.pdf` (asserts both the ASCII fallback and the UTF-8 `filename*`) and a fully non-ASCII name (`日本語`) that falls back to `document`.