### PR TITLE
Backfill reviewer_user_id from handled_status_set_by_user_id

### DIFF
--- a/database/migrations/2026_06_25_000000_backfill_reviewer_user_id_on_zaken.php
+++ b/database/migrations/2026_06_25_000000_backfill_reviewer_user_id_on_zaken.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Query\Builder;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Backfill reviewer_user_id from the previous handled_status_set_by_user_id.
+     *
+     * Before #389 the working stock (and its navigation badges) was scoped by
+     * handled_status_set_by_user_id, the reviewer who took a case into handling.
+     * #389 switched that to the new explicit reviewer_user_id, which is null for
+     * every existing case. Copying the handler over reproduces the prior working
+     * stock so cases keep their reviewer instead of all reappearing as unassigned.
+     */
+    public function up(): void
+    {
+        DB::table('zaken')
+            ->whereNull('reviewer_user_id')
+            ->whereNotNull('handled_status_set_by_user_id')
+            ->whereIn('handled_status_set_by_user_id', fn (Builder $query) => $query->select('id')->from('users'))
+            ->update(['reviewer_user_id' => DB::raw('handled_status_set_by_user_id')]);
+    }
+
+    /**
+     * The backfill copies existing data and cannot be reliably reversed.
+     * Reviewer assignments are managed through the application afterwards.
+     */
+    public function down(): void
+    {
+        // No-op.
+    }
+};

--- a/database/migrations/2026_06_25_000000_backfill_reviewer_user_id_on_zaken.php
+++ b/database/migrations/2026_06_25_000000_backfill_reviewer_user_id_on_zaken.php
@@ -17,11 +17,21 @@ return new class extends Migration
      */
     public function up(): void
     {
-        DB::table('zaken')
+        // Distinct handlers that still exist as users; restricting to existing
+        // ids guards the reviewer_user_id foreign key.
+        $handlerIds = DB::table('zaken')
             ->whereNull('reviewer_user_id')
             ->whereNotNull('handled_status_set_by_user_id')
             ->whereIn('handled_status_set_by_user_id', fn (Builder $query) => $query->select('id')->from('users'))
-            ->update(['reviewer_user_id' => DB::raw('handled_status_set_by_user_id')]);
+            ->distinct()
+            ->pluck('handled_status_set_by_user_id');
+
+        foreach ($handlerIds as $handlerId) {
+            DB::table('zaken')
+                ->whereNull('reviewer_user_id')
+                ->where('handled_status_set_by_user_id', $handlerId)
+                ->update(['reviewer_user_id' => $handlerId]);
+        }
     }
 
     /**

--- a/tests/Feature/Migrations/BackfillReviewerUserIdOnZakenTest.php
+++ b/tests/Feature/Migrations/BackfillReviewerUserIdOnZakenTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Enums\Role;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+
+beforeEach(function () {
+    $this->municipality = Municipality::factory()->create();
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->municipality->id]);
+    $this->organisation = Organisation::factory()->create();
+
+    $this->makeZaak = fn (array $attributes): Zaak => Zaak::withoutEvents(fn () => Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        ...$attributes,
+    ]));
+
+    $this->migration = include database_path('migrations/2026_06_25_000000_backfill_reviewer_user_id_on_zaken.php');
+});
+
+it('copies the handler into reviewer_user_id for handled cases', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $reviewer->municipalities()->attach($this->municipality);
+
+    $zaak = ($this->makeZaak)([
+        'handled_status_set_by_user_id' => $reviewer->id,
+        'reviewer_user_id' => null,
+    ]);
+
+    $this->migration->up();
+
+    expect($zaak->fresh()->reviewer_user_id)->toBe($reviewer->id);
+});
+
+it('leaves cases without a handler unassigned', function () {
+    $zaak = ($this->makeZaak)([
+        'handled_status_set_by_user_id' => null,
+        'reviewer_user_id' => null,
+    ]);
+
+    $this->migration->up();
+
+    expect($zaak->fresh()->reviewer_user_id)->toBeNull();
+});
+
+it('does not overwrite an already assigned reviewer', function () {
+    $handler = User::factory()->create(['role' => Role::Reviewer]);
+    $assignedReviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $handler->municipalities()->attach($this->municipality);
+    $assignedReviewer->municipalities()->attach($this->municipality);
+
+    $zaak = ($this->makeZaak)([
+        'handled_status_set_by_user_id' => $handler->id,
+        'reviewer_user_id' => $assignedReviewer->id,
+    ]);
+
+    $this->migration->up();
+
+    expect($zaak->fresh()->reviewer_user_id)->toBe($assignedReviewer->id);
+});
+
+it('is idempotent when run more than once', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $reviewer->municipalities()->attach($this->municipality);
+
+    $zaak = ($this->makeZaak)([
+        'handled_status_set_by_user_id' => $reviewer->id,
+        'reviewer_user_id' => null,
+    ]);
+
+    $this->migration->up();
+    $this->migration->up();
+
+    expect($zaak->fresh()->reviewer_user_id)->toBe($reviewer->id);
+});


### PR DESCRIPTION
## What & why

#389 switched the municipality working stock (the "Nieuwe zaken" and "Mijn werkvoorraad" filters and their navigation badges) from `handled_status_set_by_user_id` to the new explicit `reviewer_user_id` column. That column is `null` for every existing zaak, and the migration that added it does not backfill.

Without a backfill, immediately after deploy:
- **"Nieuwe zaken" fills up**: every open case (no resultaat, not imported) reappears as unassigned, including cases that were already in handling.
- **"Mijn werkvoorraad" empties** for every reviewer until each case is reassigned via "Behandelaar toewijzen".

## Change

Adds a data migration that copies `handled_status_set_by_user_id` (the reviewer who took a case into handling, still maintained for status tracking) into `reviewer_user_id` where no reviewer is set yet. This reproduces the prior working stock membership exactly.

- Only fills rows where `reviewer_user_id IS NULL` and `handled_status_set_by_user_id IS NOT NULL`, so existing explicit assignments are never overwritten.
- Guards the foreign key by restricting to handler ids that still exist in `users`.
- Idempotent and runs automatically as part of `php artisan migrate`, so no extra deploy step is needed.

Covered by `tests/Feature/Migrations/BackfillReviewerUserIdOnZakenTest.php` (handled case backfilled, unhandled stays null, existing assignment preserved, idempotent).