### PR TITLE
Add Dutch release notes for v1.0.0

### DIFF
--- a/docs/releases/RELEASE_NOTES_v1.0.0_NL.md
+++ b/docs/releases/RELEASE_NOTES_v1.0.0_NL.md
@@ -1,0 +1,93 @@
+# Versie 1.0.0 — Wat is er nieuw?
+
+**Releasedatum:** 24 juni 2026
+
+---
+
+Deze versie is een grote mijlpaal. Het aanvraagformulier voor evenementen is volledig vernieuwd en zit nu rechtstreeks in Eventloket zelf. Organisatoren vullen hun aanvraag stap voor stap in via een overzichtelijke wizard, met automatisch opgeslagen concepten, een kaart om de locatie in te tekenen en een duidelijke samenvatting. Hieronder lees je per onderdeel wat er verandert.
+
+---
+
+## ✨ Nieuw aanvraagformulier voor evenementen
+
+### Stap-voor-stap aanvraag in een overzichtelijke wizard
+
+**Voor wie:** Organisatoren
+
+Het aanvraagformulier is volledig opnieuw opgebouwd en zit nu in de applicatie zelf. Je doorloopt de aanvraag in heldere stappen, met een zijbalk die laat zien waar je bent en welke stappen nog volgen. Bij het wisselen van stap spring je automatisch naar de bovenkant van de pagina, zodat je altijd bij de eerste vraag begint.
+
+---
+
+### Tot 5 aanvragen tegelijk als concept
+
+**Voor wie:** Organisatoren
+
+Je aanvraag wordt tijdens het invullen automatisch als concept opgeslagen, zodat je werk nooit verloren gaat. Je kunt meerdere aanvragen naast elkaar voorbereiden: tot 5 concepten tegelijk per organisatie. In het overzicht van je concepten zie je al je openstaande aanvragen en kun je verdergaan waar je was gebleven, een concept verwijderen of een nieuwe aanvraag starten. Heb je 5 concepten openstaan, dan vraagt het systeem je eerst een concept te verwijderen voordat je een nieuwe aanvraag begint. Concepten die zes maanden niet zijn bewerkt, worden automatisch opgeruimd.
+
+---
+
+### Snelheid en betrouwbaarheid formulier
+
+**Voor wie:** Organisatoren
+
+Het formulier is veel sneller en betrouwbaarder in de nieuwe opzet. Met de Open Formulieren implementatie moest het formulier vaker langer nadenken en ontstonden er onderliggende fouten. Dit kwam door de complexiteit van het formulier en de vele afhankelijkheden. Deze problemen zijn nu verholpen door het formulier in Eventloket te integreren.
+
+---
+
+### Locatie en route op de kaart intekenen
+
+**Voor wie:** Organisatoren
+
+Je geeft de locatie van je evenement aan door deze direct op de kaart in te tekenen. Je kunt zowel een gebied (vlak) als een route tekenen, bijvoorbeeld voor een optocht of wandeling. De applicatie herkent automatisch in welke gemeente de ingetekende locatie ligt en de kaartbediening is volledig in het Nederlands. De ingetekende locatie blijft bewaard, ook als je de pagina ververst. De kaart functionaliteiten zijn veel stabieler en betrouwbaarder, er moet altijd een gemeente bepaald zijn voor je verder kan.
+
+---
+
+### Slimmere keuze van datums en tijden
+
+**Voor wie:** Organisatoren
+
+Bij het kiezen van data en tijden grijst de kalender onmogelijke datums uit en krijg je begrijpelijke Nederlandse meldingen wanneer een combinatie niet klopt (bijvoorbeeld een einddatum vóór de begindatum). Zo voorkom je fouten al tijdens het invullen. Ook wordt bijvoorbeeld het seizoen al ingevuld op basis van de datum van het evenement.
+
+---
+
+### Duidelijke samenvatting en PDF van je aanvraag
+
+**Voor wie:** Organisatoren, Gemeentemedewerkers, Behandelaars
+
+Voordat je indient zie je een complete samenvatting van je aanvraag, met onder andere een kaartweergave van de locatie, een overzicht van de tijden in een tabel en een verplicht akkoord op de privacyverklaring (AVG). Na het indienen wordt automatisch een PDF van het volledige aanvraagformulier gemaakt, inclusief alle ingevulde velden en een kaart. Deze PDF wordt samen met je bijlagen als document bij de zaak opgeslagen, zodat behandelaars de volledige aanvraag teruglezen. De pdf is overzichtelijker opgebouwd en bevat de belangrijkste informatie bovenaan.
+
+---
+
+### Een eerdere aanvraag opnieuw gebruiken
+
+**Voor wie:** Organisatoren
+
+Organiseer je een vergelijkbaar evenement als eerder? Dan kun je de gegevens van een eerdere aanvraag hergebruiken om een nieuw formulier alvast in te vullen. Je controleert en past aan waar nodig en hoeft niet alles opnieuw in te voeren.
+
+---
+
+### Bijlagen overzichtelijk bij de zaak
+
+**Voor wie:** Organisatoren, Gemeentemedewerkers, Behandelaars
+
+Bijlagen die je bij een aanvraag uploadt, worden per vraag overzichtelijk weergegeven en zijn na het indienen terug te vinden bij de zaak. De maximale bestandsgrootte voor een upload is 60 MB.
+
+---
+
+## 🐛 Opgeloste problemen
+
+### Documenten met bijzondere tekens in de bestandsnaam zijn weer te openen
+
+**Voor wie:** Organisatoren, Gemeentemedewerkers, Behandelaars
+
+Bestanden met bijzondere of niet-westerse tekens in de bestandsnaam konden soms niet correct worden gedownload. Deze documenten zijn nu weer normaal te openen en te downloaden.
+
+---
+
+## 📱 Wat moet je doen?
+
+### Voor organisatoren
+Vanaf deze versie vul je een evenementaanvraag in via het nieuwe formulier in Eventloket. Bestaande zaken blijven gewoon beschikbaar. Niet afgemaakte aanvragen zijn zoals vooraf gecommuniceerd niet meer beschikbaar.
+
+### Voor gemeentemedewerkers en behandelaars
+**Niets!** Ingediende aanvragen, de bijbehorende PDF en de bijlagen komen automatisch bij de zaak terecht, zoals je gewend bent.


### PR DESCRIPTION
## Summary

Adds the Dutch release notes document for version 1.0.0 under `docs/releases/`.

The notes cover the highlights of this release: the fully rebuilt event application form (now native to Eventloket with a step-by-step wizard), automatically saved drafts (up to 5 concurrent per organisation), a map for drawing the location, and a clear summary step.

## Notes

Documentation only. No application code changes.