### PR TITLE
Fix null statustype crash when creating concept advice threads

### DIFF
--- a/app/EventForm/Submit/Steps/CreateLocalZaak.php
+++ b/app/EventForm/Submit/Steps/CreateLocalZaak.php
@@ -11,6 +11,8 @@ use App\Models\Users\OrganiserUser;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use App\ValueObjects\OzZaak;
+use Illuminate\Support\Facades\Log;
+use Woweb\Openzaak\Openzaak;
 
 /**
  * Synchrone stap: schrijft de lokale `zaken`-row op basis van de net
@@ -24,7 +26,10 @@ use App\ValueObjects\OzZaak;
  */
 final class CreateLocalZaak
 {
-    public function __construct(private readonly MapFormStateToReferenceData $mapReferenceData) {}
+    public function __construct(
+        private readonly MapFormStateToReferenceData $mapReferenceData,
+        private readonly Openzaak $openzaak,
+    ) {}
 
     public function execute(
         FormState $state,
@@ -36,7 +41,7 @@ final class CreateLocalZaak
         $referenceData = $this->mapReferenceData->build(
             state: $state,
             statusName: 'Ingediend',
-            statustypeUrl: '',
+            statustypeUrl: $this->resolveInitialStatustypeUrl($zaaktype),
         );
 
         return Zaak::create([
@@ -49,5 +54,43 @@ final class CreateLocalZaak
             'reference_data' => $referenceData,
             'form_state_snapshot' => $state->toSnapshot(),
         ]);
+    }
+
+    /**
+     * Resolves the URL of the initial statustype (volgnummer 1) for the
+     * zaaktype so the local zaak has a valid statustype_url from creation.
+     *
+     * Without this the statustype_url stays empty until the async ZGW
+     * round-trip (SetInitialStatusZGW -> webhook -> UpdateZaakReferenceData)
+     * fills it, and the CreateConceptAdviceQuestions job dispatched on
+     * `Zaak::created` runs in that window. Its system-generated thread message
+     * triggers Thread::getParticipants(), which reads $zaak->statustype and
+     * crashed on null. Setting the initial statustype here closes that window.
+     *
+     * Resolution failures must not block the submit: we fall back to an empty
+     * string (the previous behaviour), and the webhook still fills it later.
+     */
+    private function resolveInitialStatustypeUrl(Zaaktype $zaaktype): string
+    {
+        if (! $zaaktype->zgw_zaaktype_url) {
+            return '';
+        }
+
+        try {
+            $statustypen = $this->openzaak->catalogi()->statustypen()
+                ->getAll(['zaaktype' => $zaaktype->zgw_zaaktype_url]);
+
+            $initieel = $statustypen->sortBy('volgnummer')->first();
+
+            return $initieel ? ($initieel['url'] ?? '') : '';
+        } catch (\Throwable $e) {
+            Log::warning('CreateLocalZaak: kon initiële statustype niet bepalen', [
+                'zaaktype_id' => $zaaktype->id,
+                'zgw_zaaktype_url' => $zaaktype->zgw_zaaktype_url,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return '';
+        }
     }
 }

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -13,6 +13,7 @@ use App\Models\Users\MunicipalityAdminUser;
 use App\Models\Users\OrganiserUser;
 use App\Models\Users\ReviewerMunicipalityAdminUser;
 use App\Models\Users\ReviewerUser;
+use App\ValueObjects\OzStatustype;
 use Database\Factories\ThreadFactory;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
@@ -156,7 +157,7 @@ class Thread extends Model
         // yet, for example for freshly created or imported zaken whose status has not been
         // synced from ZGW. In that case we skip the fallback rather than crash.
         if ($municipalityReviewerUsers->isEmpty()) {
-            /** @var \App\ValueObjects\OzStatustype|null $statustype */
+            /** @var OzStatustype|null $statustype */
             $statustype = $this->zaak->statustype;
 
             if ($statustype?->isReceived() || $statustype?->isFinalised()) {

--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -150,12 +150,18 @@ class Thread extends Model
             ->get();
 
         // If no municipality reviewers are found and the zaak status
-        // has just been received or has been finalized, include all municipality reviewers
-        if (
-            $municipalityReviewerUsers->isEmpty() &&
-            ($this->zaak->statustype->isReceived() || $this->zaak->statustype->isFinalised())
-        ) {
-            $municipalityReviewerUsers = $this->zaak->municipality->allReviewerUsers()->get();
+        // has just been received or has been finalized, include all municipality reviewers.
+        // The statustype is only resolved when no reviewers were found (it can trigger a
+        // ZGW lookup), and it can be null when the zaak has no (matching) statustype_url
+        // yet, for example for freshly created or imported zaken whose status has not been
+        // synced from ZGW. In that case we skip the fallback rather than crash.
+        if ($municipalityReviewerUsers->isEmpty()) {
+            /** @var \App\ValueObjects\OzStatustype|null $statustype */
+            $statustype = $this->zaak->statustype;
+
+            if ($statustype?->isReceived() || $statustype?->isFinalised()) {
+                $municipalityReviewerUsers = $this->zaak->municipality->allReviewerUsers()->get();
+            }
         }
 
         return $threadParticipants->merge($municipalityReviewerUsers);

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -39,6 +39,7 @@ use Woweb\Openzaak\Openzaak;
  * @property-read ?Organisation                $organisation
  * @property-read ?Municipality                $municipality
  * @property-read Collection<Informatieobject> $documenten
+ * @property-read ?OzStatustype                $statustype
  */
 #[ObservedBy(ZaakObserver::class)]
 class Zaak extends Model implements Eventable
@@ -264,7 +265,7 @@ class Zaak extends Model implements Eventable
     protected function statustype(): Attribute
     {
         return Attribute::make(
-            get: function () {
+            get: function (): ?OzStatustype {
                 $statustypen = Cache::remember('statustypen', 60 * 60 * 24, function () {
                     return (new Openzaak)->catalogi()->statustypen()->getAll(['pageSize' => 999999999])
                         ->map(function ($statustype) {

--- a/tests/Feature/DefaultAdviceQuestion/CreateConceptAdviceQuestionsTest.php
+++ b/tests/Feature/DefaultAdviceQuestion/CreateConceptAdviceQuestionsTest.php
@@ -109,6 +109,51 @@ test('creates multiple concept threads for multiple default questions', function
     Notification::assertNothingSent();
 });
 
+test('creates concept threads without crashing when zaak has no statustype yet', function () {
+    // Regression: when a zaak is freshly created its statustype_url is still
+    // empty (the async ZGW status round-trip has not run yet), so
+    // $zaak->statustype resolves to null. The system-generated message in the
+    // concept thread triggers Thread::getParticipants(), which previously
+    // called isReceived()/isFinalised() on that null and crashed the
+    // CreateConceptAdviceQuestions job.
+    DefaultAdviceQuestion::factory()->create([
+        'municipality_id' => $this->municipality->id,
+        'advisory_id' => $this->advisory->id,
+        'risico_classificatie' => 'B',
+        'title' => 'Test Question B',
+        'description' => 'Test Description B',
+        'response_deadline_days' => 14,
+    ]);
+
+    $createZaakWithoutStatustype = fn () => Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: now()->toDateTimeString(),
+            eind_evenement: now()->addDay()->toDateTimeString(),
+            registratiedatum: now()->toDateTimeString(),
+            status_name: 'Ingediend',
+            statustype_url: '', // no status set yet
+            risico_classificatie: 'B',
+            naam_locatie_eveneme: 'Test locatie',
+            naam_evenement: 'Test event'
+        ),
+    ]);
+
+    expect($createZaakWithoutStatustype)->not->toThrow(Throwable::class);
+
+    $zaak = $createZaakWithoutStatustype();
+
+    expect($zaak->statustype)->toBeNull();
+    expect(AdviceThread::where('zaak_id', $zaak->id)->count())->toBe(1);
+
+    $thread = AdviceThread::where('zaak_id', $zaak->id)->first();
+    expect($thread->messages()->count())->toBe(1);
+    expect($thread->messages()->first()->body)->toBe('Test Description B');
+
+    // Concept thread: no notifications go out.
+    Notification::assertNothingSent();
+});
+
 test('does not create threads when no matching risico classificatie', function () {
     DefaultAdviceQuestion::factory()->create([
         'municipality_id' => $this->municipality->id,

--- a/tests/Feature/EventForm/Submit/CreateLocalZaakTest.php
+++ b/tests/Feature/EventForm/Submit/CreateLocalZaakTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/**
+ * Tests voor CreateLocalZaak, specifiek het synchroon zetten van de
+ * initiële statustype_url (volgnummer 1) bij aanmaak.
+ *
+ * Achtergrond: CreateConceptAdviceQuestions wordt op `Zaak::created`
+ * gedispatcht en draait vóór de async ZGW-statusketen. Zonder een
+ * statustype_url op de zaak is $zaak->statustype null, wat
+ * Thread::getParticipants() liet crashen. Door de initiële statustype
+ * hier al te resolven is dat venster dicht.
+ *
+ * Faalt de lookup, dan mag de submit niet breken: we vallen terug op
+ * een lege statustype_url (de webhook vult 'm later alsnog).
+ */
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\Steps\CreateLocalZaak;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Users\OrganiserUser;
+use App\Models\Zaaktype;
+use App\ValueObjects\OzZaak;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+uses(RefreshDatabase::class);
+
+function makeOzZaak(): OzZaak
+{
+    return new OzZaak(
+        uuid: 'new-1',
+        url: ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/new-1',
+        identificatie: 'ZAAK-2026-0001',
+        zaaktype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        omschrijving: 'Test event',
+        startdatum: now()->toDateString(),
+        registratiedatum: now()->toDateString(),
+        einddatum: null,
+        einddatumGepland: null,
+        uiterlijkeEinddatumAfdoening: null,
+        bronorganisatie: '820151130',
+        zaakgeometrie: null,
+    );
+}
+
+function localZaakContext(): array
+{
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $zaaktype = Zaaktype::factory()->create([
+        'is_active' => true,
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+    $organisation = Organisation::factory()->create();
+    $user = User::factory()->state(['role' => Role::Organiser])->create();
+    $user->organisations()->attach($organisation, ['role' => OrganisationRole::Admin->value]);
+    $organiser = OrganiserUser::findOrFail($user->id);
+
+    $state = new FormState(values: [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Test event',
+    ]);
+
+    return compact('zaaktype', 'organisation', 'organiser', 'state');
+}
+
+test('sets the initial statustype_url (volgnummer 1) on the local zaak', function () {
+    $ctx = localZaakContext();
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen*' => Http::response([
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/2', 'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1', 'omschrijving' => 'In behandeling', 'volgnummer' => 2, 'isEindstatus' => false],
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1', 'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1', 'omschrijving' => 'Ontvangen', 'volgnummer' => 1, 'isEindstatus' => false],
+        ], 200),
+    ]);
+
+    $zaak = app(CreateLocalZaak::class)->execute(
+        state: $ctx['state'],
+        ozZaak: makeOzZaak(),
+        zaaktype: $ctx['zaaktype'],
+        user: $ctx['organiser'],
+        organisation: $ctx['organisation'],
+    );
+
+    // Volgnummer 1 wordt gekozen, ongeacht de volgorde uit de API.
+    expect($zaak->reference_data->statustype_url)
+        ->toBe(ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1')
+        ->and($zaak->reference_data->status_name)->toBe('Ingediend');
+
+    // En de statustype-accessor resolvet daardoor een niet-null OzStatustype.
+    expect($zaak->statustype)->not->toBeNull()
+        ->and($zaak->statustype->isReceived())->toBeTrue();
+});
+
+test('falls back to empty statustype_url when the statustype lookup fails', function () {
+    $ctx = localZaakContext();
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen*' => Http::response(['error' => 'boom'], 500),
+    ]);
+
+    $zaak = app(CreateLocalZaak::class)->execute(
+        state: $ctx['state'],
+        ozZaak: makeOzZaak(),
+        zaaktype: $ctx['zaaktype'],
+        user: $ctx['organiser'],
+        organisation: $ctx['organisation'],
+    );
+
+    // Submit breekt niet: zaak is aangemaakt, statustype_url leeg.
+    expect($zaak->exists)->toBeTrue()
+        ->and($zaak->reference_data->statustype_url)->toBe('');
+});

--- a/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
+++ b/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
@@ -115,6 +115,12 @@ function fakeOpenzaakZaakCreate(): string
             'toelichting' => '',
             'omschrijving' => 'Buurtfeest Testlaan',
         ], 201),
+        // CreateLocalZaak resolves the initial statustype (volgnummer 1) so the
+        // local zaak has a valid statustype_url from creation.
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen*' => Http::response([
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1', 'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1', 'omschrijving' => 'Ontvangen', 'volgnummer' => 1, 'isEindstatus' => false],
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/2', 'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1', 'omschrijving' => 'In behandeling', 'volgnummer' => 2, 'isEindstatus' => false],
+        ], 200),
     ]);
 
     return $zaakUrl;
@@ -160,6 +166,12 @@ test('happy-path: lokale Zaak, ZGW-URL, draft leeg, async keten dispatched', fun
     expect($zaak->reference_data->naam_evenement)->toBe('Buurtfeest Testlaan')
         ->and($zaak->reference_data->types_evenement)->toBe('Buurtfeest')
         ->and($zaak->reference_data->status_name)->toBe('Ingediend');
+
+    // 2b. De initiële statustype_url (volgnummer 1) is al bij aanmaak gezet,
+    //     zodat $zaak->statustype niet null is in het venster vóór de async
+    //     ZGW-statusupdate. Voorkomt de crash in Thread::getParticipants().
+    expect($zaak->reference_data->statustype_url)
+        ->toBe(ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1');
 
     // 3. form_state_snapshot is opgeslagen voor latere prefill / jobs.
     expect($zaak->form_state_snapshot)->toBeArray()


### PR DESCRIPTION
## Problem

Sentry reported `Call to a member function isReceived() on null` in `Thread::getParticipants()` in production.

A freshly created zaak has an empty `statustype_url` until the asynchronous ZGW status chain (`SetInitialStatusZGW` to OpenZaak, webhook back, `UpdateZaakReferenceData`) completes. `CreateConceptAdviceQuestions` is dispatched on `Zaak::created` and is guaranteed to run inside that window. The system-generated message in the concept thread triggers `MessageObserver::created`, which calls `getParticipants()` while `$zaak->statustype` is still `null` at that point. The fallback branch then called `isReceived()` on it and crashed the job (which ended up in `failed_jobs`).

## Solution

Two layers:

1. **`Thread::getParticipants()`** now resolves the statustype only inside the branch where no reviewers were found (this preserves the original short-circuit, since the accessor can trigger a ZGW lookup) and uses null-safe calls. A null statustype skips the fallback instead of crashing. This also covers imported and doorkomst zaken with an empty `statustype_url`.

2. **`CreateLocalZaak`** resolves the initial statustype (volgnummer 1) for the zaaktype and sets it in `reference_data->statustype_url` at creation time, closing the window. If the lookup fails it falls back to an empty string so the submit never breaks (the webhook still fills it later).

In addition, the `Zaak::statustype` accessor is explicitly typed as nullable to match the runtime behaviour.

## Tests

- New: `CreateLocalZaakTest` (volgnummer-1 selection regardless of API order, accessor then resolves non-null, empty fallback on HTTP 500).
- `CreateConceptAdviceQuestionsTest`: regression test with a zaak without a statustype that does not crash through the `MessageObserver` to `getParticipants` path.
- `SubmitEventFormTest`: statustypen endpoint faked and asserts `statustype_url` is populated after submit.

Verified: affected tests (132 passed), PHPStan clean on the changed files, Pint passed.