### PR TITLE
Remove unused MySQL service and daily zaaktypen sync

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,6 @@ services:
         networks:
             - sail
         depends_on:
-            - mysql
             - redis
             - pgsql
     horizon:
@@ -43,30 +42,6 @@ services:
             pgsql:
                 condition: service_healthy
         command: php /var/www/html/artisan horizon
-    mysql:
-        image: 'mysql/mysql-server:8.0'
-        ports:
-            - '${FORWARD_DB_PORT:-3306}:3306'
-        environment:
-            MYSQL_ROOT_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ROOT_HOST: '%'
-            MYSQL_DATABASE: '${DB_DATABASE}'
-            MYSQL_USER: '${DB_USERNAME}'
-            MYSQL_PASSWORD: '${DB_PASSWORD}'
-            MYSQL_ALLOW_EMPTY_PASSWORD: 1
-        volumes:
-            - 'sail-mysql:/var/lib/mysql'
-            - './vendor/laravel/sail/database/mysql/create-testing-database.sh:/docker-entrypoint-initdb.d/10-create-testing-database.sh'
-        networks:
-            - sail
-        healthcheck:
-            test:
-                - CMD
-                - mysqladmin
-                - ping
-                - '-p${DB_PASSWORD}'
-            retries: 3
-            timeout: 5s
     mailpit:
         image: 'axllent/mailpit:latest'
         ports:
@@ -120,8 +95,6 @@ networks:
     sail:
         driver: bridge
 volumes:
-    sail-mysql:
-        driver: local
     sail-redis:
         driver: local
     sail-pgsql:

--- a/routes/console.php
+++ b/routes/console.php
@@ -20,5 +20,3 @@ Schedule::job(new SendAdviceReminders)->dailyAt('12:00');
 Schedule::job(new CleanupExpiredInvites)->daily();
 Schedule::job(new CleanupExports)->daily();
 Schedule::job(new CleanupExpiredEventFormDrafts)->daily();
-
-Schedule::command('sync:zaaktypen')->dailyAt('02:00');


### PR DESCRIPTION
## Summary

Two small cleanups bundled together.

### Remove unused MySQL service from Sail compose

The application runs entirely on PostgreSQL (`DB_CONNECTION=pgsql`). The leftover `mysql` service in `docker-compose.yml` shared the `FORWARD_DB_PORT` variable with `pgsql`, which causes a port allocation conflict on `sail up` whenever that variable is set to a custom value. The service, its `depends_on` reference and the `sail-mysql` volume are removed.

### Remove daily sync:zaaktypen scheduled command

Drops the daily 02:00 `sync:zaaktypen` schedule from `routes/console.php`.