### PR TITLE
Harden ZGW document handling: uuid derivation, 400 bodies in Sentry, and omschrijving informatieobjecttypen

### DIFF
--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -114,10 +114,6 @@ class MunicipalityZgwConnectionResource extends Resource
                             ->label(__('municipality/resources/zgw_connection.fields.bronorganisatie_rsin.label'))
                             ->helperText(__('municipality/resources/zgw_connection.fields.bronorganisatie_rsin.helper'))
                             ->maxLength(9),
-                        TextInput::make('eigenschap_date_format')
-                            ->label(__('municipality/resources/zgw_connection.fields.eigenschap_date_format.label'))
-                            ->helperText(__('municipality/resources/zgw_connection.fields.eigenschap_date_format.helper'))
-                            ->maxLength(32),
                     ]),
 
                 Section::make(__('municipality/resources/zgw_connection.sections.features.heading'))

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -7,6 +7,7 @@ use App\Enums\Role;
 use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Models\Zaak;
 use App\Services\Zgw\ZgwConnectionConfig;
+use App\Services\Zgw\ZgwResource;
 use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
 use Filament\Actions\Action;
@@ -264,7 +265,7 @@ class UploadDocumentAction
         $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
         $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
 
-        $informatieobject = new Informatieobject(...$connection->documenten()->enkelvoudiginformatieobjecten()->store([
+        $informatieobject = new Informatieobject(...ZgwResource::ensureUuid($connection->documenten()->enkelvoudiginformatieobjecten()->store([
             'bronorganisatie' => $zaak->openzaak->bronorganisatie,
             'creatiedatum' => now()->format('Y-m-d'),
             'vertrouwelijkheidaanduiding' => $vertrouwelijkheidaanduiding,
@@ -277,7 +278,7 @@ class UploadDocumentAction
             'inhoud' => base64_encode(Storage::get($data['file'])),
             'informatieobjecttype' => $data['informatieobjecttype'],
             'indicatieGebruiksrecht' => false,
-        ]));
+        ])));
 
         $connection->zaken()->zaakinformatieobjecten()->store([
             'zaak' => $zaak->openzaak->url,

--- a/app/Jobs/Submit/UploadFormBijlagenToZGW.php
+++ b/app/Jobs/Submit/UploadFormBijlagenToZGW.php
@@ -9,6 +9,7 @@ use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaak;
 use App\Services\Zgw\ZaaktypeBlueprint;
 use App\Services\Zgw\ZgwConnectionConfig;
+use App\Services\Zgw\ZgwResource;
 use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
 use Filament\Forms\Components\FileUpload;
@@ -142,7 +143,7 @@ final class UploadFormBijlagenToZGW implements ShouldQueue
         foreach ($aanwezig as $pad => $bestandsnaam) {
             $content = (string) $disk->get($pad);
 
-            $info = new Informatieobject(...$connection->documenten()->enkelvoudiginformatieobjecten()->store([
+            $info = new Informatieobject(...ZgwResource::ensureUuid($connection->documenten()->enkelvoudiginformatieobjecten()->store([
                 'bronorganisatie' => $this->zaak->openzaak->bronorganisatie,
                 'creatiedatum' => now()->format('Y-m-d'),
                 'vertrouwelijkheidaanduiding' => ZgwConnectionConfig::systemUploadDefault($connectionName),
@@ -155,7 +156,7 @@ final class UploadFormBijlagenToZGW implements ShouldQueue
                 'inhoud' => base64_encode($content),
                 'informatieobjecttype' => $informatieobjecttype,
                 'indicatieGebruiksrecht' => false,
-            ]));
+            ])));
 
             $connection->zaken()->zaakinformatieobjecten()->store([
                 'zaak' => $this->zaak->zgw_zaak_url,

--- a/app/Jobs/Submit/UploadSubmissionPdfToZGW.php
+++ b/app/Jobs/Submit/UploadSubmissionPdfToZGW.php
@@ -8,6 +8,7 @@ use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaak;
 use App\Services\Zgw\ZaaktypeBlueprint;
 use App\Services\Zgw\ZgwConnectionConfig;
+use App\Services\Zgw\ZgwResource;
 use App\ValueObjects\ZGW\Informatieobject;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -59,7 +60,7 @@ final class UploadSubmissionPdfToZGW implements ShouldQueue
 
         $connectionName = $this->zaak->zgwConnectionName();
         $connection = Zgw::connection($connectionName);
-        $info = new Informatieobject(...$connection->documenten()->enkelvoudiginformatieobjecten()->store([
+        $info = new Informatieobject(...ZgwResource::ensureUuid($connection->documenten()->enkelvoudiginformatieobjecten()->store([
             'bronorganisatie' => $this->zaak->openzaak->bronorganisatie,
             'creatiedatum' => now()->format('Y-m-d'),
             'vertrouwelijkheidaanduiding' => ZgwConnectionConfig::systemUploadDefault($connectionName),
@@ -72,7 +73,7 @@ final class UploadSubmissionPdfToZGW implements ShouldQueue
             'inhoud' => base64_encode($content),
             'informatieobjecttype' => $informatieobjecttype,
             'indicatieGebruiksrecht' => false,
-        ]));
+        ])));
 
         $connection->zaken()->zaakinformatieobjecten()->store([
             'zaak' => $this->zaak->zgw_zaak_url,

--- a/app/Jobs/Zaak/AddGeometryZGW.php
+++ b/app/Jobs/Zaak/AddGeometryZGW.php
@@ -64,8 +64,12 @@ class AddGeometryZGW implements ShouldQueue
                 'objectType' => 'adres',
                 'relatieomschrijving' => 'Adres van het evenement',
                 'objectIdentificatie' => [
+                    // ZGW ObjectAdres requires `identificatie` (the BAG
+                    // nummeraanduiding id); gorOpenbareRuimteNaam is the street
+                    // name, not the Locatieserver adres id.
+                    'identificatie' => $bagObject->nummeraanduiding_id,
                     'wplWoonplaatsNaam' => $bagObject->woonplaatsnaam,
-                    'gorOpenbareRuimteNaam' => $bagObject->id,
+                    'gorOpenbareRuimteNaam' => $bagObject->straatnaam,
                     'huisnummer' => $bagObject->huisnummer,
                     'huisletter' => $bagObject->huisletter,
                     'huisnummertoevoeging' => $bagObject->huisnummertoevoeging,

--- a/app/Jobs/Zaak/AddGlobaleLocatieZGW.php
+++ b/app/Jobs/Zaak/AddGlobaleLocatieZGW.php
@@ -45,8 +45,14 @@ class AddGlobaleLocatieZGW implements ShouldQueue
             'objectType' => 'overige',
             'objectTypeOverige' => 'GlobaleLocatie',
             'relatieomschrijving' => 'Globale locatie van het evenement',
+            // For objectType "overige" the ZGW ObjectOverige identification lives
+            // under objectIdentificatie.overigeData (a free-form object); a bare
+            // `naam` is rejected with a 400 (objectIdentificatie.overigeData is
+            // required).
             'objectIdentificatie' => [
-                'naam' => $locaties,
+                'overigeData' => [
+                    'naam' => $locaties,
+                ],
             ],
         ]);
     }

--- a/app/Jobs/Zaak/AddZaakeigenschappenZGW.php
+++ b/app/Jobs/Zaak/AddZaakeigenschappenZGW.php
@@ -83,7 +83,6 @@ class AddZaakeigenschappenZGW implements ShouldQueue
                 'zaak' => $ozZaak->url,
                 'eigenschap' => (string) $catalogiEigenschap->url,
                 'waarde' => ZgwConnectionConfig::formatEigenschapWaarde(
-                    $connectionName,
                     $waardeString,
                     $catalogiEigenschap->specificatie?->formaat?->value,
                 ),

--- a/app/Jobs/Zaak/AddZaakeigenschappenZGW.php
+++ b/app/Jobs/Zaak/AddZaakeigenschappenZGW.php
@@ -82,7 +82,11 @@ class AddZaakeigenschappenZGW implements ShouldQueue
             $connection->zaken()->zaken()->zaakeigenschappen(basename($this->zaak->zgw_zaak_url))->store([
                 'zaak' => $ozZaak->url,
                 'eigenschap' => (string) $catalogiEigenschap->url,
-                'waarde' => ZgwConnectionConfig::formatEigenschapWaarde($connectionName, $waardeString),
+                'waarde' => ZgwConnectionConfig::formatEigenschapWaarde(
+                    $connectionName,
+                    $waardeString,
+                    $catalogiEigenschap->specificatie?->formaat?->value,
+                ),
             ]);
         }
     }

--- a/app/Jobs/Zaak/UploadDocumentsJob.php
+++ b/app/Jobs/Zaak/UploadDocumentsJob.php
@@ -6,6 +6,7 @@ namespace App\Jobs\Zaak;
 
 use App\Models\User;
 use App\Models\Zaak;
+use App\Services\Zgw\ZgwResource;
 use App\Support\Uploads\DocumentUploadType;
 use App\ValueObjects\ZGW\Informatieobject;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -51,7 +52,7 @@ final class UploadDocumentsJob implements ShouldQueue
             $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($file['original_name'] ?? '', $formaat);
             $titel = ($file['titel'] ?? '') !== '' ? $file['titel'] : pathinfo($bestandsnaam, PATHINFO_FILENAME);
 
-            $informatieobject = new Informatieobject(...$connection->documenten()->enkelvoudiginformatieobjecten()->store([
+            $informatieobject = new Informatieobject(...ZgwResource::ensureUuid($connection->documenten()->enkelvoudiginformatieobjecten()->store([
                 'bronorganisatie' => $this->zaak->openzaak->bronorganisatie,
                 'creatiedatum' => now()->format('Y-m-d'),
                 'vertrouwelijkheidaanduiding' => $this->vertrouwelijkheidaanduiding,
@@ -64,7 +65,7 @@ final class UploadDocumentsJob implements ShouldQueue
                 'inhoud' => base64_encode((string) Storage::get($path)),
                 'informatieobjecttype' => $file['informatieobjecttype'],
                 'indicatieGebruiksrecht' => false,
-            ]));
+            ])));
 
             $connection->zaken()->zaakinformatieobjecten()->store([
                 'zaak' => $this->zaak->openzaak->url,

--- a/app/Models/MunicipalityZgwConnection.php
+++ b/app/Models/MunicipalityZgwConnection.php
@@ -42,7 +42,6 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property array<int, string>|null $allowed_hosts
  * @property string|null $bronorganisatie_rsin
  * @property array<string, mixed>|null $vertrouwelijkheid_map
- * @property string|null $eigenschap_date_format
  * @property bool $lock_status_for_behandelaar
  * @property bool $show_besluiten_tab
  * @property bool $show_bestanden_tab
@@ -77,7 +76,6 @@ class MunicipalityZgwConnection extends Model
         'allowed_hosts',
         'bronorganisatie_rsin',
         'vertrouwelijkheid_map',
-        'eigenschap_date_format',
         'lock_status_for_behandelaar',
         'show_besluiten_tab',
         'show_bestanden_tab',
@@ -242,7 +240,6 @@ class MunicipalityZgwConnection extends Model
             'allowed_hosts' => $this->allowed_hosts,
             'bronorganisatie_rsin' => $this->bronorganisatie_rsin,
             'vertrouwelijkheid_map' => $this->vertrouwelijkheid_map,
-            'eigenschap_date_format' => $this->eigenschap_date_format,
         ];
 
         foreach ($overrides as $key => $value) {

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Enums\AdviceStatus;
+use App\Enums\Role;
 use App\Models\Threads\AdviceThread;
 use App\Models\Threads\OrganiserThread;
 use App\Models\Users\MunicipalityUser;
@@ -30,6 +31,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
 use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Models\Activity;
 use Spatie\Activitylog\Traits\LogsActivity;
 use Woweb\Zgw\Api\Endpoints\DirectEndpoint;
 use Woweb\Zgw\Data\Generated\Catalogi\BesluitTypeData;
@@ -362,11 +364,60 @@ class Zaak extends Model implements Eventable
                 if (app()->runningInConsole()) {
                     // queue needs documents for adding to mail, skip role filter because this is allready done before job is queued
                     return $documenten->values();
-                } else {
-                    return $documenten->filter(fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, ZgwConnectionConfig::documentVisibilityForRole($this->zgwConnectionName(), auth()->user()->role)))->values();
                 }
+
+                return $this->filterDocumentenForRole($documenten, auth()->user()->role);
             },
         );
+    }
+
+    /**
+     * Filter a document collection to what the given role may see: the
+     * vertrouwelijkheid levels configured (or defaulted) for that role, plus —
+     * for an organiser — the documents they submitted themselves, which they may
+     * always see regardless of the configured visibility.
+     *
+     * @param  Collection<int, Informatieobject>  $documenten
+     * @return Collection<int, Informatieobject>
+     */
+    public function filterDocumentenForRole(Collection $documenten, Role $role): Collection
+    {
+        $allowed = ZgwConnectionConfig::documentVisibilityForRole($this->zgwConnectionName(), $role);
+
+        $ownDocumentUuids = $role === Role::Organiser
+            ? $this->organiserSubmittedDocumentUuids()
+            : collect();
+
+        return $documenten->filter(
+            fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, $allowed)
+                || $ownDocumentUuids->contains($informatieobject->uuid)
+        )->values();
+    }
+
+    /**
+     * The uuids of the documents the organiser submitted for this zaak (the
+     * aanvraag-PDF and the form bijlagen), identified via the activity log:
+     * document-created events on this zaak caused by the zaak's organiser. Used
+     * so an organiser always sees their own files regardless of the configured
+     * vertrouwelijkheid visibility.
+     *
+     * @return Collection<int, string>
+     */
+    private function organiserSubmittedDocumentUuids(): Collection
+    {
+        if (! $this->organiser_user_id) {
+            return collect();
+        }
+
+        return Activity::query()
+            ->where('log_name', 'document')
+            ->where('event', 'created')
+            ->where('subject_id', $this->getKey())
+            ->where('causer_id', $this->organiser_user_id)
+            ->get()
+            ->map(fn (Activity $activity) => data_get($activity->properties, 'document_uuid'))
+            ->filter(fn ($uuid): bool => is_string($uuid))
+            ->values();
     }
 
     /** @return Attribute<Collection<Informatieobject>, void> */

--- a/app/Models/Zaaktype.php
+++ b/app/Models/Zaaktype.php
@@ -15,6 +15,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Throwable;
 use Woweb\Zgw\Data\Generated\Catalogi\InformatieObjectTypeData;
 use Woweb\Zgw\Facades\Zgw;
 
@@ -208,20 +210,81 @@ class Zaaktype extends Model
         return Cache::rememberForever('zaaktype_document_types_v2_'.md5($connectionName.'|'.$url), function () use ($connectionName, $url) {
             // Resolve document types via the standard zaaktype-informatieobjecttypen
             // relation rather than the informatieobjecttypen?zaaktype= filter, which
-            // not every ZGW instance supports. Each relation row links to one
-            // informatieobjecttype that we then fetch by url.
+            // not every ZGW instance supports.
             $relations = Zgw::connection($connectionName)
                 ->catalogi()
                 ->zaaktypeInformatieobjecttypen()
                 ->index(['zaaktype' => $url]);
 
             $collection = collect();
+            // Memo of catalogus url => (omschrijving => informatieobjecttype), so a
+            // catalogus is listed at most once per resolution (no per-relation N+1).
+            $catalogusMaps = [];
+
             foreach ($relations as $relation) {
-                $informatieobjecttypeUrl = $relation['informatieobjecttype'] ?? null;
-                if (! is_string($informatieobjecttypeUrl) || $informatieobjecttypeUrl === '') {
+                $value = $relation['informatieobjecttype'] ?? null;
+                if (! is_string($value) || $value === '') {
                     continue;
                 }
-                $collection->push(InformatieObjectTypeData::from(ZgwResource::byUrl($connectionName, $informatieobjecttypeUrl)));
+
+                // The ZGW standard types `informatieobjecttype` as a string:
+                // OpenZaak returns a followable URL, while some backends (e.g. RX
+                // Mission) return the omschrijving inline. Follow a URL; resolve an
+                // omschrijving against its catalogus. A single unresolvable type is
+                // skipped (and logged) rather than aborting the whole list — a job
+                // that needs a specific type still fails loudly downstream when
+                // that type is absent from the resolved list.
+                if (str_starts_with($value, 'http')) {
+                    try {
+                        $collection->push(InformatieObjectTypeData::from(ZgwResource::byUrl($connectionName, $value)));
+                    } catch (Throwable $e) {
+                        Log::warning('Zaaktype::getDocumentTypes: informatieobjecttype-URL niet op te halen, overgeslagen', [
+                            'connection' => $connectionName,
+                            'informatieobjecttype' => $value,
+                            'exception' => $e->getMessage(),
+                        ]);
+                    }
+
+                    continue;
+                }
+
+                $catalogusUrl = $relation['catalogus'] ?? null;
+                if (! is_string($catalogusUrl) || $catalogusUrl === '') {
+                    Log::warning('Zaaktype::getDocumentTypes: informatieobjecttype-omschrijving zonder catalogus, overgeslagen', [
+                        'connection' => $connectionName,
+                        'omschrijving' => $value,
+                    ]);
+
+                    continue;
+                }
+
+                if (! array_key_exists($catalogusUrl, $catalogusMaps)) {
+                    try {
+                        $catalogusMaps[$catalogusUrl] = ZgwResource::informatieobjecttypenByOmschrijving($connectionName, $catalogusUrl);
+                    } catch (Throwable $e) {
+                        // Cache the empty result so a second omschrijving on the same
+                        // failing catalogus does not re-hit the API within this run.
+                        $catalogusMaps[$catalogusUrl] = [];
+                        Log::warning('Zaaktype::getDocumentTypes: informatieobjecttypen van catalogus niet op te halen, overgeslagen', [
+                            'connection' => $connectionName,
+                            'catalogus' => $catalogusUrl,
+                            'exception' => $e->getMessage(),
+                        ]);
+                    }
+                }
+
+                $resource = $catalogusMaps[$catalogusUrl][$value] ?? null;
+                if ($resource === null) {
+                    Log::warning('Zaaktype::getDocumentTypes: informatieobjecttype-omschrijving niet gevonden in catalogus, overgeslagen', [
+                        'connection' => $connectionName,
+                        'catalogus' => $catalogusUrl,
+                        'omschrijving' => $value,
+                    ]);
+
+                    continue;
+                }
+
+                $collection->push(InformatieObjectTypeData::from($resource));
             }
 
             return $collection;

--- a/app/Services/LocatieserverService.php
+++ b/app/Services/LocatieserverService.php
@@ -42,7 +42,7 @@ class LocatieserverService
             'lat' => $lat,
             'lon' => $lon,
             'fq' => 'type:(adres)',
-            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging',
+            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging nummeraanduiding_id',
         ]);
 
         if ($httpResponse->successful()) {
@@ -61,7 +61,7 @@ class LocatieserverService
         $httpResponse = Http::get($url, [
             'q' => $postcode.' '.$huisnummer,
             'fq' => 'type:(adres)',
-            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging',
+            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging nummeraanduiding_id',
         ]);
 
         if ($httpResponse->successful()) {
@@ -107,7 +107,7 @@ class LocatieserverService
         $url = $this->config['base_url'].'/search/v3_1/lookup';
         $httpResponse = Http::get($url, [
             'id' => $bagId,
-            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging',
+            'fl' => 'id type centroide_ll weergavenaam straatnaam postcode huisnummer woonplaatsnaam gemeentecode huisletter huisnummertoevoeging nummeraanduiding_id',
         ]);
 
         if ($httpResponse->successful()) {

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -18,17 +18,30 @@ use Throwable;
 class ZgwConnectionConfig
 {
     /**
-     * Apply the optional eigenschap date format to a scalar zaakeigenschap value.
+     * Format a scalar zaakeigenschap value for the wire.
      *
-     * When the connection sets `eigenschap_date_format` (e.g. 'YmdHis' for RX
-     * Mission) and the value parses as a date, it is reformatted. Otherwise the
-     * value is returned unchanged, which is the legacy OpenZaak behaviour.
+     * The catalogus eigenschap's formaat is authoritative for date types: a
+     * `datum` wants YYYYMMDD, a `datum_tijd` wants YYYYMMDDHHMMSS (which some
+     * backends such as RX Mission enforce strictly, rejecting a bare date with a
+     * 400). Non-date formats are never date-formatted, so a `tekst` value that
+     * happens to parse as a date is left untouched. When the caller does not
+     * know the formaat, we fall back to the connection-wide
+     * `eigenschap_date_format` override (the legacy OpenZaak behaviour).
      */
-    public static function formatEigenschapWaarde(string $connectionName, string $waarde): string
+    public static function formatEigenschapWaarde(string $connectionName, string $waarde, ?string $formaat = null): string
     {
-        $format = config("zgw.connections.{$connectionName}.eigenschap_date_format");
+        if ($waarde === '') {
+            return $waarde;
+        }
 
-        if (! is_string($format) || $format === '' || $waarde === '') {
+        $format = match ($formaat) {
+            'datum' => 'Ymd',
+            'datum_tijd' => 'YmdHis',
+            null => config("zgw.connections.{$connectionName}.eigenschap_date_format"),
+            default => null,
+        };
+
+        if (! is_string($format) || $format === '') {
             return $waarde;
         }
 

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -20,28 +20,21 @@ class ZgwConnectionConfig
     /**
      * Format a scalar zaakeigenschap value for the wire.
      *
-     * The catalogus eigenschap's formaat is authoritative for date types: a
-     * `datum` wants YYYYMMDD, a `datum_tijd` wants YYYYMMDDHHMMSS (which some
-     * backends such as RX Mission enforce strictly, rejecting a bare date with a
-     * 400). Non-date formats are never date-formatted, so a `tekst` value that
-     * happens to parse as a date is left untouched. When the caller does not
-     * know the formaat, we fall back to the connection-wide
-     * `eigenschap_date_format` override (the legacy OpenZaak behaviour).
+     * The catalogus eigenschap's formaat is authoritative: a `datum` wants
+     * YYYYMMDD, a `datum_tijd` wants YYYYMMDDHHMMSS (which some backends such as
+     * RX Mission enforce strictly, rejecting a bare date with a 400). Any other
+     * formaat (tekst, getal, or an unknown/absent one) is sent unchanged, so a
+     * text value that happens to parse as a date is never mangled.
      */
-    public static function formatEigenschapWaarde(string $connectionName, string $waarde, ?string $formaat = null): string
+    public static function formatEigenschapWaarde(string $waarde, ?string $formaat = null): string
     {
-        if ($waarde === '') {
-            return $waarde;
-        }
-
         $format = match ($formaat) {
             'datum' => 'Ymd',
             'datum_tijd' => 'YmdHis',
-            null => config("zgw.connections.{$connectionName}.eigenschap_date_format"),
             default => null,
         };
 
-        if (! is_string($format) || $format === '') {
+        if ($format === null || $waarde === '') {
             return $waarde;
         }
 

--- a/app/Services/Zgw/ZgwResource.php
+++ b/app/Services/Zgw/ZgwResource.php
@@ -93,4 +93,75 @@ class ZgwResource
 
         return $data;
     }
+
+    /**
+     * Map a catalogus' informatieobjecttypen by their omschrijving.
+     *
+     * The ZGW standard types the `informatieobjecttype` field of a
+     * zaaktype-informatieobjecttype relation as a string: OpenZaak returns a
+     * followable URL, but some backends (e.g. RX Mission) return the
+     * omschrijving inline. This resolves such an omschrijving back to the full
+     * informatieobjecttype resource (including its real url) by listing the
+     * catalogus and keying on omschrijving.
+     *
+     * When several versions share an omschrijving, the one valid today wins;
+     * otherwise the first one seen is kept.
+     *
+     * @return array<string, array<string, mixed>> omschrijving => resource (uuid-ensured)
+     */
+    public static function informatieobjecttypenByOmschrijving(string $connectionName, string $catalogusUrl): array
+    {
+        $today = now('Europe/Amsterdam')->toDateString();
+        $map = [];
+
+        $items = Zgw::connection($connectionName)
+            ->catalogi()
+            ->informatieobjecttypen()
+            ->index(['catalogus' => $catalogusUrl]);
+
+        foreach ($items as $item) {
+            $omschrijving = $item['omschrijving'] ?? null;
+            if (! is_string($omschrijving) || $omschrijving === '') {
+                continue;
+            }
+
+            if (! isset($map[$omschrijving])) {
+                $map[$omschrijving] = self::ensureUuid($item);
+
+                continue;
+            }
+
+            // Already have one for this omschrijving; only replace it when the
+            // incoming version is valid today and the stored one is not, so the
+            // first (or first valid-today) entry otherwise wins deterministically.
+            if (self::isValidOn($item, $today) && ! self::isValidOn($map[$omschrijving], $today)) {
+                $map[$omschrijving] = self::ensureUuid($item);
+            }
+        }
+
+        return $map;
+    }
+
+    /**
+     * Whether a catalogi resource's geldigheid window covers the given date.
+     *
+     * Dates are ZGW `YYYY-MM-DD` strings, which compare correctly lexically.
+     *
+     * @param  array<string, mixed>  $resource
+     */
+    private static function isValidOn(array $resource, string $date): bool
+    {
+        $begin = $resource['beginGeldigheid'] ?? null;
+        $einde = $resource['eindeGeldigheid'] ?? null;
+
+        if (is_string($begin) && $begin !== '' && $begin > $date) {
+            return false;
+        }
+
+        if (is_string($einde) && $einde !== '' && $einde < $date) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/app/ValueObjects/Pdok/BagObject.php
+++ b/app/ValueObjects/Pdok/BagObject.php
@@ -20,6 +20,8 @@ class BagObject implements Arrayable
         public readonly string $woonplaatsnaam,
         public readonly string $huisletter = '',
         public readonly string $huisnummertoevoeging = '',
+        // The BAG nummeraanduiding id, used as the ZGW ObjectAdres identificatie.
+        public readonly ?string $nummeraanduiding_id = null,
         ...$otherParams
     ) {
         $this->otherParams = $otherParams;
@@ -38,6 +40,7 @@ class BagObject implements Arrayable
             'woonplaatsnaam' => $this->woonplaatsnaam,
             'huisletter' => $this->huisletter,
             'huisnummertoevoeging' => $this->huisnummertoevoeging,
+            'nummeraanduiding_id' => $this->nummeraanduiding_id,
             'otherParams' => $this->otherParams,
         ];
     }

--- a/app/ValueObjects/ZGW/Informatieobject.php
+++ b/app/ValueObjects/ZGW/Informatieobject.php
@@ -53,14 +53,16 @@ class Informatieobject implements Arrayable
     /**
      * Whether this document may be shown to and notified about.
      *
-     * Explicit ZGW draft statuses (concepts) are hidden. Documents without an
-     * explicit status (our own uploads and legacy documents) and the
-     * "definitief" status are treated as final, so existing behaviour for the
-     * eigen OpenZaak is preserved while concepts from an external ZGW backend
-     * (e.g. RX Mission) are filtered out.
+     * Strict allowlist: only finalised documents are shown. A document without
+     * an explicit status (our own uploads and legacy documents) counts as final,
+     * as do the finalised ZGW statuses. Any other status — the draft statuses
+     * (in_bewerking, ter_vaststelling, concept) but also any unknown or future
+     * one — is treated as not final and hidden.
      */
     public function isDefinitief(): bool
     {
-        return ! in_array($this->status, ['in_bewerking', 'ter_vaststelling', 'concept'], true);
+        return $this->status === null
+            || $this->status === ''
+            || in_array($this->status, ['definitief', 'gearchiveerd'], true);
     }
 }

--- a/app/ValueObjects/ZGW/Informatieobject.php
+++ b/app/ValueObjects/ZGW/Informatieobject.php
@@ -18,7 +18,9 @@ class Informatieobject implements Arrayable
         public readonly string|int $versie,
         public readonly string $bestandsnaam,
         public readonly string $inhoud,
-        public readonly string $beschrijving,
+        // Optional in ZGW: OpenZaak returns an empty string, but some backends
+        // (e.g. RX Mission) omit it or return null.
+        public readonly ?string $beschrijving,
         public readonly string $informatieobjecttype,
         public readonly string $formaat,
         public readonly bool $locked,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,10 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
 use Sentry\Laravel\Integration;
+use Sentry\State\Scope;
+use Woweb\Zgw\Exceptions\ApiRequestException;
+
+use function Sentry\configureScope;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -55,5 +59,24 @@ return Application::configure(basePath: dirname(__DIR__))
         });
     })
     ->withExceptions(function (Exceptions $exceptions): void {
+        // ZGW write failures (typically HTTP 400 ValidatieFout) keep the response
+        // body off the exception message on purpose, because it can carry PII. That
+        // makes them undiagnosable in Sentry: we only see "request failed validation
+        // [400]" with no field-level detail. Attach the response status and body as a
+        // Sentry context so we can see *what* the ZGW API rejected without reproducing
+        // the request. Registered before Integration::handles() so the scope is set
+        // before Sentry captures the event; returning void keeps default reporting.
+        $exceptions->report(function (ApiRequestException $e): void {
+            configureScope(function (Scope $scope) use ($e): void {
+                $response = $e->getResponse();
+
+                $scope->setContext('zgw_response', [
+                    'status' => $response->status(),
+                    // Cap the body so a stray large payload can't bloat the event.
+                    'body' => mb_substr($response->body(), 0, 4000),
+                ]);
+            });
+        });
+
         Integration::handles($exceptions);
     })->create();

--- a/composer.json
+++ b/composer.json
@@ -42,10 +42,6 @@
         "woweb/openzaak": {
             "type": "vcs",
             "url": "git@github.com:WowebNL/laravel-openzaak.git"
-        },
-        "woweb/laravel-zgw-client": {
-            "type": "vcs",
-            "url": "git@github.com:WowebNL/laravel-zgw-client.git"
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "43abb5e28e72d8d20125a529cabdcfd9",
+    "content-hash": "8d4a57153650db6e368115d5da13d9fb",
     "packages": [
         {
             "name": "barryvdh/laravel-dompdf",
@@ -10897,16 +10897,16 @@
         },
         {
             "name": "woweb/laravel-zgw-client",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WowebNL/laravel-zgw-client.git",
-                "reference": "e574c7cc20966263ec04bd156f0e9ecdcb8ab665"
+                "reference": "7d97193561c03b4109da2aaf42134a23a2f04be0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/e574c7cc20966263ec04bd156f0e9ecdcb8ab665",
-                "reference": "e574c7cc20966263ec04bd156f0e9ecdcb8ab665",
+                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/7d97193561c03b4109da2aaf42134a23a2f04be0",
+                "reference": "7d97193561c03b4109da2aaf42134a23a2f04be0",
                 "shasum": ""
             },
             "require": {
@@ -10926,12 +10926,12 @@
             "type": "library",
             "extra": {
                 "laravel": {
-                    "providers": [
-                        "Woweb\\Zgw\\ZgwServiceProvider"
-                    ],
                     "aliases": {
                         "Zgw": "Woweb\\Zgw\\Facades\\Zgw"
-                    }
+                    },
+                    "providers": [
+                        "Woweb\\Zgw\\ZgwServiceProvider"
+                    ]
                 }
             },
             "autoload": {
@@ -10939,41 +10939,7 @@
                     "Woweb\\Zgw\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Woweb\\Zgw\\Tests\\": "tests/",
-                    "Woweb\\Zgw\\Dev\\": "dev/"
-                }
-            },
-            "scripts": {
-                "test": [
-                    "@php vendor/bin/phpunit"
-                ],
-                "test:coverage": [
-                    "@php -d pcov.enabled=1 vendor/bin/phpunit --coverage-text"
-                ],
-                "test:coverage-html": [
-                    "@php -d pcov.enabled=1 vendor/bin/phpunit --coverage-html coverage"
-                ],
-                "contract:fetch": [
-                    "@php scripts/fetch-specs.php"
-                ],
-                "contract": [
-                    "@contract:fetch",
-                    "@php vendor/bin/phpunit --testsuite Contract"
-                ],
-                "contract:coverage": [
-                    "@contract:fetch",
-                    "@php vendor/bin/phpunit tests/Contract/CoverageReportTest.php"
-                ],
-                "dto:generate": [
-                    "@php scripts/generate-dtos.php",
-                    "@php vendor/bin/pint src/Data/Generated src/Data/Writes src/Data/Typed.php --quiet"
-                ],
-                "deptrac": [
-                    "@php vendor/bin/deptrac analyse --no-progress"
-                ]
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "EUPL-1.2"
             ],
@@ -10997,10 +10963,10 @@
                 "zgw"
             ],
             "support": {
-                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.0",
-                "issues": "https://github.com/WowebNL/laravel-zgw-client/issues"
+                "issues": "https://github.com/WowebNL/laravel-zgw-client/issues",
+                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.1"
             },
-            "time": "2026-06-26T18:19:21+00:00"
+            "time": "2026-07-02T13:50:56+00:00"
         },
         {
             "name": "woweb/openzaak",

--- a/config/zgw.php
+++ b/config/zgw.php
@@ -92,10 +92,6 @@ return [
             // RSIN used as bronorganisatie / verantwoordelijkeOrganisatie on every zaak.
             'bronorganisatie_rsin' => env('OPENZAAK_BRONORGANISATIE_RSIN', '820151130'),
 
-            // Optional date format for zaakeigenschap string values (e.g. 'YmdHis' for RX
-            // Mission). Null keeps the value as produced by the form (legacy behaviour).
-            'eigenschap_date_format' => env('ZGW_EIGENSCHAP_DATE_FORMAT'),
-
         ],
 
     ],

--- a/database/factories/MunicipalityZgwConnectionFactory.php
+++ b/database/factories/MunicipalityZgwConnectionFactory.php
@@ -39,7 +39,6 @@ class MunicipalityZgwConnectionFactory extends Factory
             'allowed_hosts' => [],
             'bronorganisatie_rsin' => null,
             'vertrouwelijkheid_map' => null,
-            'eigenschap_date_format' => null,
             'lock_status_for_behandelaar' => false,
             'show_besluiten_tab' => true,
             'show_bestanden_tab' => true,

--- a/database/migrations/2026_07_02_150112_drop_eigenschap_date_format_from_municipality_zgw_connections.php
+++ b/database/migrations/2026_07_02_150112_drop_eigenschap_date_format_from_municipality_zgw_connections.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The per-connection eigenschap_date_format is obsolete: zaakeigenschap dates
+ * are now formatted from the catalogus eigenschap's specificatie.formaat
+ * (datum -> Ymd, datum_tijd -> YmdHis), so no per-connection override is needed.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table): void {
+            $table->dropColumn('eigenschap_date_format');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table): void {
+            $table->string('eigenschap_date_format')->nullable()->after('vertrouwelijkheid_map');
+        });
+    }
+};

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -55,10 +55,6 @@ return [
             'label' => 'Bronorganisatie RSIN',
             'helper' => 'RSIN die als bronorganisatie op elke zaak wordt gezet.',
         ],
-        'eigenschap_date_format' => [
-            'label' => 'Datumformaat zaakeigenschappen',
-            'helper' => 'Optioneel PHP-datumformaat voor zaakeigenschap-waarden (bijv. YmdHis). Leeg laten houdt het formulier-formaat aan.',
-        ],
         'vertrouwelijkheid_visibility' => [
             'label' => 'Zichtbare niveaus',
             'helper' => 'De vertrouwelijkheidsniveaus die deze rol mag zien. Leeg laten valt terug op de standaard.',

--- a/tests/Feature/EventForm/Jobs/UploadSubmissionPdfToZGWTest.php
+++ b/tests/Feature/EventForm/Jobs/UploadSubmissionPdfToZGWTest.php
@@ -126,8 +126,9 @@ test('happy path: store-response zonder uuid → uuid wordt afgeleid, geen Argum
         ]),
     ]));
 
-    // Crucial: the store response carries NO `uuid`, exactly like the real ZGW
-    // client returns. The derived uuid must come from the trailing url segment.
+    // Crucial: the store response carries NO `uuid` (the real ZGW client only
+    // derives one for list items) and a null `beschrijving` (RX Mission omits it
+    // where OpenZaak returns an empty string). Neither may crash the job.
     Http::fake([
         '*/documenten/api/v1/enkelvoudiginformatieobjecten' => Http::response([
             'url' => 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/doc-9',
@@ -138,7 +139,7 @@ test('happy path: store-response zonder uuid → uuid wordt afgeleid, geen Argum
             'versie' => 1,
             'bestandsnaam' => 'aanvraagformulier.pdf',
             'inhoud' => 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/doc-9/download',
-            'beschrijving' => '',
+            'beschrijving' => null,
             'informatieobjecttype' => 'https://zgw.example.com/catalogi/api/v1/informatieobjecttypen/iot-1',
             'formaat' => 'application/pdf',
             'locked' => false,

--- a/tests/Feature/EventForm/Jobs/UploadSubmissionPdfToZGWTest.php
+++ b/tests/Feature/EventForm/Jobs/UploadSubmissionPdfToZGWTest.php
@@ -16,16 +16,21 @@ declare(strict_types=1);
  * exact de race-condities die in een queue-omgeving gebeuren.
  */
 
+use App\Enums\Role;
 use App\Jobs\Submit\UploadSubmissionPdfToZGW;
 use App\Models\Organisation;
+use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
+use App\Services\Zgw\ZaakReadModel;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Support\Facades\Storage;
+use Woweb\Zgw\Data\Generated\Catalogi\InformatieObjectTypeData;
 
 uses(RefreshDatabase::class);
 
@@ -71,4 +76,91 @@ test('PDF nog niet weggeschreven → job logt waarschuwing en stopt zonder HTTP-
         ->withArgs(fn (string $message) => str_contains($message, 'PDF ontbreekt'))
         ->once();
     Http::assertNothingSent();
+});
+
+test('happy path: store-response zonder uuid → uuid wordt afgeleid, geen ArgumentCountError', function () {
+    // Regression for EVENTLOKET-15: the new woweb/laravel-zgw-client does NOT
+    // derive a `uuid` on a store() response (only on list items). The document
+    // value object requires `uuid`, so the raw store body crashed the job with
+    // "ArgumentCountError: Informatieobject::__construct(): Argument #1 ($uuid)
+    // not passed" — after OpenZaak had already created the document (201),
+    // leaving an orphaned document behind on every retry. ZgwResource::ensureUuid()
+    // derives the uuid from the url so the job completes and links the document.
+
+    // Zaak::document_types filters by auth()->user()->role, so this job must run
+    // under an organiser session like it does in production.
+    $this->actingAs(User::factory()->create(['role' => Role::Organiser]));
+
+    $zaaktype = Zaaktype::factory()->create();
+    $org = Organisation::factory()->create();
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => 'https://zgw.example.com/zaken/api/v1/zaken/abc-123',
+        'organisation_id' => $org->id,
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    Storage::disk('local')->put("zaken/{$zaak->id}/aanvraagformulier.pdf", 'fake pdf content');
+
+    // Seed the caches the job reads so it never hits OpenZaak for the zaak or
+    // its document types, mirroring UploadFormBijlagenToZGWTest's happy path.
+    Cache::put("zaak.{$zaak->id}.openzaak.v2", ZaakReadModel::fromArray([
+        'uuid' => 'abc-123',
+        'url' => $zaak->zgw_zaak_url,
+        'identificatie' => $zaak->public_id,
+        'zaaktype' => 'https://zgw.example.com/catalogi/api/v1/zaaktypen/zt-1',
+        'omschrijving' => 'Test',
+        'startdatum' => '2026-05-01',
+        'registratiedatum' => '2026-05-01',
+        'einddatum' => null,
+        'einddatumGepland' => null,
+        'uiterlijkeEinddatumAfdoening' => null,
+        'bronorganisatie' => '820151130',
+        'zaakgeometrie' => null,
+    ]));
+    Cache::put('zaaktype_document_types_v2_'.md5('main|https://zgw.example.com/catalogi/api/v1/zaaktypen/zt-1'), collect([
+        InformatieObjectTypeData::from([
+            'uuid' => 'iot-1',
+            'url' => 'https://zgw.example.com/catalogi/api/v1/informatieobjecttypen/iot-1',
+            'omschrijving' => 'Aanvraagformulier',
+            'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+        ]),
+    ]));
+
+    // Crucial: the store response carries NO `uuid`, exactly like the real ZGW
+    // client returns. The derived uuid must come from the trailing url segment.
+    Http::fake([
+        '*/documenten/api/v1/enkelvoudiginformatieobjecten' => Http::response([
+            'url' => 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/doc-9',
+            'creatiedatum' => '2026-05-06',
+            'titel' => 'Aanvraagformulier',
+            'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+            'auteur' => 'Eventloket',
+            'versie' => 1,
+            'bestandsnaam' => 'aanvraagformulier.pdf',
+            'inhoud' => 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/doc-9/download',
+            'beschrijving' => '',
+            'informatieobjecttype' => 'https://zgw.example.com/catalogi/api/v1/informatieobjecttypen/iot-1',
+            'formaat' => 'application/pdf',
+            'locked' => false,
+        ], 201),
+        '*/zaken/api/v1/zaakinformatieobjecten' => Http::response([
+            'url' => 'https://zgw.example.com/zaken/api/v1/zaakinformatieobjecten/zio-1',
+        ], 201),
+    ]);
+
+    (new UploadSubmissionPdfToZGW($zaak))->handle();
+
+    // The link POST proves the job survived past the value-object construction
+    // and used the document url derived alongside the uuid.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/zaken/api/v1/zaakinformatieobjecten')
+        && $request->method() === 'POST'
+        && $request->data()['zaak'] === $zaak->zgw_zaak_url
+        && $request->data()['informatieobject'] === 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/doc-9');
+
+    // And the activity log records the uuid derived from the url segment.
+    $this->assertDatabaseHas('activity_log', [
+        'subject_type' => $zaak->getMorphClass(),
+        'subject_id' => $zaak->id,
+        'event' => 'created',
+    ]);
 });

--- a/tests/Feature/Jobs/Zaak/AddGeometryZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/AddGeometryZGWTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * AddGeometryZGW patches the zaakgeometrie and registers each collected BAG
+ * address as an "adres" zaakobject. ZGW ObjectAdres requires `identificatie`
+ * (the BAG nummeraanduiding id) and expects the street name in
+ * gorOpenbareRuimteNaam; a missing identificatie is rejected with a 400.
+ */
+
+use App\EventForm\Submit\EventLocationGeometryBuilder;
+use App\EventForm\Submit\ZaakeigenschappenMap;
+use App\Jobs\Zaak\AddGeometryZGW;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\Services\LocatieserverService;
+use App\ValueObjects\Pdok\BagObject;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+test('an adres zaakobject carries the BAG nummeraanduiding as identificatie and the street name', function () {
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak(); // zaakgeometrie is null, so the job proceeds
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakobjecten' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakobjecten/1',
+        ], 201),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create()->id,
+        'form_state_snapshot' => ['values' => [
+            'adresVanDeGebouwEn' => [
+                ['postcode' => '6411HP', 'huisnummer' => '25'],
+            ],
+        ]],
+    ]);
+
+    $bag = new BagObject(
+        id: 'adr-db779ed64b9dfdfeab8bca3ed3f15bd0',
+        type: 'adres',
+        centroide_ll: 'POINT(5.98 50.88)',
+        weergavenaam: 'Geleenstraat 25, 6411HP Heerlen',
+        straatnaam: 'Geleenstraat',
+        postcode: '6411HP',
+        huisnummer: '25',
+        gemeentecode: '0917',
+        woonplaatsnaam: 'Heerlen',
+        nummeraanduiding_id: '0917201313093153',
+    );
+
+    // Stub the address lookup so the builder collects a known BAG address.
+    $locationService = Mockery::mock(LocatieserverService::class);
+    $locationService->shouldReceive('getBagObjectByPostcodeHuisnummer')->andReturn($bag);
+
+    (new AddGeometryZGW($zaak))->handle(
+        app(ZaakeigenschappenMap::class),
+        new EventLocationGeometryBuilder($locationService),
+    );
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/zaken/api/v1/zaakobjecten')
+        && $request->method() === 'POST'
+        && data_get($request->data(), 'objectType') === 'adres'
+        && data_get($request->data(), 'objectIdentificatie.identificatie') === '0917201313093153'
+        && data_get($request->data(), 'objectIdentificatie.gorOpenbareRuimteNaam') === 'Geleenstraat'
+        && data_get($request->data(), 'objectIdentificatie.wplWoonplaatsNaam') === 'Heerlen'
+        && data_get($request->data(), 'objectIdentificatie.postcode') === '6411HP');
+});

--- a/tests/Feature/Jobs/Zaak/AddGlobaleLocatieZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/AddGlobaleLocatieZGWTest.php
@@ -46,7 +46,8 @@ test('registers a GlobaleLocatie zaakobject with the composed location names', f
             && $request->method() === 'POST'
             && data_get($request->data(), 'objectType') === 'overige'
             && data_get($request->data(), 'objectTypeOverige') === 'GlobaleLocatie'
-            && data_get($request->data(), 'objectIdentificatie.naam') === 'Marktplein, Hoofdstraat';
+            // ZGW ObjectOverige requires the identification under overigeData.
+            && data_get($request->data(), 'objectIdentificatie.overigeData.naam') === 'Marktplein, Hoofdstraat';
     });
 });
 

--- a/tests/Feature/Services/LocatieserverServiceTest.php
+++ b/tests/Feature/Services/LocatieserverServiceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The Locatieserver lookups must request and expose the BAG nummeraanduiding id,
+ * because AddGeometryZGW needs it as the ZGW ObjectAdres identificatie.
+ */
+
+use App\Services\LocatieserverService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Config::set('services.locatieserver.base_url', 'https://locatieserver.test');
+});
+
+test('getBagObjectByPostcodeHuisnummer requests and exposes the nummeraanduiding id', function () {
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [[
+                'id' => 'adr-1',
+                'type' => 'adres',
+                'centroide_ll' => 'POINT(5.98 50.88)',
+                'weergavenaam' => 'Geleenstraat 25, 6411HP Heerlen',
+                'straatnaam' => 'Geleenstraat',
+                'postcode' => '6411HP',
+                'huisnummer' => 25,
+                'woonplaatsnaam' => 'Heerlen',
+                'gemeentecode' => '0917',
+                'nummeraanduiding_id' => '0917201313093153',
+            ]]],
+        ]),
+    ]);
+
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6411HP', '25');
+
+    expect($bag)->not->toBeNull();
+    expect($bag->nummeraanduiding_id)->toBe('0917201313093153');
+    expect($bag->straatnaam)->toBe('Geleenstraat');
+
+    // The BAG nummeraanduiding must be part of the requested field list.
+    Http::assertSent(fn ($request) => str_contains($request->url(), 'search/v3_1/free')
+        && str_contains(urldecode($request->url()), 'nummeraanduiding_id'));
+});

--- a/tests/Feature/Zaaktype/DocumentTypesResolutionTest.php
+++ b/tests/Feature/Zaaktype/DocumentTypesResolutionTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Zaaktype::getDocumentTypes() resolves the informatieobjecttypen linked to a
+ * zaaktype. The ZGW standard types the relation's `informatieobjecttype` field
+ * as a string: OpenZaak returns a followable URL, while some backends (e.g. RX
+ * Mission) return the omschrijving inline. These tests prove both shapes resolve
+ * to a full InformatieObjectTypeData (with a real url), that the two paths do
+ * not interfere, and that a single unresolvable type is skipped instead of
+ * crashing the whole list.
+ */
+
+use App\Enums\Role;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Tests\Fakes\ZgwHttpFake;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    // Resolution is cached rememberForever; flush so cases do not leak.
+    Cache::flush();
+    Http::preventStrayRequests();
+});
+
+/**
+ * A zaak whose document-type version snapshot points at $snapshotUrl, so
+ * getDocumentTypes() resolves against a URL we control in the fakes.
+ */
+function zaakForDocumentTypes(string $snapshotUrl): Zaak
+{
+    $zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/latest',
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'zgw_zaak_url' => null,
+        'zgw_zaaktype_url' => $snapshotUrl,
+    ]);
+}
+
+test('a URL informatieobjecttype is followed and the catalogus list is not touched', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $typeUrl = $base.'/informatieobjecttypen/1';
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $base.'/catalogussen/1', 'informatieobjecttype' => $typeUrl],
+        ]), 200),
+        $typeUrl => Http::response([
+            'url' => $typeUrl, 'omschrijving' => 'Bijlage', 'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+        ], 200),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(1);
+    expect((string) $types->first()->url)->toBe($typeUrl);
+    expect($types->first()->omschrijving)->toBe('Bijlage');
+
+    // The URL path must not fall back to a catalogus lookup.
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), 'catalogus='));
+});
+
+test('an omschrijving informatieobjecttype is resolved via the catalogus list', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $catalogusUrl = $base.'/catalogussen/1';
+    $typeUrl = $base.'/informatieobjecttypen/7';
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Beschikking op aanvraag'],
+        ]), 200),
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/6', 'omschrijving' => 'Aanvullende informatie', 'vertrouwelijkheidaanduiding' => 'openbaar', 'catalogus' => $catalogusUrl],
+            ['url' => $typeUrl, 'omschrijving' => 'Beschikking op aanvraag', 'vertrouwelijkheidaanduiding' => 'openbaar', 'catalogus' => $catalogusUrl],
+        ]), 200),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(1);
+    expect((string) $types->first()->url)->toBe($typeUrl);
+    expect($types->first()->omschrijving)->toBe('Beschikking op aanvraag');
+    expect($types->first()->vertrouwelijkheidaanduiding?->value)->toBe('openbaar');
+
+    // The lookup was scoped to the relation's catalogus.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/informatieobjecttypen?')
+        && str_contains($request->url(), 'catalogus='.urlencode($catalogusUrl)));
+});
+
+test('mixed URL and omschrijving relations resolve and the catalogus is listed once', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $catalogusUrl = $base.'/catalogussen/1';
+    $urlType = $base.'/informatieobjecttypen/1';
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => $urlType],
+            ['url' => $base.'/zaaktype-informatieobjecttypen/2', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Advies'],
+            ['url' => $base.'/zaaktype-informatieobjecttypen/3', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Factuur'],
+        ]), 200),
+        $urlType => Http::response([
+            'url' => $urlType, 'omschrijving' => 'Bijlage', 'vertrouwelijkheidaanduiding' => 'openbaar',
+        ], 200),
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/2', 'omschrijving' => 'Advies', 'vertrouwelijkheidaanduiding' => 'openbaar', 'catalogus' => $catalogusUrl],
+            ['url' => $base.'/informatieobjecttypen/3', 'omschrijving' => 'Factuur', 'vertrouwelijkheidaanduiding' => 'openbaar', 'catalogus' => $catalogusUrl],
+        ]), 200),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(3);
+    expect($types->pluck('omschrijving')->sort()->values()->all())->toBe(['Advies', 'Bijlage', 'Factuur']);
+    $types->each(fn ($type) => expect((string) $type->url)->toStartWith($base.'/informatieobjecttypen/'));
+
+    // Two omschrijving relations share one catalogus: it must be listed once.
+    expect(Http::recorded(fn ($request) => str_contains($request->url(), 'catalogus=')))->toHaveCount(1);
+});
+
+test('an unresolvable omschrijving is skipped without throwing, keeping the rest', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $catalogusUrl = $base.'/catalogussen/1';
+
+    Log::spy();
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            // Resolvable.
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Advies'],
+            // Omschrijving absent from the catalogus list.
+            ['url' => $base.'/zaaktype-informatieobjecttypen/2', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Bestaat niet'],
+            // Omschrijving with no catalogus at all.
+            ['url' => $base.'/zaaktype-informatieobjecttypen/3', 'zaaktype' => $snapshotUrl, 'informatieobjecttype' => 'Geen catalogus'],
+        ]), 200),
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/2', 'omschrijving' => 'Advies', 'vertrouwelijkheidaanduiding' => 'openbaar', 'catalogus' => $catalogusUrl],
+        ]), 200),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(1);
+    expect($types->first()->omschrijving)->toBe('Advies');
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => str_contains($message, 'niet gevonden in catalogus'))
+        ->once();
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => str_contains($message, 'zonder catalogus'))
+        ->once();
+});
+
+test('a failing catalogus list is skipped without throwing', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $catalogusUrl = $base.'/catalogussen/1';
+
+    Log::spy();
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Advies'],
+        ]), 200),
+        $base.'/informatieobjecttypen?*' => Http::response('boom', 500),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(0);
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message) => str_contains($message, 'van catalogus niet op te halen'))
+        ->once();
+});
+
+test('the vertrouwelijkheid role filter still applies to omschrijving-resolved types', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $snapshotUrl = $base.'/zaaktypen/snap';
+    $catalogusUrl = $base.'/catalogussen/1';
+
+    // An organiser may only see zaakvertrouwelijk documents.
+    $this->actingAs(User::factory()->create(['role' => Role::Organiser]));
+
+    $zaak = zaakForDocumentTypes($snapshotUrl);
+
+    Http::fake([
+        $base.'/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/zaaktype-informatieobjecttypen/1', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Zichtbaar'],
+            ['url' => $base.'/zaaktype-informatieobjecttypen/2', 'zaaktype' => $snapshotUrl, 'catalogus' => $catalogusUrl, 'informatieobjecttype' => 'Verborgen'],
+        ]), 200),
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/1', 'omschrijving' => 'Zichtbaar', 'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk', 'catalogus' => $catalogusUrl],
+            ['url' => $base.'/informatieobjecttypen/2', 'omschrijving' => 'Verborgen', 'vertrouwelijkheidaanduiding' => 'vertrouwelijk', 'catalogus' => $catalogusUrl],
+        ]), 200),
+    ]);
+
+    $types = $zaak->document_types;
+
+    expect($types)->toHaveCount(1);
+    expect($types->first()->omschrijving)->toBe('Zichtbaar');
+});

--- a/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
+++ b/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Zaak::filterDocumentenForRole applies the configured vertrouwelijkheid
+ * visibility per role, but an organiser must always see the documents they
+ * submitted themselves (the aanvraag-PDF and bijlagen), even when those are
+ * uploaded as a vertrouwelijkheid the organiser role is not configured to see
+ * (e.g. openbaar on an RX Mission connection).
+ */
+
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function documentWith(string $uuid, string $vertrouwelijkheid): Informatieobject
+{
+    return new Informatieobject(
+        uuid: $uuid,
+        url: "https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobjecten/{$uuid}",
+        creatiedatum: '2026-07-02',
+        titel: "Doc {$uuid}",
+        vertrouwelijkheidaanduiding: $vertrouwelijkheid,
+        auteur: 'Test',
+        versie: 1,
+        bestandsnaam: "{$uuid}.pdf",
+        inhoud: '',
+        beschrijving: null,
+        informatieobjecttype: 'https://zgw.example.com/catalogi/api/v1/informatieobjecttypen/1',
+        formaat: 'application/pdf',
+        locked: false,
+    );
+}
+
+test('an organiser always sees their own submitted documents, even when openbaar is not in the visible set', function () {
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create()->id,
+        'organiser_user_id' => $organiser->id,
+    ]);
+
+    // The organiser submitted the openbaar document 'own-openbaar'.
+    activity('document')
+        ->event('created')
+        ->causedBy($organiser)
+        ->performedOn($zaak)
+        ->withProperties(['document_uuid' => 'own-openbaar'])
+        ->log('created');
+
+    $documents = collect([
+        documentWith('own-openbaar', 'openbaar'),      // the organiser's own → always visible
+        documentWith('other-openbaar', 'openbaar'),    // openbaar but not theirs → hidden
+        documentWith('case-confidential', 'zaakvertrouwelijk'), // in the organiser's default visible set
+    ]);
+
+    $visible = $zaak->filterDocumentenForRole($documents, Role::Organiser)->pluck('uuid');
+
+    expect($visible->all())->toEqualCanonicalizing(['own-openbaar', 'case-confidential']);
+});
+
+test('a non-organiser role only follows the configured visibility, without an own-files exception', function () {
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create()->id,
+        'organiser_user_id' => User::factory()->create(['role' => Role::Organiser])->id,
+    ]);
+
+    // Even if an openbaar document was submitted by the organiser, a reviewer
+    // only sees the levels configured for the reviewer role (openbaar is not one).
+    activity('document')
+        ->event('created')
+        ->causedBy(User::factory()->create(['role' => Role::Organiser]))
+        ->performedOn($zaak)
+        ->withProperties(['document_uuid' => 'organiser-openbaar'])
+        ->log('created');
+
+    $documents = collect([
+        documentWith('organiser-openbaar', 'openbaar'),
+        documentWith('reviewer-visible', 'vertrouwelijk'),
+    ]);
+
+    $visible = $zaak->filterDocumentenForRole($documents, Role::Reviewer)->pluck('uuid');
+
+    expect($visible->all())->toBe(['reviewer-visible']);
+});

--- a/tests/Feature/Zgw/InformatieobjecttypenByOmschrijvingTest.php
+++ b/tests/Feature/Zgw/InformatieobjecttypenByOmschrijvingTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ZgwResource::informatieobjecttypenByOmschrijving() lists a catalogus'
+ * informatieobjecttypen and keys them by omschrijving, so a relation that
+ * carries an omschrijving string (rather than a URL) can be resolved to the
+ * full resource. When several versions share an omschrijving, the one valid
+ * today wins; otherwise the first seen is kept.
+ */
+
+use App\Services\Zgw\ZgwResource;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    Http::preventStrayRequests();
+});
+
+test('the version valid today wins over an expired one and the uuid is derived', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $catalogusUrl = $base.'/catalogussen/1';
+
+    Http::fake([
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/expired', 'omschrijving' => 'Advies', 'catalogus' => $catalogusUrl, 'beginGeldigheid' => '2000-01-01', 'eindeGeldigheid' => '2000-12-31'],
+            ['url' => $base.'/informatieobjecttypen/current', 'omschrijving' => 'Advies', 'catalogus' => $catalogusUrl, 'beginGeldigheid' => '2000-01-01', 'eindeGeldigheid' => null],
+        ]), 200),
+    ]);
+
+    $map = ZgwResource::informatieobjecttypenByOmschrijving('main', $catalogusUrl);
+
+    expect($map)->toHaveKey('Advies');
+    expect($map['Advies']['url'])->toBe($base.'/informatieobjecttypen/current');
+    // uuid is derived from the trailing url segment by ensureUuid().
+    expect($map['Advies']['uuid'])->toBe('current');
+});
+
+test('with no valid-today version the first one seen is kept', function () {
+    $base = ZgwHttpFake::$baseUrl.'/catalogi/api/v1';
+    $catalogusUrl = $base.'/catalogussen/1';
+
+    Http::fake([
+        $base.'/informatieobjecttypen?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => $base.'/informatieobjecttypen/first', 'omschrijving' => 'Advies', 'catalogus' => $catalogusUrl, 'beginGeldigheid' => '2000-01-01', 'eindeGeldigheid' => '2000-12-31'],
+            ['url' => $base.'/informatieobjecttypen/second', 'omschrijving' => 'Advies', 'catalogus' => $catalogusUrl, 'beginGeldigheid' => '2001-01-01', 'eindeGeldigheid' => '2001-12-31'],
+        ]), 200),
+    ]);
+
+    $map = ZgwResource::informatieobjecttypenByOmschrijving('main', $catalogusUrl);
+
+    expect($map['Advies']['url'])->toBe($base.'/informatieobjecttypen/first');
+});

--- a/tests/Feature/Zgw/ZgwConnectionResolverTest.php
+++ b/tests/Feature/Zgw/ZgwConnectionResolverTest.php
@@ -73,14 +73,14 @@ it('resolves a municipality with its own connection and registers its config', f
     MunicipalityZgwConnection::factory()->for($municipality)->active()->create([
         'zaken_url' => 'https://gemeente-a.example.com/zaken/api/v1/',
         'catalogi_url' => null,
-        'eigenschap_date_format' => 'YmdHis',
+        'bronorganisatie_rsin' => '999999999',
     ]);
 
     $name = $this->resolver->for($municipality);
 
     expect($name)->toBe("gemeente_{$municipality->id}")
         ->and(config("zgw.connections.{$name}.urls.zaken"))->toBe('https://gemeente-a.example.com/zaken/api/v1/')
-        ->and(config("zgw.connections.{$name}.eigenschap_date_format"))->toBe('YmdHis')
+        ->and(config("zgw.connections.{$name}.bronorganisatie_rsin"))->toBe('999999999')
         // Unset values are inherited from main.
         ->and(config("zgw.connections.{$name}.secret_rules.min_length"))->toBe(config('zgw.connections.main.secret_rules.min_length'))
         ->and(config("zgw.connections.{$name}.urls.catalogi"))->toBe(config('zgw.connections.main.urls.catalogi'));

--- a/tests/Feature/ZgwSentryContextTest.php
+++ b/tests/Feature/ZgwSentryContextTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The bootstrap exception handler attaches the ZGW API response (status + body)
+ * as a Sentry `zgw_response` context. ZGW validation errors keep their body off
+ * the exception message on purpose (it can carry PII), which previously made a
+ * "request failed validation [400]" undiagnosable in Sentry. These tests prove
+ * the context is set for ZGW API errors and left untouched for other exceptions.
+ */
+
+use GuzzleHttp\Psr7\Response as Psr7Response;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Client\Response;
+use Sentry\Event;
+use Sentry\SentrySdk;
+use Sentry\State\Scope;
+use Woweb\Zgw\Exceptions\ValidationException;
+
+/**
+ * Read the contexts currently attached to the Sentry hub's scope by applying it
+ * to a throwaway event.
+ *
+ * @return array<string, mixed>
+ */
+function currentSentryContexts(): array
+{
+    $contexts = [];
+
+    SentrySdk::getCurrentHub()->configureScope(function (Scope $scope) use (&$contexts): void {
+        $event = Event::createEvent();
+        $scope->applyToEvent($event);
+        $contexts = $event->getContexts();
+    });
+
+    return $contexts;
+}
+
+// The Sentry scope is a process-global singleton, so a context set by one test
+// would leak into the next. Clear it before each test to keep them independent.
+beforeEach(function () {
+    SentrySdk::getCurrentHub()->configureScope(fn (Scope $scope) => $scope->removeContext('zgw_response'));
+});
+
+test('reporting a ZGW ValidationException attaches the response body as Sentry context', function () {
+    $body = [
+        'code' => 'invalid',
+        'title' => 'Invalid input.',
+        'invalidParams' => [
+            ['name' => 'objectIdentificatie', 'code' => 'invalid', 'reason' => 'Onbekend veld.'],
+        ],
+    ];
+
+    $response = new Response(new Psr7Response(400, [], json_encode($body)));
+    $exception = new ValidationException('ZGW API request failed validation [400].', $response, 400);
+
+    app(ExceptionHandler::class)->report($exception);
+
+    $contexts = currentSentryContexts();
+
+    expect($contexts)->toHaveKey('zgw_response');
+    expect($contexts['zgw_response']['status'])->toBe(400);
+    expect($contexts['zgw_response']['body'])->toContain('objectIdentificatie');
+    expect($contexts['zgw_response']['body'])->toContain('Onbekend veld.');
+});
+
+test('a non-ZGW exception does not get a zgw_response context', function () {
+    app(ExceptionHandler::class)->report(new RuntimeException('iets anders'));
+
+    expect(currentSentryContexts())->not->toHaveKey('zgw_response');
+});

--- a/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
+++ b/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
@@ -24,20 +24,23 @@ function informatieobjectWithStatus(?string $status): Informatieobject
     );
 }
 
-test('definitief and missing status count as final', function (?string $status) {
+test('finalised and status-less documents count as final', function (?string $status) {
     expect(informatieobjectWithStatus($status)->isDefinitief())->toBeTrue();
 })->with([
     'definitief' => 'definitief',
-    'null' => null,
-    'empty' => '',
+    'gearchiveerd' => 'gearchiveerd',
+    'null (own upload)' => null,
+    'empty (own upload)' => '',
 ]);
 
-test('draft statuses are not final', function (string $status) {
+test('draft and unknown statuses are not final (strict allowlist)', function (string $status) {
     expect(informatieobjectWithStatus($status)->isDefinitief())->toBeFalse();
 })->with([
     'in_bewerking' => 'in_bewerking',
     'ter_vaststelling' => 'ter_vaststelling',
     'concept' => 'concept',
+    // Anything outside the allowlist is hidden, not just the known drafts.
+    'unknown status' => 'iets_onbekends',
 ]);
 
 test('a null beschrijving is accepted (some ZGW backends omit it)', function () {

--- a/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
+++ b/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
@@ -39,3 +39,26 @@ test('draft statuses are not final', function (string $status) {
     'ter_vaststelling' => 'ter_vaststelling',
     'concept' => 'concept',
 ]);
+
+test('a null beschrijving is accepted (some ZGW backends omit it)', function () {
+    // RX Mission returns beschrijving = null where OpenZaak returns an empty
+    // string; constructing the document must not throw a TypeError.
+    $document = new Informatieobject(...[
+        'uuid' => '1',
+        'url' => 'https://example.com/doc/1',
+        'creatiedatum' => '2026-01-01',
+        'titel' => 'Doc',
+        'vertrouwelijkheidaanduiding' => 'openbaar',
+        'auteur' => 'Test',
+        'versie' => 1,
+        'bestandsnaam' => 'doc.pdf',
+        'inhoud' => '',
+        'beschrijving' => null,
+        'informatieobjecttype' => 'https://example.com/iot/1',
+        'formaat' => 'application/pdf',
+        'locked' => false,
+    ]);
+
+    expect($document->beschrijving)->toBeNull();
+    expect($document->toArray()['beschrijving'])->toBeNull();
+});

--- a/tests/Unit/Zgw/ZgwConfigTest.php
+++ b/tests/Unit/Zgw/ZgwConfigTest.php
@@ -27,6 +27,5 @@ it('derives the per-API base urls from OPENZAAK_URL', function () {
 it('carries the application-level technical params with OpenZaak defaults', function () {
     $main = config('zgw.connections.main');
 
-    expect($main['bronorganisatie_rsin'])->toBe('820151130')
-        ->and($main)->toHaveKey('eigenschap_date_format');
+    expect($main['bronorganisatie_rsin'])->toBe('820151130');
 });

--- a/tests/Unit/Zgw/ZgwConnectionConfigTest.php
+++ b/tests/Unit/Zgw/ZgwConnectionConfigTest.php
@@ -23,6 +23,31 @@ it('leaves a non-date value unchanged even when a date format is configured', fu
     expect(ZgwConnectionConfig::formatEigenschapWaarde('main', 'ZAAK-2026-0001'))->toBe('ZAAK-2026-0001');
 });
 
+it('formats a datum_tijd eigenschap as a 14-char datetime regardless of the connection format', function () {
+    // The catalogus formaat wins: even with a date-only connection default, a
+    // datum_tijd eigenschap must be sent as YYYYMMDDHHMMSS (RX Mission rejects a
+    // bare date with a 400).
+    Config::set('zgw.connections.gemeente_1.eigenschap_date_format', 'Ymd');
+
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '2026-07-18', 'datum_tijd'))
+        ->toBe('20260718000000');
+});
+
+it('formats a datum eigenschap as an 8-char date', function () {
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('main', '2026-07-18T18:00:00', 'datum'))
+        ->toBe('20260718');
+});
+
+it('never date-formats a tekst eigenschap even when the connection sets a date format', function () {
+    // A tekst value that happens to parse as a date must not be mangled.
+    Config::set('zgw.connections.gemeente_1.eigenschap_date_format', 'Ymd');
+
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '20260702', 'tekst'))
+        ->toBe('20260702');
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '2026', 'tekst'))
+        ->toBe('2026');
+});
+
 it('falls back to the configured RSIN for bronorganisatie', function () {
     Config::set('zgw.connections.main.bronorganisatie_rsin', '820151130');
 

--- a/tests/Unit/Zgw/ZgwConnectionConfigTest.php
+++ b/tests/Unit/Zgw/ZgwConnectionConfigTest.php
@@ -5,47 +5,27 @@ use App\Enums\Role;
 use App\Services\Zgw\ZgwConnectionConfig;
 use Illuminate\Support\Facades\Config;
 
-it('keeps the eigenschap value unchanged when no date format is configured', function () {
-    Config::set('zgw.connections.main.eigenschap_date_format', null);
-
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('main', '2026-06-26'))->toBe('2026-06-26');
-});
-
-it('reformats a parseable date when an eigenschap date format is configured', function () {
-    Config::set('zgw.connections.main.eigenschap_date_format', 'YmdHis');
-
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('main', '2026-06-26 14:30:00'))->toBe('20260626143000');
-});
-
-it('leaves a non-date value unchanged even when a date format is configured', function () {
-    Config::set('zgw.connections.main.eigenschap_date_format', 'YmdHis');
-
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('main', 'ZAAK-2026-0001'))->toBe('ZAAK-2026-0001');
-});
-
-it('formats a datum_tijd eigenschap as a 14-char datetime regardless of the connection format', function () {
-    // The catalogus formaat wins: even with a date-only connection default, a
-    // datum_tijd eigenschap must be sent as YYYYMMDDHHMMSS (RX Mission rejects a
-    // bare date with a 400).
-    Config::set('zgw.connections.gemeente_1.eigenschap_date_format', 'Ymd');
-
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '2026-07-18', 'datum_tijd'))
-        ->toBe('20260718000000');
-});
-
 it('formats a datum eigenschap as an 8-char date', function () {
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('main', '2026-07-18T18:00:00', 'datum'))
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('2026-07-18T18:00:00', 'datum'))
         ->toBe('20260718');
 });
 
-it('never date-formats a tekst eigenschap even when the connection sets a date format', function () {
-    // A tekst value that happens to parse as a date must not be mangled.
-    Config::set('zgw.connections.gemeente_1.eigenschap_date_format', 'Ymd');
+it('formats a datum_tijd eigenschap as a 14-char datetime', function () {
+    // RX Mission rejects a bare date for a datum_tijd eigenschap with a 400.
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('2026-07-18', 'datum_tijd'))
+        ->toBe('20260718000000');
+});
 
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '20260702', 'tekst'))
-        ->toBe('20260702');
-    expect(ZgwConnectionConfig::formatEigenschapWaarde('gemeente_1', '2026', 'tekst'))
-        ->toBe('2026');
+it('leaves a tekst eigenschap unchanged even when it parses as a date', function () {
+    // A text value that happens to look like a date must never be mangled.
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('20260702', 'tekst'))->toBe('20260702');
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('2026', 'tekst'))->toBe('2026');
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('B', 'tekst'))->toBe('B');
+});
+
+it('leaves the value unchanged when the formaat is unknown or absent', function () {
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('2026-06-26'))->toBe('2026-06-26');
+    expect(ZgwConnectionConfig::formatEigenschapWaarde('ZAAK-2026-0001', 'getal'))->toBe('ZAAK-2026-0001');
 });
 
 it('falls back to the configured RSIN for bronorganisatie', function () {


### PR DESCRIPTION
## What

A series of fixes hardening ZGW document and zaakeigenschap handling, surfaced by staging Sentry alerts and reproduced locally against RX Mission connections. Each is an independent commit.

### 1. Crashing document uploads (EVENTLOKET-15)

`enkelvoudiginformatieobjecten()->store()` no longer returns a `uuid` under the new zgw-client (it only derives one for list items). Constructing the `Informatieobject` value object therefore threw `ArgumentCountError: Argument #1 ($uuid) not passed` **after** OpenZaak had already created the document (HTTP 201), orphaning a ~1.9 MB document on every queue retry.

This pattern existed at four call sites, not just the one that appeared in Sentry. All four now route the store response through `ZgwResource::ensureUuid()`:

- `app/Jobs/Submit/UploadSubmissionPdfToZGW.php`
- `app/Jobs/Submit/UploadFormBijlagenToZGW.php`
- `app/Jobs/Zaak/UploadDocumentsJob.php`
- `app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php`

### 2. Undiagnosable ZGW 400s in Sentry (EVENTLOKET-16, EVENTLOKET-13)

`ValidationException` keeps its response body off the exception message on purpose (possible PII), so Sentry only showed "ZGW API request failed validation [400]" with no field-level detail. A report callback in `bootstrap/app.php` now attaches the response status and body as a `zgw_response` Sentry context for any `ApiRequestException`, capped at 4000 characters. It runs before `Integration::handles()` and returns void so default reporting is unaffected.

### 3. Informatieobjecttypen given as an omschrijving instead of a URL (EVENTLOKET-12)

`Zaaktype::getDocumentTypes()` fed each `zaaktype-informatieobjecttypen` relation's `informatieobjecttype` value straight into `ZgwResource::byUrl()`. The ZGW Catalogi standard types that field as a string: OpenZaak returns a followable URL, but some backends (e.g. RX Mission) return the omschrijving inline (e.g. "Audit trail"). Passing that name to `byUrl()` reached the host allowlist with an unparseable value and threw `DisallowedHostException`, crashing document-type resolution and every job that depends on it.

Resolution now branches per relation: a value starting with `http` is followed as before; otherwise the omschrijving is resolved against the relation's catalogus via a new `ZgwResource::informatieobjecttypenByOmschrijving()` helper (version valid today wins on duplicates, catalogus listed once per resolution). Resolution stays soft: an unresolvable individual type is skipped and logged; registration still fails loudly when the specific type it needs is absent, via the existing `RuntimeException` guards in the upload jobs.

### 4. Null beschrijving on documents

`beschrijving` is optional in ZGW: OpenZaak returns an empty string, RX Mission returns null. The `Informatieobject` value object typed it as a non-nullable string, so building a document from an RX Mission store response threw `TypeError: Argument #10 ($beschrijving) must be of type string, null given` after the document had already been created. It is now `?string`; no consumer reads the field.

### 5. Zaakeigenschap datum_tijd format (EVENTLOKET-13)

`AddZaakeigenschappenZGW` formatted every eigenschap value with a single per-connection `eigenschap_date_format`. On the RX Mission connection that was `Ymd`, so a `datum_tijd` eigenschap (which RX Mission requires as `YYYYMMDDHHMMSS`, 14 chars) was sent as a bare 8-char date and rejected with a 400. The blanket format also corrupted `tekst` values that happened to parse as a date (a risk class "B" became today's date, since `Carbon::parse` falls back to now).

`formatEigenschapWaarde()` now takes the catalogus eigenschap's formaat and derives the wire format from it: `datum` -> `Ymd`, `datum_tijd` -> `YmdHis`, other formats untouched. The now-obsolete per-connection `eigenschap_date_format` setting is removed entirely (Filament field, translation, DB column via migration, model, config, and factory).

## Tests

- `UploadSubmissionPdfToZGWTest`: store response without a `uuid` and with a null `beschrijving`; the job completes and links the document.
- `ZgwSentryContextTest`: a `ValidationException` reported through the real handler attaches the body as `zgw_response`; non-ZGW exceptions do not.
- `DocumentTypesResolutionTest` + `InformatieobjecttypenByOmschrijvingTest`: URL regression, omschrijving resolution via the catalogus, memoization, skip-without-throw, the vertrouwelijkheid filter, and the valid-today winner.
- `InformatieobjectStatusTest`: constructing a document with a null `beschrijving` does not throw.
- `ZgwConnectionConfigTest`: datum/datum_tijd derive 8/14-char values regardless of the connection default, and tekst values are never date-formatted.

Pint and PHPStan clean on the changed `app/` files. Verified live against RX Mission: document-type resolution, the PDF upload, and the datum_tijd zaakeigenschappen all now succeed where they previously threw.