### PR TITLE
Recover v0.x zaken orphaned by failed UpdateInitiatorZGW

### DIFF
--- a/app/Console/Commands/Zaak/RecoverOrphanedZaken.php
+++ b/app/Console/Commands/Zaak/RecoverOrphanedZaken.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Zaak;
+
+use App\Jobs\Zaak\AddGeometryZGW;
+use App\Models\Organisation;
+use App\Models\Users\OrganiserUser;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use App\ValueObjects\OzZaak;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Woweb\Openzaak\ObjectsApi;
+use Woweb\Openzaak\Openzaak;
+
+/**
+ * Eenmalig herstel van v0.x-zaken die nooit lokaal zijn aangemaakt.
+ *
+ * In v0.x liep de ingest als een `Bus::chain`:
+ *   AddZaakeigenschappenZGW -> AddEinddatumZGW -> UpdateInitiatorZGW (3)
+ *   -> AddGeometryZGW (4) -> CreateZaak (5) -> CreateDoorkomstZaken (6)
+ * `UpdateInitiatorZGW` faalde op de adresvalidatie en stopte de chain, dus
+ * `CreateZaak` (positie 5) heeft de lokale `zaken`-row nooit geschreven. De
+ * zaak, documenten en de OF-initiator-rol bestaan wel in OpenZaak.
+ *
+ * Dit command herbouwt de lokale row (port van de verwijderde `CreateZaak`-job)
+ * zodat de zaak met bestanden weer zichtbaar wordt, en draait optioneel de
+ * overgeslagen geometrie-stap opnieuw. De initiator-rol blijft ongemoeid (OF's
+ * rol bestaat al; opnieuw POSTen zou dupliceren).
+ */
+class RecoverOrphanedZaken extends Command
+{
+    protected $signature = 'zaak:recover-orphaned
+        {url?* : One or more zgw_zaak_url values to recover}
+        {--from-failed-jobs : Discover urls by scanning failed_jobs for UpdateInitiatorZGW}
+        {--no-geometry : Skip re-running AddGeometryZGW (visibility-only recovery)}
+        {--dry-run : Report what would be created without writing}';
+
+    protected $description = 'Recreate local zaken rows for v0.x cases orphaned by a failed UpdateInitiatorZGW chain.';
+
+    public function handle(Openzaak $openzaak, ObjectsApi $objectsapi): int
+    {
+        $urls = $this->resolveUrls();
+
+        if ($urls === []) {
+            $this->error('No zgw_zaak_url values provided. Pass urls as arguments or use --from-failed-jobs.');
+
+            return self::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $withGeometry = ! $this->option('no-geometry');
+
+        $this->info(sprintf('%d case(s) to process%s.', count($urls), $dryRun ? ' (dry-run)' : ''));
+
+        $recovered = 0;
+        foreach ($urls as $url) {
+            if ($this->recoverOne($url, $openzaak, $objectsapi, $dryRun, $withGeometry)) {
+                $recovered++;
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf('Done. %d/%d case(s) %s.', $recovered, count($urls), $dryRun ? 'would be recovered' : 'recovered'));
+        $this->printFailedJobHint();
+
+        return self::SUCCESS;
+    }
+
+    private function recoverOne(
+        string $url,
+        Openzaak $openzaak,
+        ObjectsApi $objectsapi,
+        bool $dryRun,
+        bool $withGeometry,
+    ): bool {
+        if (Zaak::where('zgw_zaak_url', $url)->exists()) {
+            $this->line("- {$url}: already present locally, skipping.");
+
+            return false;
+        }
+
+        try {
+            $ozZaak = new OzZaak(...$openzaak->get($url.'?expand=zaakobjecten,eigenschappen,status,status.statustype,rollen')->toArray());
+        } catch (Throwable $e) {
+            $this->error("- {$url}: failed to fetch ZGW case ({$e->getMessage()}).");
+
+            return false;
+        }
+
+        $zaaktype = Zaaktype::where(['zgw_zaaktype_url' => $ozZaak->zaaktype, 'is_active' => true])->first();
+        if (! $zaaktype) {
+            $this->warn("- {$url}: zaaktype not found or inactive ({$ozZaak->zaaktype}), skipping.");
+
+            return false;
+        }
+
+        [$organisation, $user] = $this->resolveOrganisationAndUser($ozZaak, $objectsapi);
+        $organisator = $this->buildOrganisatorLabel($ozZaak);
+
+        $this->line(sprintf(
+            '- %s: %s | zaaktype=%s | organisation=%s | user=%s | organisator=%s',
+            $url,
+            $ozZaak->identificatie,
+            $zaaktype->id,
+            $organisation ? $organisation->id : 'null',
+            $user ? $user->id : 'null',
+            $organisator !== '' ? $organisator : 'null',
+        ));
+
+        if ($dryRun) {
+            return true;
+        }
+
+        $zaak = Zaak::updateOrCreate(
+            ['zgw_zaak_url' => $ozZaak->url],
+            [
+                'public_id' => $ozZaak->identificatie,
+                'zaaktype_id' => $zaaktype->id,
+                'data_object_url' => $ozZaak->data_object_url,
+                'organisation_id' => $organisation?->id,
+                'organiser_user_id' => $user?->id,
+                'reference_data' => new ZaakReferenceData(
+                    ...array_merge(
+                        $ozZaak->eigenschappen_key_value,
+                        [
+                            'registratiedatum' => $ozZaak->registratiedatum,
+                            'status_name' => $ozZaak->status_name ?? '',
+                            'statustype_url' => $ozZaak->statustype_url ?? '',
+                            'organisator' => $organisator,
+                        ]
+                    )
+                ),
+            ]
+        );
+
+        if ($withGeometry) {
+            $this->reAddGeometry($zaak);
+        }
+
+        return true;
+    }
+
+    /**
+     * Re-run the geometry step the halted chain skipped. AddGeometryZGW reads the
+     * event_location from form_state_snapshot, which old cases lack, so first
+     * populate it from the Objects record, then dispatch the (idempotent) job.
+     */
+    private function reAddGeometry(Zaak $zaak): void
+    {
+        if (! $zaak->data_object_url) {
+            $this->warn("  {$zaak->public_id}: no data_object_url, cannot backfill snapshot for geometry.");
+
+            return;
+        }
+
+        Artisan::call('eventform:backfill-snapshots-from-objects', ['--zaak' => $zaak->id]);
+        AddGeometryZGW::dispatch($zaak->refresh());
+        $this->line("  {$zaak->public_id}: snapshot backfilled and AddGeometryZGW dispatched.");
+    }
+
+    /**
+     * Resolve the local organisation and organiser user from the Objects record.
+     * Replaces the deleted FormSubmissionObject value object. A failing Objects
+     * API lookup must not block row creation (org/user simply stay null).
+     *
+     * @return array{0: ?Organisation, 1: ?OrganiserUser}
+     */
+    private function resolveOrganisationAndUser(OzZaak $ozZaak, ObjectsApi $objectsapi): array
+    {
+        if (! $ozZaak->data_object_url) {
+            return [null, null];
+        }
+
+        try {
+            $object = $objectsapi->get(basename($ozZaak->data_object_url))->toArray();
+        } catch (Throwable $e) {
+            Log::warning('RecoverOrphanedZaken: Objects API lookup failed', ['zaak' => $ozZaak->url, 'error' => $e->getMessage()]);
+
+            return [null, null];
+        }
+
+        $prefix = strtolower((string) config('app.name'));
+        $organisationUuid = data_get($object, "record.data.{$prefix}_organisation_uuid");
+        $userUuid = data_get($object, "record.data.{$prefix}_user_uuid");
+
+        return [
+            $organisationUuid ? Organisation::where('uuid', $organisationUuid)->first() : null,
+            $userUuid ? OrganiserUser::where('uuid', $userUuid)->first() : null,
+        ];
+    }
+
+    private function buildOrganisatorLabel(OzZaak $ozZaak): string
+    {
+        $initiator = $ozZaak->initiator;
+        if (! $initiator) {
+            return '';
+        }
+
+        if ($initiator->betrokkeneType === 'natuurlijk_persoon') {
+            return trim(($initiator->betrokkeneIdentificatie['voornamen'] ?? '').' '.($initiator->betrokkeneIdentificatie['geslachtsnaam'] ?? ''));
+        }
+
+        if ($initiator->betrokkeneType === 'niet_natuurlijk_persoon') {
+            return ($initiator->betrokkeneIdentificatie['statutaireNaam'] ?? '').' - '.($initiator->contactpersoonRol['naam'] ?? '');
+        }
+
+        return '';
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resolveUrls(): array
+    {
+        /** @var list<string> $urls */
+        $urls = $this->argument('url') ?? [];
+
+        if ($this->option('from-failed-jobs')) {
+            $urls = array_merge($urls, $this->discoverUrlsFromFailedJobs());
+        }
+
+        return array_values(array_unique(array_filter($urls)));
+    }
+
+    /**
+     * Pull zgw_zaak_url values out of failed UpdateInitiatorZGW payloads. The old
+     * job serialized the url under a `zaakUrlZGW` property; rather than unserialize
+     * a deleted class, match the url with a regex over the command string.
+     *
+     * @return list<string>
+     */
+    private function discoverUrlsFromFailedJobs(): array
+    {
+        $rows = DB::table('failed_jobs')
+            ->where('payload', 'like', '%UpdateInitiatorZGW%')
+            ->pluck('payload');
+
+        $urls = [];
+        foreach ($rows as $payload) {
+            $command = (string) data_get(json_decode((string) $payload, true), 'data.command');
+            if (preg_match('#https?://[^"\\\\\s]+/zaken/[^"\\\\\s]+#', $command, $m)) {
+                $urls[] = rtrim($m[0], '";');
+            }
+        }
+
+        $found = array_values(array_unique($urls));
+        $this->info(sprintf('Discovered %d url(s) from failed_jobs.', count($found)));
+        foreach ($found as $u) {
+            $this->line("  {$u}");
+        }
+
+        return $found;
+    }
+
+    private function printFailedJobHint(): void
+    {
+        $uuids = DB::table('failed_jobs')
+            ->where('payload', 'like', '%UpdateInitiatorZGW%')
+            ->pluck('uuid');
+
+        if ($uuids->isEmpty()) {
+            return;
+        }
+
+        $this->newLine();
+        $this->comment('Stale UpdateInitiatorZGW failed_jobs can be removed once recovery is confirmed:');
+        foreach ($uuids as $uuid) {
+            $this->line("  php artisan queue:forget {$uuid}");
+        }
+    }
+}

--- a/tests/Feature/Console/Zaak/RecoverOrphanedZakenTest.php
+++ b/tests/Feature/Console/Zaak/RecoverOrphanedZakenTest.php
@@ -1,0 +1,273 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Role;
+use App\Jobs\Zaak\AddGeometryZGW;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Users\OrganiserUser;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Str;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    config(['openzaak.objectsapi.url' => 'https://objects.test/']);
+});
+
+/**
+ * Fakes the ZGW case GET and its Objects record, and returns the zaak url plus
+ * the created organisation/user so tests can assert the linkage.
+ *
+ * @return array{url: string, organisation: Organisation, user: OrganiserUser, objectUuid: string}
+ */
+function fakeOrphanedZaak(array $overrides = []): array
+{
+    $zaaktypeUrl = $overrides['zaaktypeUrl'] ?? 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1';
+    $zaakUrl = 'https://zgw.example.com/zaken/api/v1/zaken/orphan-1';
+    $objectUuid = 'obj-orphan-1';
+    $objectUrl = 'https://objects.test/api/v2/objects/'.$objectUuid;
+
+    $organisation = Organisation::factory()->create(['uuid' => (string) Str::uuid()]);
+    /** @var OrganiserUser $user */
+    $user = User::factory()->state(['role' => Role::Organiser, 'uuid' => (string) Str::uuid()])->create();
+
+    $prefix = strtolower((string) config('app.name'));
+
+    $zaakResponse = [
+        'uuid' => 'orphan-1',
+        'url' => $zaakUrl,
+        'identificatie' => 'ZAAK-ORPHAN-1',
+        'zaaktype' => $zaaktypeUrl,
+        'omschrijving' => 'Orphaned test zaak',
+        'startdatum' => '2026-01-01',
+        'registratiedatum' => '2026-01-01',
+        'einddatum' => null,
+        'einddatumGepland' => null,
+        'uiterlijkeEinddatumAfdoening' => null,
+        'bronorganisatie' => '123456789',
+        'zaakgeometrie' => null,
+        '_expand' => [
+            'zaakobjecten' => [
+                ['object' => $objectUrl, 'objectType' => 'overige', 'relatieomschrijving' => ''],
+            ],
+            'eigenschappen' => [
+                eigenschap('start_evenement', '2026-06-01T10:00:00+02:00'),
+                eigenschap('eind_evenement', '2026-06-01T20:00:00+02:00'),
+                eigenschap('naam_evenement', 'Testfeest'),
+            ],
+            'rollen' => [
+                [
+                    'url' => 'https://zgw.example.com/zaken/api/v1/rollen/1',
+                    'uuid' => 'rol-1',
+                    'betrokkeneType' => 'natuurlijk_persoon',
+                    'roltype' => 'https://zgw.example.com/catalogi/api/v1/roltypen/1',
+                    'omschrijving' => 'Initiator',
+                    'omschrijvingGeneriek' => 'initiator',
+                    'contactpersoonRol' => [],
+                    'betrokkeneIdentificatie' => ['voornamen' => 'Jan', 'geslachtsnaam' => 'Jansen'],
+                ],
+            ],
+        ],
+    ];
+
+    $objectResponse = [
+        'record' => [
+            'data' => [
+                "{$prefix}_organisation_uuid" => $organisation->uuid,
+                "{$prefix}_user_uuid" => $user->uuid,
+                'data' => ['watIsDeNaamVanHetEvenementVergunning' => 'Testfeest'],
+            ],
+        ],
+    ];
+
+    Http::fake([
+        $zaakUrl.'*' => Http::response($zaakResponse, 200),
+        $objectUrl.'*' => Http::response($objectResponse, 200),
+        'https://objects.test/*' => Http::response($objectResponse, 200),
+    ]);
+
+    return ['url' => $zaakUrl, 'organisation' => $organisation, 'user' => $user, 'objectUuid' => $objectUuid];
+}
+
+function eigenschap(string $naam, string $waarde): array
+{
+    return [
+        'uuid' => 'eig-'.Str::slug($naam),
+        'url' => 'https://zgw.example.com/zaken/api/v1/zaakeigenschappen/'.Str::slug($naam),
+        'zaak' => 'https://zgw.example.com/zaken/api/v1/zaken/orphan-1',
+        'eigenschap' => 'https://zgw.example.com/catalogi/api/v1/eigenschappen/'.Str::slug($naam),
+        'naam' => $naam,
+        'waarde' => $waarde,
+    ];
+}
+
+it('recreates the local zaak row linked to organisation, user and document url', function () {
+    Queue::fake();
+    $zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']]])
+        ->assertSuccessful();
+
+    $zaak = Zaak::where('zgw_zaak_url', $fake['url'])->first();
+    expect($zaak)->not->toBeNull();
+    expect($zaak->public_id)->toBe('ZAAK-ORPHAN-1');
+    expect($zaak->zaaktype_id)->toBe($zaaktype->id);
+    expect($zaak->organisation_id)->toBe($fake['organisation']->id);
+    expect($zaak->organiser_user_id)->toBe($fake['user']->id);
+    expect($zaak->data_object_url)->toBe('https://objects.test/api/v2/objects/obj-orphan-1');
+    expect($zaak->reference_data->organisator)->toBe('Jan Jansen');
+});
+
+it('is idempotent and does not duplicate an already recovered row', function () {
+    Queue::fake();
+    Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']]])->assertSuccessful();
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']]])->assertSuccessful();
+
+    expect(Zaak::where('zgw_zaak_url', $fake['url'])->count())->toBe(1);
+});
+
+it('writes nothing and dispatches nothing on --dry-run', function () {
+    Queue::fake();
+    Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']], '--dry-run' => true])
+        ->assertSuccessful();
+
+    expect(Zaak::where('zgw_zaak_url', $fake['url'])->exists())->toBeFalse();
+    Queue::assertNothingPushed();
+});
+
+it('dispatches AddGeometryZGW by default and skips it with --no-geometry', function () {
+    Queue::fake();
+    Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']]])->assertSuccessful();
+    Queue::assertPushed(AddGeometryZGW::class);
+});
+
+it('does not dispatch AddGeometryZGW with --no-geometry', function () {
+    Queue::fake();
+    Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']], '--no-geometry' => true])
+        ->assertSuccessful();
+
+    expect(Zaak::where('zgw_zaak_url', $fake['url'])->exists())->toBeTrue();
+    Queue::assertNotPushed(AddGeometryZGW::class);
+});
+
+it('discovers urls from failed UpdateInitiatorZGW jobs and recovers them', function () {
+    Queue::fake();
+    $zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+    $fake = fakeOrphanedZaak();
+
+    $command = 'O:36:"App\\Jobs\\Zaak\\UpdateInitiatorZGW":1:{s:10:"zaakUrlZGW";s:50:"'.$fake['url'].'";}';
+    DB::table('failed_jobs')->insert([
+        'uuid' => (string) Str::uuid(),
+        'connection' => 'database',
+        'queue' => 'default',
+        'payload' => json_encode([
+            'displayName' => 'App\\Jobs\\Zaak\\UpdateInitiatorZGW',
+            'data' => ['command' => $command],
+        ]),
+        'exception' => 'ValidationError',
+        'failed_at' => now(),
+    ]);
+
+    $this->artisan('zaak:recover-orphaned', ['--from-failed-jobs' => true])
+        ->assertSuccessful();
+
+    $zaak = Zaak::where('zgw_zaak_url', $fake['url'])->first();
+    expect($zaak)->not->toBeNull();
+    expect($zaak->zaaktype_id)->toBe($zaaktype->id);
+});
+
+it('skips a case whose zaaktype is missing or inactive without creating a row', function () {
+    Queue::fake();
+    // No matching active zaaktype created.
+    $fake = fakeOrphanedZaak();
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$fake['url']]])
+        ->assertSuccessful();
+
+    expect(Zaak::where('zgw_zaak_url', $fake['url'])->exists())->toBeFalse();
+});
+
+it('still creates the row with null org and user when the Objects API lookup fails', function () {
+    Queue::fake();
+    $zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'is_active' => true,
+    ]);
+
+    $zaakUrl = 'https://zgw.example.com/zaken/api/v1/zaken/orphan-1';
+    $zaakResponse = [
+        'uuid' => 'orphan-1',
+        'url' => $zaakUrl,
+        'identificatie' => 'ZAAK-ORPHAN-1',
+        'zaaktype' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/1',
+        'omschrijving' => 'Orphaned test zaak',
+        'startdatum' => '2026-01-01',
+        'registratiedatum' => '2026-01-01',
+        'einddatum' => null,
+        'einddatumGepland' => null,
+        'uiterlijkeEinddatumAfdoening' => null,
+        'bronorganisatie' => '123456789',
+        'zaakgeometrie' => null,
+        '_expand' => [
+            'zaakobjecten' => [
+                ['object' => 'https://objects.test/api/v2/objects/obj-orphan-1', 'objectType' => 'overige', 'relatieomschrijving' => ''],
+            ],
+            'eigenschappen' => [
+                eigenschap('start_evenement', '2026-06-01T10:00:00+02:00'),
+                eigenschap('eind_evenement', '2026-06-01T20:00:00+02:00'),
+            ],
+        ],
+    ];
+
+    Http::fake([
+        $zaakUrl.'*' => Http::response($zaakResponse, 200),
+        'https://objects.test/*' => Http::response([], 500),
+    ]);
+
+    $this->artisan('zaak:recover-orphaned', ['url' => [$zaakUrl], '--no-geometry' => true])
+        ->assertSuccessful();
+
+    $zaak = Zaak::where('zgw_zaak_url', $zaakUrl)->first();
+    expect($zaak)->not->toBeNull();
+    expect($zaak->organisation_id)->toBeNull();
+    expect($zaak->organiser_user_id)->toBeNull();
+    expect($zaak->zaaktype_id)->toBe($zaaktype->id);
+});


### PR DESCRIPTION
## Problem

After deploying v1.0.0, several `UpdateInitiatorZGW` jobs from the v0.x era remained in `failed_jobs`. They failed on OpenZaak validation of the applicant address (e.g. `betrokkeneIdentificatie.verblijfsadres.wplWoonplaatsNaam` blank, `aoaHuisnummer` invalid). The underlying cause was incomplete data in the Objects API record.

The real impact is bigger than a missing initiator. In v0.x, ingestion ran as a single `Bus::chain`:

```
AddZaakeigenschappenZGW -> AddEinddatumZGW -> UpdateInitiatorZGW (3)
  -> AddGeometryZGW (4) -> CreateZaak (5) -> CreateDoorkomstZaken (6)
```

`UpdateInitiatorZGW` sat at position 3. A chained job that exhausts its retries halts the rest of the chain, so `CreateZaak` (position 5, the job that writes the local `zaken` row) never ran. These cases exist in OpenZaak (case, documents, and the Open Forms initiator rol), but the local row was never created, so they are invisible in every Eventloket panel.

Retrying the failed jobs is not possible: their serialized payloads target old job signatures (old `UpdateInitiatorZGW(string $url)`, old `CreateZaak`) whose Objects-API code was removed in v1.0.0.

## Solution

A one-off, idempotent artisan command `zaak:recover-orphaned`:

```
zaak:recover-orphaned {url?*} {--from-failed-jobs} {--no-geometry} {--dry-run}
```

Per case it:

1. Skips if a local row already exists (safe to re-run).
2. Fetches the ZGW case with `expand=zaakobjecten,eigenschappen,status,status.statustype,rollen` (the `zaakobjecten` expand is required for `OzZaak` to resolve `data_object_url`).
3. Resolves the local zaaktype (skips if missing or inactive).
4. Resolves organisation and organiser user from the Objects record (`{app}_organisation_uuid` / `{app}_user_uuid`), replacing the deleted `FormSubmissionObject`. A failing Objects lookup leaves them null rather than blocking the row.
5. Recreates the local `zaken` row (a port of the deleted `CreateZaak` job). Documents are read live from OpenZaak via `zgw_zaak_url`, so they appear once the row exists.
6. By default re-runs the geometry step the halted chain skipped: it populates `form_state_snapshot` via the existing `eventform:backfill-snapshots-from-objects` command, then dispatches the idempotent `AddGeometryZGW`. Use `--no-geometry` for a visibility-only recovery.
7. Prints `queue:forget` hints for the stale `UpdateInitiatorZGW` `failed_jobs` so they can be cleared after recovery is confirmed.

The initiator rol is deliberately left untouched: Open Forms already created it, and the v1.0.0 `UpdateInitiatorZGW` does a POST, which would duplicate it.

## Usage

1. Identify cases: `SELECT uuid, failed_at, payload FROM failed_jobs WHERE payload LIKE '%UpdateInitiatorZGW%';`
2. Dry run: `php artisan zaak:recover-orphaned --from-failed-jobs --dry-run`
3. Execute, then verify the case, its documents, and the map in the Municipality and Organiser panels.
4. Run the printed `php artisan queue:forget <uuid>` for the stale entries.

## Tests

8 feature tests covering row creation and linkage, idempotency, dry-run (no writes or dispatches), geometry on/off, missing/inactive zaaktype skip, Objects-API-failure fallback, and `--from-failed-jobs` discovery. Pint and PHPStan (level 5) pass.