### PR TITLE
Schedule horizon:snapshot every five minutes

### DIFF
--- a/routes/console.php
+++ b/routes/console.php
@@ -8,6 +8,9 @@ use App\Jobs\SendAdviceReminders;
 use App\Models\Municipality;
 use Illuminate\Support\Facades\Schedule;
 
+// Capture Horizon queue metrics so the dashboard charts populate
+Schedule::command('horizon:snapshot')->everyFiveMinutes();
+
 // Sync with Kadaster
 Schedule::call(function () {
     foreach (Municipality::all() as $municipality) {


### PR DESCRIPTION
Horizon's dashboard metrics (jobs per minute, runtime, throughput) are built from periodic snapshots. The scheduler did not run `horizon:snapshot`, so those charts stay empty in production.

Adds `Schedule::command('horizon:snapshot')->everyFiveMinutes()` to `routes/console.php`, the interval Horizon's metrics retention is tuned for.

Verified with `artisan schedule:list`:
`*/5 * * * * php artisan horizon:snapshot`

Follow-up to the v1.0.0-beta.1 deployment notes, which flagged this as a recommended addition.