### PR TITLE
Fix CSP blocking Vite dev server assets in local dev

### DIFF
--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -36,10 +36,16 @@ class SecurityHeaders
 
     private function buildCsp(): string
     {
-        // connect-src must allow the Vite HMR WebSocket in local dev and the PDOK Locatieserver API.
+        // In local dev, assets (JS modules + CSS) are served by the Vite dev
+        // server on a separate origin, so it must be whitelisted for script-src,
+        // style-src and connect-src (the latter also for the HMR WebSocket).
         $connectSrc = "'self' https://api.pdok.nl";
+        $viteScriptSrc = '';
+        $viteStyleSrc = '';
         if (config('app.debug')) {
             $connectSrc .= ' ws://localhost:5173 ws://127.0.0.1:5173 http://localhost:5173';
+            $viteScriptSrc = ' http://localhost:5173';
+            $viteStyleSrc = ' http://localhost:5173';
         }
 
         $directives = [
@@ -48,9 +54,9 @@ class SecurityHeaders
             // which requires 'unsafe-eval'. Livewire injects inline <script> tags,
             // requiring 'unsafe-inline'. Both are unavoidable without a nonce-based
             // approach and full Alpine.js CSP build.
-            "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+            "script-src 'self' 'unsafe-inline' 'unsafe-eval'{$viteScriptSrc}",
             // Alpine generates inline style attributes at runtime.
-            "style-src 'self' 'unsafe-inline'",
+            "style-src 'self' 'unsafe-inline'{$viteStyleSrc}",
             // data: for locally-generated SVG avatar data URIs; blob: for
             // any canvas/object-URL created by UI components.
             "img-src 'self' data: blob: https://tile.openstreetmap.org",

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -41,24 +41,28 @@ test('CSP contains required directives', function () {
         ->toContain("form-action 'self'");
 });
 
-test('CSP connect-src includes Vite WebSocket in debug mode', function () {
+test('CSP allows the Vite dev server in debug mode', function () {
     Config::set('app.debug', true);
 
     $response = $this->get('/up');
 
     $csp = $response->headers->get('Content-Security-Policy');
 
-    expect($csp)->toContain('ws://localhost:5173');
+    expect($csp)
+        ->toContain("script-src 'self' 'unsafe-inline' 'unsafe-eval' http://localhost:5173")
+        ->toContain("style-src 'self' 'unsafe-inline' http://localhost:5173")
+        ->toContain('ws://localhost:5173')
+        ->toContain('ws://127.0.0.1:5173');
 });
 
-test('CSP connect-src does not include Vite WebSocket when debug is off', function () {
+test('CSP does not reference the Vite dev server when debug is off', function () {
     Config::set('app.debug', false);
 
     $response = $this->get('/up');
 
     $csp = $response->headers->get('Content-Security-Policy');
 
-    expect($csp)->not->toContain('ws://localhost:5173');
+    expect($csp)->not->toContain('5173');
 });
 
 test('HSTS header is absent in local environment', function () {


### PR DESCRIPTION
@Michel-Verhoeven deze fix is door AI gegenereerd, dus kijk er even goed naar :).

## Probleem
In local development laadde de app ongestyled: de CSP in `SecurityHeaders` stond de Vite dev server (`http://localhost:5173`) alleen toe in `connect-src` (voor de HMR-websocket), maar niet in `script-src`/`style-src`. Daardoor blokkeerde de browser de JS-modules en CSS van de dev server.

## Oplossing
In debug-modus wordt `http://localhost:5173` nu ook toegevoegd aan `script-src` en `style-src`. Productie/CSP blijft ongewijzigd.