### PR TITLE
Handle zaaktypen-kanaal notifications with refresh, warnings and main fallback

### DIFF
--- a/app/Actions/OpenNotification/GetIncommingNotificationType.php
+++ b/app/Actions/OpenNotification/GetIncommingNotificationType.php
@@ -9,11 +9,10 @@ use Illuminate\Support\Facades\Log;
 /**
  * Check incoming notifications and dispatch correct handle event.
  *
- * De `CreateZaak`-tak is verwijderd — in de nieuwe Filament-flow maken
- * wij de zaak zelf aan bij submit, dus de OpenZaak-webhook die
- * OF-submissions triggerde is niet meer relevant. Status/besluit/
- * document-notificaties blijven wel werken omdat die ook bij onze
- * eigen zaken nog kunnen binnenkomen.
+ * The `CreateZaak` branch has been removed: in the Filament flow we create the
+ * zaak ourselves at submit, so the OpenZaak webhook that triggered Open Forms
+ * submissions is no longer relevant. Status/besluit/document notifications
+ * keep working because they can still arrive for our own zaken.
  */
 class GetIncommingNotificationType
 {
@@ -30,6 +29,11 @@ class GetIncommingNotificationType
             return OpenNotificationType::NewZaakDocument;
         } elseif (($data['actie'] === 'update' || $data['actie'] === 'partial_update') && $data['kanaal'] === 'documenten' && $data['resource'] === 'enkelvoudiginformatieobject') {
             return OpenNotificationType::UpdatedZaakDocument;
+        } elseif ($data['kanaal'] === 'zaaktypen') {
+            // Every resource on this channel (zaaktype and its child resources
+            // like statustype or resultaattype) carries the zaaktype version url
+            // as hoofdObject, so one case covers publish, change and destroy.
+            return OpenNotificationType::ZaaktypeChanged;
         }
 
         // TODO: Implement other notification types

--- a/app/Console/Commands/Zaaktypen/SyncZaaktypen.php
+++ b/app/Console/Commands/Zaaktypen/SyncZaaktypen.php
@@ -2,12 +2,13 @@
 
 namespace App\Console\Commands\Zaaktypen;
 
+use App\Enums\ZaaktypeRefreshStatus;
 use App\Enums\ZaaktypeRole;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\MunicipalityZgwConnection;
 use App\Models\Zaaktype;
-use App\Services\Zgw\MappedZaaktypeSync;
+use App\Services\Zgw\ZaaktypeRefresher;
 use App\Services\Zgw\ZgwConnectionResolver;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
@@ -33,7 +34,7 @@ class SyncZaaktypen extends Command
     /**
      * Execute the console command.
      */
-    public function handle(MappedZaaktypeSync $mappedSync)
+    public function handle(ZaaktypeRefresher $refresher)
     {
         $this->info('Syncing zaaktypen...');
 
@@ -48,7 +49,7 @@ class SyncZaaktypen extends Command
         // Municipalities with their own ZGW instance only get local rows for the
         // zaaktypen they actually use (their mappings), read one by one from their
         // own instance rather than importing the whole external catalogus.
-        $this->refreshOwnInstanceZaaktypen($mappedSync);
+        $this->refreshOwnInstanceZaaktypen($refresher);
 
         return Command::SUCCESS;
     }
@@ -200,12 +201,11 @@ class SyncZaaktypen extends Command
     /**
      * Targeted refresh of own-instance zaaktypen: for each municipality that runs
      * its own ZGW instance, refresh only the distinct identificaties it has mapped,
-     * reading each one from its own instance via {@see MappedZaaktypeSync}.
-     *
-     * Own-instance rows are not deactivated here: a stale-but-mapped doorkomst
-     * zaaktype must keep working, so removal is left to the beheerder unmapping it.
+     * reading each one from its own instance via {@see ZaaktypeRefresher}, so the
+     * sync engages the same fallback/restore transitions and warnings as the
+     * zaaktypen-kanaal webhook.
      */
-    private function refreshOwnInstanceZaaktypen(MappedZaaktypeSync $mappedSync): void
+    private function refreshOwnInstanceZaaktypen(ZaaktypeRefresher $refresher): void
     {
         $this->info('Refreshing own-instance zaaktypen...');
 
@@ -223,7 +223,9 @@ class SyncZaaktypen extends Command
                 ->pluck('zaaktype_identificatie');
 
             foreach ($identificaties as $identificatie) {
-                if ($mappedSync->ensure($municipality, $identificatie) !== null) {
+                $result = $refresher->refreshOwnInstance($municipality, $identificatie);
+
+                if ($result->status === ZaaktypeRefreshStatus::Refreshed) {
                     $this->line("  Gemeente {$municipality->id}: zaaktype {$identificatie} ververst.");
                 }
             }

--- a/app/Enums/BlueprintFindingType.php
+++ b/app/Enums/BlueprintFindingType.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum BlueprintFindingType: string
+{
+    /** The zaaktype version has no resource for this slot at all. */
+    case Missing = 'missing';
+
+    /** The koppeling names a value that no longer matches any catalogus resource. */
+    case MappedValueNotFound = 'mapped_value_not_found';
+}

--- a/app/Enums/OpenNotificationType.php
+++ b/app/Enums/OpenNotificationType.php
@@ -9,4 +9,5 @@ enum OpenNotificationType: string
     case ZaakStatusChanged = 'zaak_status_changed';
     case NewZaakDocument = 'new_zaak_document';
     case UpdatedZaakDocument = 'updated_zaak_document';
+    case ZaaktypeChanged = 'zaaktype_changed';
 }

--- a/app/Enums/ZaaktypeKoppelingIssue.php
+++ b/app/Enums/ZaaktypeKoppelingIssue.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ZaaktypeKoppelingIssue: string
+{
+    /** A mapped own-instance zaaktype has no valid definitief version anymore. */
+    case Unavailable = 'unavailable';
+
+    /** A previously unavailable zaaktype is valid again and back in use. */
+    case Restored = 'restored';
+
+    /** The current version misses blueprint prerequisites (warn-only). */
+    case BlueprintIncomplete = 'blueprint_incomplete';
+
+    /** A main-catalogus zaaktype has no valid definitief version anymore. */
+    case MainUnavailable = 'main_unavailable';
+}

--- a/app/Enums/ZaaktypeRefreshStatus.php
+++ b/app/Enums/ZaaktypeRefreshStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum ZaaktypeRefreshStatus: string
+{
+    /** A definitief version was found and the local row reflects it. */
+    case Refreshed = 'refreshed';
+
+    /** The catalogus read succeeded but no definitief version exists anymore. */
+    case Unavailable = 'unavailable';
+
+    /** The catalogus could not be read (or the sync does not apply); nothing changed. */
+    case Failed = 'failed';
+}

--- a/app/EventForm/Submit/ResolveZaaktype.php
+++ b/app/EventForm/Submit/ResolveZaaktype.php
@@ -9,6 +9,7 @@ use App\EventForm\State\FormState;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaaktype;
+use Illuminate\Database\Eloquent\Builder;
 use RuntimeException;
 
 /**
@@ -68,20 +69,35 @@ final class ResolveZaaktype
 
     private function resolveByRole(Municipality $municipality, ZaaktypeRole $role): ?Zaaktype
     {
-        return Zaaktype::query()
-            ->where('municipality_id', $municipality->id)
-            ->where('is_active', true)
-            ->where('role', $role->value)
-            ->first();
+        return $this->preferOwnConnection(
+            Zaaktype::query()
+                ->where('municipality_id', $municipality->id)
+                ->where('is_active', true)
+                ->where('role', $role->value),
+        )->first();
     }
 
     private function resolveByNamePrefix(Municipality $municipality, ZaaktypeRole $role): ?Zaaktype
     {
-        return Zaaktype::query()
-            ->where('municipality_id', $municipality->id)
-            ->where('is_active', true)
-            ->where('name', 'like', $role->namePrefix().'%')
-            ->first();
+        return $this->preferOwnConnection(
+            Zaaktype::query()
+                ->where('municipality_id', $municipality->id)
+                ->where('is_active', true)
+                ->where('name', 'like', $role->namePrefix().'%'),
+        )->first();
+    }
+
+    /**
+     * During a main-fallback both the (inactive) own-instance row and the linked
+     * main row can exist for a municipality; once the own row is active again it
+     * must win deterministically over the still-linked main fallback row.
+     *
+     * @param  Builder<Zaaktype>  $query
+     * @return Builder<Zaaktype>
+     */
+    private function preferOwnConnection(Builder $query): Builder
+    {
+        return $query->orderByRaw("case when connection = 'main' then 1 else 0 end");
     }
 
     private function resolveMunicipality(FormState $state): Municipality

--- a/app/EventForm/Submit/Steps/CreateZaakInZGW.php
+++ b/app/EventForm/Submit/Steps/CreateZaakInZGW.php
@@ -10,6 +10,7 @@ use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaaktype;
 use App\Services\Zgw\ZaakReadModel;
 use App\Services\Zgw\ZgwConnectionConfig;
+use App\Services\Zgw\ZgwConnectionResolver;
 use App\Services\Zgw\ZgwResource;
 use Carbon\Carbon;
 use Throwable;
@@ -61,7 +62,7 @@ final class CreateZaakInZGW
      */
     private function resolveVersionUrl(string $connectionName, Zaaktype $zaaktype, FormState $state): string
     {
-        $identificatie = $this->mappingIdentificatie($zaaktype, $state) ?? $zaaktype->identificatie;
+        $identificatie = $this->mappingIdentificatie($connectionName, $zaaktype, $state) ?? $zaaktype->identificatie;
 
         if (is_string($identificatie) && $identificatie !== '') {
             try {
@@ -86,11 +87,18 @@ final class CreateZaakInZGW
      * The connection-catalogus zaaktype identificatie from the blueprint mapping
      * for this municipality and aanvraag-type, or null when no mapping applies.
      */
-    private function mappingIdentificatie(Zaaktype $zaaktype, FormState $state): ?string
+    private function mappingIdentificatie(string $connectionName, Zaaktype $zaaktype, FormState $state): ?string
     {
         $municipality = $zaaktype->municipality;
 
         if ($municipality === null) {
+            return null;
+        }
+
+        // During a main-fallback the zaak is created on "main" while the mapping's
+        // identificatie belongs to the municipality's own catalogus; skip it so the
+        // local row's own (main-catalogus) identificatie resolves the version.
+        if ($municipality->zgwConnection !== null && $connectionName === ZgwConnectionResolver::DEFAULT_CONNECTION) {
             return null;
         }
 

--- a/app/Http/Requests/Api/OpenNotificationRequest.php
+++ b/app/Http/Requests/Api/OpenNotificationRequest.php
@@ -25,8 +25,10 @@ class OpenNotificationRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'actie' => 'required|string|in:create,update,delete,partial_update',
-            'kanaal' => 'required|string|in:zaken,objecten,documenten,besluiten,autorisaties',
+            // The Notificaties API standard uses "destroy" for deletions; "delete"
+            // is kept for tolerance towards non-standard senders.
+            'actie' => 'required|string|in:create,update,delete,partial_update,destroy',
+            'kanaal' => 'required|string|in:zaken,objecten,documenten,besluiten,autorisaties,zaaktypen',
             'resource' => 'required|string',
             'hoofdObject' => ['required', 'url', $this->zgwHostRule()],
             'resourceUrl' => ['required', 'url', $this->zgwHostRule()],

--- a/app/Jobs/ProcessOpenNotification.php
+++ b/app/Jobs/ProcessOpenNotification.php
@@ -22,6 +22,10 @@ class ProcessOpenNotification implements ShouldQueue
             OpenNotificationType::ZaakStatusChanged => ZaakStatusNotificationReceived::dispatch($this->notification),
             OpenNotificationType::NewZaakDocument => DocumentNotificationReceived::dispatch($this->notification, true)->delay(now()->addSeconds(10)), // delay because document needs to be linked to the zaak first
             OpenNotificationType::UpdatedZaakDocument => DocumentNotificationReceived::dispatch($this->notification, false)->delay(now()->addSeconds(10)),
+            // Delay so the burst of notifications a zaaktype publish fires
+            // (zaaktype update + child-resource creates, all sharing the same
+            // hoofdObject) collapses into the one unique job.
+            OpenNotificationType::ZaaktypeChanged => ZaaktypeNotificationReceived::dispatch($this->notification)->delay(now()->addSeconds(30)),
             default => null,
         };
     }

--- a/app/Jobs/ZaaktypeNotificationReceived.php
+++ b/app/Jobs/ZaaktypeNotificationReceived.php
@@ -1,0 +1,174 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Models\Municipality;
+use App\Models\MunicipalityZaaktypeMapping;
+use App\Models\Zaaktype;
+use App\Models\ZgwRequestLog;
+use App\Services\Zgw\ZaaktypeRefresher;
+use App\Services\Zgw\ZgwConnectionResolver;
+use App\Services\Zgw\ZgwResource;
+use App\ValueObjects\OpenNotification;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Woweb\Zgw\Exceptions\ApiRequestException;
+
+/**
+ * Handles a zaaktypen-kanaal notification by refreshing the local zaaktype row
+ * it concerns. The notification only carries the zaaktype version url
+ * (hoofdObject), so the identificatie is read from the catalogus; on a destroy
+ * the fetch 404s and the local rows are matched by url instead.
+ *
+ * Publishing a zaaktype fires a burst of notifications (the zaaktype update
+ * plus child-resource creates, all sharing the same hoofdObject). The dispatch
+ * delay in {@see ProcessOpenNotification} combined with ShouldBeUnique
+ * collapses that burst into a single refresh; the refresh itself is
+ * idempotent, so a late straggler after the unique window just no-ops.
+ */
+class ZaaktypeNotificationReceived implements ShouldBeUnique, ShouldQueue
+{
+    use Queueable;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    /** Safely exceeds the dispatch delay plus retries. */
+    public int $uniqueFor = 600;
+
+    public function __construct(private OpenNotification $notification) {}
+
+    public function uniqueId(): string
+    {
+        return 'zaaktype-notification:'.md5($this->notification->hoofdObject);
+    }
+
+    public function handle(ZaaktypeRefresher $refresher): void
+    {
+        // Zaaktype urls never match a zaak, so this is the unique-host index;
+        // ambiguous or unknown hosts resolve to main.
+        $connectionName = app(ZgwConnectionResolver::class)->forUrl($this->notification->hoofdObject);
+
+        $identificatie = $this->resolveIdentificatie($connectionName);
+
+        $municipalityId = ZgwRequestLog::municipalityIdFromConnection($connectionName);
+
+        if ($municipalityId === null) {
+            $this->refreshMain($refresher, $identificatie);
+
+            return;
+        }
+
+        $municipality = Municipality::find($municipalityId);
+
+        if ($municipality === null) {
+            Log::debug('Zaaktype notification for an unknown municipality ignored.', $this->context($connectionName, $identificatie));
+
+            return;
+        }
+
+        $this->refreshOwnInstance($refresher, $municipality, $connectionName, $identificatie);
+    }
+
+    /**
+     * The identificatie of the zaaktype the notification concerns: fetched from
+     * the catalogus, or matched against local rows when the version is already
+     * gone (destroy). Null when neither resolves.
+     */
+    private function resolveIdentificatie(string $connectionName): ?string
+    {
+        try {
+            $identificatie = ZgwResource::byUrl($connectionName, $this->notification->hoofdObject)['identificatie'] ?? null;
+
+            return is_string($identificatie) && $identificatie !== '' ? $identificatie : null;
+        } catch (Throwable $e) {
+            if (! $this->resourceIsGone($e)) {
+                // Transient error: rethrow for a retry; exhausting the retries
+                // surfaces through the failed-jobs channel.
+                throw $e;
+            }
+        }
+
+        return Zaaktype::query()
+            ->where('connection', $connectionName)
+            ->where('zgw_zaaktype_url', $this->notification->hoofdObject)
+            ->value('identificatie');
+    }
+
+    private function refreshMain(ZaaktypeRefresher $refresher, ?string $identificatie): void
+    {
+        if ($identificatie === null) {
+            // A destroyed version we never referenced: nothing to refresh.
+            Log::debug('Zaaktype notification without a resolvable identificatie ignored.', $this->context(ZgwConnectionResolver::DEFAULT_CONNECTION, null));
+
+            return;
+        }
+
+        $refresher->refreshMain($identificatie);
+    }
+
+    private function refreshOwnInstance(ZaaktypeRefresher $refresher, Municipality $municipality, string $connectionName, ?string $identificatie): void
+    {
+        $mapped = MunicipalityZaaktypeMapping::query()
+            ->where('municipality_id', $municipality->id)
+            ->whereNotNull('zaaktype_identificatie')
+            ->distinct()
+            ->pluck('zaaktype_identificatie');
+
+        if ($identificatie !== null) {
+            // Only mapped zaaktypen can carry aanvragen; the rest of an external
+            // catalogus is none of our concern (mirrors MappedZaaktypeSync).
+            if (! $mapped->contains($identificatie)) {
+                Log::debug('Zaaktype notification for an unmapped identificatie ignored.', $this->context($connectionName, $identificatie));
+
+                return;
+            }
+
+            $refresher->refreshOwnInstance($municipality, $identificatie);
+
+            return;
+        }
+
+        // A destroy without a local url match may still have hit the mapped
+        // zaaktype's latest version; re-verify every mapped identificatie.
+        foreach ($mapped as $mappedIdentificatie) {
+            $refresher->refreshOwnInstance($municipality, $mappedIdentificatie);
+        }
+    }
+
+    /**
+     * Whether the exception means the resource no longer exists (destroy), as
+     * opposed to a transient transport or server error.
+     */
+    private function resourceIsGone(Throwable $e): bool
+    {
+        $status = match (true) {
+            $e instanceof ApiRequestException => $e->getResponse()->status(),
+            $e instanceof RequestException => $e->response->status(),
+            default => null,
+        };
+
+        return in_array($status, [404, 410], true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function context(string $connectionName, ?string $identificatie): array
+    {
+        return [
+            'connection' => $connectionName,
+            'identificatie' => $identificatie,
+            'actie' => $this->notification->actie,
+            'resource' => $this->notification->resource,
+            'url' => $this->notification->hoofdObject,
+        ];
+    }
+}

--- a/app/Models/Zaaktype.php
+++ b/app/Models/Zaaktype.php
@@ -64,12 +64,12 @@ class Zaaktype extends Model
     /**
      * The ZGW connection name to use for calls about this zaaktype.
      *
-     * Resolved by municipality, which also registers the per-municipality
-     * connection's runtime config. Because per-instance sync attributes a
-     * zaaktype to the municipality whose instance hosts it (see the `connection`
-     * column, used for sync scoping and admin display), this resolves to the same
-     * instance that owns the zaaktype URL, so catalogus reads and zaak creation
-     * stay on that instance, including the main fallback for shared zaaktypen.
+     * The resolver honours the row's `connection` column: a main-catalogus row
+     * always resolves to main (also while linked to an own-instance municipality
+     * as a fallback), and own-instance rows resolve via their municipality,
+     * which also registers the per-municipality connection's runtime config. So
+     * catalogus reads and zaak creation stay on the instance that owns the
+     * zaaktype URL.
      */
     public function zgwConnectionName(): string
     {

--- a/app/Notifications/ZaaktypeKoppelingWarning.php
+++ b/app/Notifications/ZaaktypeKoppelingWarning.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Notifications;
+
+use App\Enums\BlueprintFindingType;
+use App\Enums\Role;
+use App\Enums\ZaaktypeKoppelingIssue;
+use App\Models\Municipality;
+use App\Models\User;
+use App\Models\Zaaktype;
+use App\ValueObjects\ZGW\BlueprintFinding;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Messages\MailMessage;
+
+/**
+ * Warns platform admins and the municipality's koppeling-beheerders about a
+ * zaaktype-koppeling problem detected from a ZGW zaaktypen notification (or a
+ * targeted sync): no valid definitief version anymore (with or without a main
+ * fallback), a restore, missing blueprint prerequisites on a new version, or
+ * an unavailable main-catalogus zaaktype.
+ */
+class ZaaktypeKoppelingWarning extends BaseNotification
+{
+    /**
+     * @param  list<BlueprintFinding>  $findings
+     * @param  string|null  $fallbackZaaktypeName  The linked main fallback for Unavailable; null means no fallback was found and new aanvragen for this role will fail.
+     */
+    public function __construct(
+        protected Zaaktype $zaaktype,
+        protected ZaaktypeKoppelingIssue $issue,
+        protected ?Municipality $municipality = null,
+        protected array $findings = [],
+        protected ?string $fallbackZaaktypeName = null,
+    ) {}
+
+    public static function getLabel(): string|Htmlable|null
+    {
+        return __('notification/zaaktype-koppeling-warning.label');
+    }
+
+    public function toMail(User $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__("notification/zaaktype-koppeling-warning.mail.subject.{$this->issue->value}", [
+                'zaaktype' => $this->zaaktype->name,
+            ]))
+            ->markdown('mail.zaaktype-koppeling-warning', [
+                'issue' => $this->issue->value,
+                'body' => $this->body(),
+                'findingLines' => $this->findingLines(),
+                'viewUrl' => $this->getViewUrl($notifiable),
+            ]);
+    }
+
+    public function toDatabase(User $notifiable): array
+    {
+        $notification = FilamentNotification::make()
+            ->title(__("notification/zaaktype-koppeling-warning.database.title.{$this->issue->value}", [
+                'zaaktype' => $this->zaaktype->name,
+            ]))
+            ->body(implode("\n", [$this->body(), ...$this->findingLines()]))
+            ->actions([
+                Action::make('view')
+                    ->label(__('View'))
+                    ->url($this->getViewUrl($notifiable))
+                    ->markAsRead(),
+            ]);
+
+        match ($this->issue) {
+            ZaaktypeKoppelingIssue::Restored => $notification->success(),
+            ZaaktypeKoppelingIssue::BlueprintIncomplete => $notification->warning(),
+            default => $notification->danger(),
+        };
+
+        return $notification->getDatabaseMessage();
+    }
+
+    public function logSubject(): Model
+    {
+        return $this->zaaktype;
+    }
+
+    private function body(): string
+    {
+        $municipalityName = $this->municipality->name ?? '';
+
+        $body = __("notification/zaaktype-koppeling-warning.body.{$this->issue->value}", [
+            'zaaktype' => $this->zaaktype->name,
+            'municipality' => $municipalityName,
+        ]);
+
+        if ($this->issue === ZaaktypeKoppelingIssue::Unavailable) {
+            $body .= ' '.($this->fallbackZaaktypeName !== null
+                ? __('notification/zaaktype-koppeling-warning.body.fallback_active', ['fallback' => $this->fallbackZaaktypeName])
+                : __('notification/zaaktype-koppeling-warning.body.fallback_missing'));
+        }
+
+        return $body;
+    }
+
+    /**
+     * Human-readable line per blueprint finding.
+     *
+     * @return list<string>
+     */
+    private function findingLines(): array
+    {
+        return array_map(function (BlueprintFinding $finding): string {
+            $slot = str_starts_with($finding->slot, 'eigenschap:')
+                ? __('notification/zaaktype-koppeling-warning.slot.eigenschap', ['key' => substr($finding->slot, strlen('eigenschap:'))])
+                : __("notification/zaaktype-koppeling-warning.slot.{$finding->slot}");
+
+            return $finding->type === BlueprintFindingType::Missing
+                ? __('notification/zaaktype-koppeling-warning.finding.missing', ['slot' => $slot])
+                : __('notification/zaaktype-koppeling-warning.finding.mapped_value_not_found', ['slot' => $slot, 'expected' => $finding->expected]);
+        }, $this->findings);
+    }
+
+    private function getViewUrl(User $notifiable): string
+    {
+        if ($notifiable->role === Role::Admin || $this->municipality === null) {
+            return route('filament.admin.resources.zaaktypes.index');
+        }
+
+        return route('filament.municipality.settings.resources.municipality-zaaktype-mappings.index', [
+            'tenant' => $this->municipality->id,
+        ]);
+    }
+}

--- a/app/Observers/MunicipalityZaaktypeMappingObserver.php
+++ b/app/Observers/MunicipalityZaaktypeMappingObserver.php
@@ -5,17 +5,19 @@ declare(strict_types=1);
 namespace App\Observers;
 
 use App\Models\MunicipalityZaaktypeMapping;
-use App\Services\Zgw\MappedZaaktypeSync;
+use App\Services\Zgw\ZaaktypeRefresher;
 
 /**
  * When a municipality that runs its own ZGW instance saves a zaaktype-koppeling,
- * ensure the matching local Zaaktype row exists right away instead of waiting for
- * the next scheduled sync. Municipalities on the shared main connection are linked
- * by name in SyncZaaktypen, so nothing is created here for them.
+ * refresh the matching local Zaaktype row right away instead of waiting for the
+ * next sync. Going through the refresher means a corrected koppeling immediately
+ * restores a fallback (or raises a fresh warning when still broken).
+ * Municipalities on the shared main connection are linked by name in
+ * SyncZaaktypen, so nothing is created here for them.
  */
 class MunicipalityZaaktypeMappingObserver
 {
-    public function __construct(private readonly MappedZaaktypeSync $sync) {}
+    public function __construct(private readonly ZaaktypeRefresher $refresher) {}
 
     public function saved(MunicipalityZaaktypeMapping $mapping): void
     {
@@ -29,6 +31,6 @@ class MunicipalityZaaktypeMappingObserver
             return;
         }
 
-        $this->sync->ensure($municipality, $mapping->zaaktype_identificatie);
+        $this->refresher->refreshOwnInstance($municipality, $mapping->zaaktype_identificatie);
     }
 }

--- a/app/Services/Zgw/MappedZaaktypeSync.php
+++ b/app/Services/Zgw/MappedZaaktypeSync.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace App\Services\Zgw;
 
+use App\Enums\ZaaktypeRefreshStatus;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaaktype;
+use App\ValueObjects\ZGW\ZaaktypeRefreshResult;
 use Illuminate\Support\Facades\Log;
 use Throwable;
-use Woweb\Zgw\Facades\Zgw;
 
 /**
  * Creates or refreshes the single local {@see Zaaktype} row a municipality needs
@@ -32,8 +33,26 @@ final class MappedZaaktypeSync
      */
     public function ensure(Municipality $municipality, string $identificatie): ?Zaaktype
     {
+        $result = $this->refresh($municipality, $identificatie);
+
+        return $result->status === ZaaktypeRefreshStatus::Refreshed ? $result->zaaktype : null;
+    }
+
+    /**
+     * Refresh the local row for (municipality, identificatie) and report what
+     * happened, distinguishing the outcomes {@see ensure()} conflates:
+     *
+     * - Refreshed: a definitief version exists; the row was created or updated.
+     * - Unavailable: the catalogus answered but no definitief version exists
+     *   anymore; an existing row is deactivated so it stops resolving at submit.
+     * - Failed: the catalogus could not be read, or this sync does not apply
+     *   (no own connection). Nothing changes: a transient outage must not flip
+     *   routing or trigger a fallback.
+     */
+    public function refresh(Municipality $municipality, string $identificatie): ZaaktypeRefreshResult
+    {
         if ($identificatie === '') {
-            return null;
+            return new ZaaktypeRefreshResult(ZaaktypeRefreshStatus::Failed);
         }
 
         // Resolving registers the per-municipality connection config. This is a
@@ -44,11 +63,11 @@ final class MappedZaaktypeSync
         $connectionName = $this->resolver->forManagement($municipality);
 
         if ($connectionName === ZgwConnectionResolver::DEFAULT_CONNECTION) {
-            return null;
+            return new ZaaktypeRefreshResult(ZaaktypeRefreshStatus::Failed);
         }
 
         try {
-            $version = $this->definitiefVersion($connectionName, $identificatie);
+            $version = ZaaktypeVersion::currentDefinitief($connectionName, $identificatie);
         } catch (Throwable $e) {
             Log::warning('MappedZaaktypeSync: kon zaaktype niet ophalen', [
                 'municipality_id' => $municipality->id,
@@ -57,13 +76,51 @@ final class MappedZaaktypeSync
                 'exception' => $e->getMessage(),
             ]);
 
-            return null;
+            return new ZaaktypeRefreshResult(ZaaktypeRefreshStatus::Failed);
         }
 
         if ($version === null) {
-            return null;
+            return $this->deactivate($connectionName, $identificatie);
         }
 
+        return $this->upsert($municipality, $connectionName, $identificatie, $version);
+    }
+
+    /**
+     * No definitief version exists anymore: deactivate the local row so
+     * ResolveZaaktype stops matching it. The row itself is kept (existing zaken
+     * reference it and it revives on the next successful refresh).
+     */
+    private function deactivate(string $connectionName, string $identificatie): ZaaktypeRefreshResult
+    {
+        $zaaktype = Zaaktype::query()
+            ->where('identificatie', $identificatie)
+            ->where('connection', $connectionName)
+            ->first();
+
+        if ($zaaktype === null) {
+            return new ZaaktypeRefreshResult(ZaaktypeRefreshStatus::Unavailable);
+        }
+
+        $becameInactive = $zaaktype->is_active;
+
+        if ($becameInactive) {
+            $zaaktype->is_active = false;
+            $zaaktype->save();
+        }
+
+        return new ZaaktypeRefreshResult(
+            ZaaktypeRefreshStatus::Unavailable,
+            $zaaktype,
+            becameInactive: $becameInactive,
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $version
+     */
+    private function upsert(Municipality $municipality, string $connectionName, string $identificatie, array $version): ZaaktypeRefreshResult
+    {
         $role = MunicipalityZaaktypeMapping::query()
             ->where('municipality_id', $municipality->id)
             ->where('zaaktype_identificatie', $identificatie)
@@ -77,6 +134,9 @@ final class MappedZaaktypeSync
                 'is_active' => true,
             ],
         );
+
+        $urlChanged = $zaaktype->wasRecentlyCreated || $zaaktype->wasChanged('zgw_zaaktype_url');
+        $becameActive = ! $zaaktype->wasRecentlyCreated && $zaaktype->wasChanged('is_active');
 
         // municipality_id is guarded from mass assignment and the role comes from
         // the mapping, so both are set explicitly.
@@ -96,32 +156,11 @@ final class MappedZaaktypeSync
             $zaaktype->save();
         }
 
-        return $zaaktype;
-    }
-
-    /**
-     * The current definitief version of an identificatie: the one valid today,
-     * falling back to any definitief version. Mirrors the resolution used by
-     * {@see ZaaktypeCatalogusOptions}.
-     *
-     * @return array<string, mixed>|null
-     */
-    private function definitiefVersion(string $connectionName, string $identificatie): ?array
-    {
-        $version = Zgw::connection($connectionName)->catalogi()->zaaktypen()->index([
-            'identificatie' => $identificatie,
-            'status' => 'definitief',
-            'datumGeldigheid' => now('Europe/Amsterdam')->toDateString(),
-        ])->first()
-            ?? Zgw::connection($connectionName)->catalogi()->zaaktypen()->index([
-                'identificatie' => $identificatie,
-                'status' => 'definitief',
-            ])->first();
-
-        if (! is_array($version) || ! is_string($version['url'] ?? null) || $version['url'] === '') {
-            return null;
-        }
-
-        return $version;
+        return new ZaaktypeRefreshResult(
+            ZaaktypeRefreshStatus::Refreshed,
+            $zaaktype,
+            urlChanged: $urlChanged,
+            becameActive: $becameActive,
+        );
     }
 }

--- a/app/Services/Zgw/ZaaktypeBlueprintHealth.php
+++ b/app/Services/Zgw/ZaaktypeBlueprintHealth.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Services\Zgw;
 
 use App\Enums\BlueprintFindingType;
+use App\Livewire\ConnectionVerifier;
 use App\Models\MunicipalityZaaktypeMapping;
+use App\Models\Zaaktype;
 use App\ValueObjects\ZGW\BlueprintFinding;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Log;
@@ -24,7 +26,7 @@ use Woweb\Zgw\Facades\Zgw;
  * data). Transport errors skip the affected checks with a warning instead of
  * producing findings: a flaky read must not raise false alarms.
  *
- * Reuse hooks: the {@see \App\Livewire\ConnectionVerifier} modal and the
+ * Reuse hooks: the {@see ConnectionVerifier} modal and the
  * koppeling form could surface these findings interactively as well.
  */
 final class ZaaktypeBlueprintHealth
@@ -217,7 +219,7 @@ final class ZaaktypeBlueprintHealth
     /**
      * The omschrijvingen of the informatieobjecttypen linked to the version,
      * resolved through the standard zaaktype-informatieobjecttypen relation
-     * (mirrors {@see \App\Models\Zaaktype::getDocumentTypes()} and
+     * (mirrors {@see Zaaktype::getDocumentTypes()} and
      * {@see ZaaktypeCatalogusOptions::informatieobjecttypen()}).
      *
      * @return Collection<int, string>|null

--- a/app/Services/Zgw/ZaaktypeBlueprintHealth.php
+++ b/app/Services/Zgw/ZaaktypeBlueprintHealth.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\Enums\BlueprintFindingType;
+use App\Models\MunicipalityZaaktypeMapping;
+use App\ValueObjects\ZGW\BlueprintFinding;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+use Woweb\Zgw\Facades\Zgw;
+
+/**
+ * Checks a zaaktype's current definitief version against the blueprint
+ * prerequisites Eventloket relies on (zgw-koppelingbeheer.md, section 4.4):
+ * begin- and eindstatus, an initiator roltype, an "Ingetrokken" resultaattype,
+ * informatieobjecttypen for the aanvraag-PDF and bijlagen, every eigenschap the
+ * koppeling maps, and the intern_zaaknummer eigenschap the zaak flow requires.
+ *
+ * Child lists are read directly against the version url (not through the
+ * cached {@see ZaaktypeCatalogusOptions}, which may still hold pre-publish
+ * data). Transport errors skip the affected checks with a warning instead of
+ * producing findings: a flaky read must not raise false alarms.
+ *
+ * Reuse hooks: the {@see \App\Livewire\ConnectionVerifier} modal and the
+ * koppeling form could surface these findings interactively as well.
+ */
+final class ZaaktypeBlueprintHealth
+{
+    /**
+     * @return list<BlueprintFinding>
+     */
+    public function check(string $connectionName, string $identificatie, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        try {
+            $version = ZaaktypeVersion::currentDefinitief($connectionName, $identificatie);
+        } catch (Throwable $e) {
+            $this->logSkip('zaaktype version', $connectionName, $identificatie, $e);
+
+            return [];
+        }
+
+        if ($version === null) {
+            // Unavailability is a routing concern handled by the refresher, not
+            // a blueprint finding.
+            return [];
+        }
+
+        $url = $version['url'];
+
+        return [
+            ...$this->checkStatustypen($connectionName, $identificatie, $url, $mapping),
+            ...$this->checkRoltypen($connectionName, $identificatie, $url, $mapping),
+            ...$this->checkResultaattypen($connectionName, $identificatie, $url, $mapping),
+            ...$this->checkInformatieobjecttypen($connectionName, $identificatie, $url, $mapping),
+            ...$this->checkEigenschappen($connectionName, $identificatie, $url, $mapping),
+        ];
+    }
+
+    /**
+     * @return list<BlueprintFinding>
+     */
+    private function checkStatustypen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        $statustypen = $this->index($connectionName, $identificatie, 'statustypen', $url);
+
+        if ($statustypen === null) {
+            return [];
+        }
+
+        $findings = [];
+
+        if (ZaaktypeBlueprint::initialStatustype($mapping, $statustypen) === null) {
+            $findings[] = new BlueprintFinding('initial_statustype', BlueprintFindingType::Missing);
+        } elseif ($mapping?->initial_statustype && $statustypen->firstWhere('omschrijving', $mapping->initial_statustype) === null) {
+            $findings[] = new BlueprintFinding('initial_statustype', BlueprintFindingType::MappedValueNotFound, $mapping->initial_statustype);
+        }
+
+        if (ZaaktypeBlueprint::eindStatustype($mapping, $statustypen) === null) {
+            $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::Missing);
+        } elseif ($mapping?->eind_statustype && $statustypen->firstWhere('omschrijving', $mapping->eind_statustype) === null) {
+            $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::MappedValueNotFound, $mapping->eind_statustype);
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return list<BlueprintFinding>
+     */
+    private function checkRoltypen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        $roltypen = $this->index($connectionName, $identificatie, 'roltypen', $url);
+
+        if ($roltypen === null) {
+            return [];
+        }
+
+        if (ZaaktypeBlueprint::initiatorRoltype($mapping, $roltypen) === null) {
+            return [new BlueprintFinding('initiator_roltype', BlueprintFindingType::Missing)];
+        }
+
+        $mapped = $mapping?->initiator_roltype;
+
+        if ($mapped && $roltypen->first(fn ($r) => ($r['omschrijving'] ?? null) === $mapped || ($r['omschrijvingGeneriek'] ?? null) === $mapped) === null) {
+            return [new BlueprintFinding('initiator_roltype', BlueprintFindingType::MappedValueNotFound, $mapped)];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<BlueprintFinding>
+     */
+    private function checkResultaattypen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        $resultaattypen = $this->index($connectionName, $identificatie, 'resultaattypen', $url);
+
+        if ($resultaattypen === null) {
+            return [];
+        }
+
+        if (ZaaktypeBlueprint::ingetrokkenResultaattype($mapping, $resultaattypen) === null) {
+            return [new BlueprintFinding('ingetrokken_resultaattype', BlueprintFindingType::Missing)];
+        }
+
+        $mapped = $mapping?->ingetrokken_resultaattype;
+
+        if ($mapped && $resultaattypen->first(fn ($r) => ($r['omschrijving'] ?? null) === $mapped || ($r['omschrijvingGeneriek'] ?? null) === $mapped) === null) {
+            return [new BlueprintFinding('ingetrokken_resultaattype', BlueprintFindingType::MappedValueNotFound, $mapped)];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<BlueprintFinding>
+     */
+    private function checkInformatieobjecttypen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        $omschrijvingen = $this->informatieobjecttypeOmschrijvingen($connectionName, $identificatie, $url);
+
+        if ($omschrijvingen === null) {
+            return [];
+        }
+
+        if ($omschrijvingen->isEmpty()) {
+            return [
+                new BlueprintFinding('aanvraag_informatieobjecttype', BlueprintFindingType::Missing),
+                new BlueprintFinding('bijlage_informatieobjecttype', BlueprintFindingType::Missing),
+            ];
+        }
+
+        $findings = [];
+
+        if ($mapping?->aanvraag_informatieobjecttype && ! $omschrijvingen->contains($mapping->aanvraag_informatieobjecttype)) {
+            $findings[] = new BlueprintFinding('aanvraag_informatieobjecttype', BlueprintFindingType::MappedValueNotFound, $mapping->aanvraag_informatieobjecttype);
+        }
+
+        if ($mapping?->bijlage_informatieobjecttype && ! $omschrijvingen->contains($mapping->bijlage_informatieobjecttype)) {
+            $findings[] = new BlueprintFinding('bijlage_informatieobjecttype', BlueprintFindingType::MappedValueNotFound, $mapping->bijlage_informatieobjecttype);
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @return list<BlueprintFinding>
+     */
+    private function checkEigenschappen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
+    {
+        $eigenschappen = $this->index($connectionName, $identificatie, 'eigenschappen', $url);
+
+        if ($eigenschappen === null) {
+            return [];
+        }
+
+        $namen = $eigenschappen->pluck('naam')->filter()->values();
+        $findings = [];
+
+        foreach ($mapping->eigenschap_map ?? [] as $logicalKey => $naam) {
+            if (is_string($naam) && $naam !== '' && ! $namen->contains($naam)) {
+                $findings[] = new BlueprintFinding("eigenschap:{$logicalKey}", BlueprintFindingType::MappedValueNotFound, $naam);
+            }
+        }
+
+        // The zaak flow always writes the internal zaaknummer eigenschap
+        // (see SyncZaaktypeEigenschappen and AddZaakeigenschappenZGW).
+        $internZaaknummer = ZaaktypeBlueprint::eigenschapNaam($mapping, 'intern_zaaknummer');
+
+        if (! $namen->contains($internZaaknummer)) {
+            $findings[] = new BlueprintFinding('eigenschap:intern_zaaknummer', BlueprintFindingType::Missing);
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Read a catalogus child list for the version url. Null means the read
+     * failed and the caller must skip its checks.
+     *
+     * @return Collection<int, array<string, mixed>>|null
+     */
+    private function index(string $connectionName, string $identificatie, string $resource, string $url): ?Collection
+    {
+        try {
+            return Zgw::connection($connectionName)->catalogi()->{$resource}()->index(['zaaktype' => $url])->collect();
+        } catch (Throwable $e) {
+            $this->logSkip($resource, $connectionName, $identificatie, $e);
+
+            return null;
+        }
+    }
+
+    /**
+     * The omschrijvingen of the informatieobjecttypen linked to the version,
+     * resolved through the standard zaaktype-informatieobjecttypen relation
+     * (mirrors {@see \App\Models\Zaaktype::getDocumentTypes()} and
+     * {@see ZaaktypeCatalogusOptions::informatieobjecttypen()}).
+     *
+     * @return Collection<int, string>|null
+     */
+    private function informatieobjecttypeOmschrijvingen(string $connectionName, string $identificatie, string $url): ?Collection
+    {
+        $relations = $this->index($connectionName, $identificatie, 'zaaktypeInformatieobjecttypen', $url);
+
+        if ($relations === null) {
+            return null;
+        }
+
+        $omschrijvingen = collect();
+
+        foreach ($relations as $relation) {
+            $value = $relation['informatieobjecttype'] ?? null;
+
+            if (! is_string($value) || $value === '') {
+                continue;
+            }
+
+            // OpenZaak returns a URL to the informatieobjecttype; RX Mission
+            // returns the omschrijving inline.
+            if (str_starts_with($value, 'http')) {
+                try {
+                    $value = ZgwResource::byUrl($connectionName, $value)['omschrijving'] ?? null;
+                } catch (Throwable $e) {
+                    $this->logSkip('informatieobjecttype', $connectionName, $identificatie, $e);
+
+                    continue;
+                }
+            }
+
+            if (is_string($value) && $value !== '') {
+                $omschrijvingen->push($value);
+            }
+        }
+
+        return $omschrijvingen;
+    }
+
+    private function logSkip(string $resource, string $connectionName, string $identificatie, Throwable $e): void
+    {
+        Log::warning('ZaaktypeBlueprintHealth: skipped a check because the catalogus read failed.', [
+            'resource' => $resource,
+            'connection' => $connectionName,
+            'identificatie' => $identificatie,
+            'exception' => $e->getMessage(),
+        ]);
+    }
+}

--- a/app/Services/Zgw/ZaaktypeMainFallback.php
+++ b/app/Services/Zgw/ZaaktypeMainFallback.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\Models\Municipality;
+use App\Models\Zaaktype;
+
+/**
+ * Activates the per-zaaktype fallback to the main connection: when a mapped
+ * own-instance zaaktype has no valid definitief version anymore, the matching
+ * main-catalogus zaaktype is linked to the municipality so
+ * {@see \App\EventForm\Submit\ResolveZaaktype} finds it by role and new zaken
+ * are created on main.
+ *
+ * Invariant this creates: a main row linked to a municipality with an own ZGW
+ * connection is an (active or historical) fallback. That link is never removed
+ * on restore, because zaken created during the fallback window derive their
+ * municipality through the zaaktype row ({@see \App\Models\Zaak::municipality()});
+ * the revived own-instance row simply wins again through the resolve ordering.
+ * {@see \App\Console\Commands\Zaaktypen\SyncZaaktypen} preserves the link too:
+ * it skips own-instance municipalities when linking and only unlinks inactive
+ * rows. Connection resolution stays correct because the resolver honours the
+ * row's `connection` column.
+ */
+final class ZaaktypeMainFallback
+{
+    /**
+     * Link the matching active main-catalogus zaaktype (same role, name ending
+     * in "gemeente {name}") to the municipality. Returns the linked row, or
+     * null when the main catalogus has no candidate for this role.
+     */
+    public function activate(Municipality $municipality, Zaaktype $ownZaaktype): ?Zaaktype
+    {
+        if ($ownZaaktype->role === null) {
+            return null;
+        }
+
+        $candidates = Zaaktype::query()
+            ->where('connection', ZgwConnectionResolver::DEFAULT_CONNECTION)
+            ->where('is_active', true)
+            ->where('role', $ownZaaktype->role->value)
+            ->where(function ($query) use ($municipality) {
+                // A main row may already be linked to this municipality from
+                // before it switched to its own instance (legacy links survive).
+                $query->whereNull('municipality_id')->orWhere('municipality_id', $municipality->id);
+            })
+            ->get();
+
+        // Match on the exact municipality-name suffix (the same convention
+        // SyncZaaktypen::syncMunicipalityLinks parses), not on LIKE: a prefix
+        // match would conflate "Sittard" and "Sittard-Geleen".
+        $fallback = $candidates->first(function (Zaaktype $candidate) use ($municipality) {
+            if (! preg_match('/\bgemeente\s+(.+)$/iu', $candidate->name, $matches)) {
+                return false;
+            }
+
+            return strtolower(trim($matches[1])) === strtolower($municipality->name);
+        });
+
+        if ($fallback === null) {
+            return null;
+        }
+
+        if ($fallback->municipality_id !== $municipality->id) {
+            $fallback->municipality_id = $municipality->id;
+            $fallback->save();
+        }
+
+        return $fallback;
+    }
+}

--- a/app/Services/Zgw/ZaaktypeMainFallback.php
+++ b/app/Services/Zgw/ZaaktypeMainFallback.php
@@ -4,22 +4,25 @@ declare(strict_types=1);
 
 namespace App\Services\Zgw;
 
+use App\Console\Commands\Zaaktypen\SyncZaaktypen;
+use App\EventForm\Submit\ResolveZaaktype;
 use App\Models\Municipality;
+use App\Models\Zaak;
 use App\Models\Zaaktype;
 
 /**
  * Activates the per-zaaktype fallback to the main connection: when a mapped
  * own-instance zaaktype has no valid definitief version anymore, the matching
  * main-catalogus zaaktype is linked to the municipality so
- * {@see \App\EventForm\Submit\ResolveZaaktype} finds it by role and new zaken
+ * {@see ResolveZaaktype} finds it by role and new zaken
  * are created on main.
  *
  * Invariant this creates: a main row linked to a municipality with an own ZGW
  * connection is an (active or historical) fallback. That link is never removed
  * on restore, because zaken created during the fallback window derive their
- * municipality through the zaaktype row ({@see \App\Models\Zaak::municipality()});
+ * municipality through the zaaktype row ({@see Zaak::municipality()});
  * the revived own-instance row simply wins again through the resolve ordering.
- * {@see \App\Console\Commands\Zaaktypen\SyncZaaktypen} preserves the link too:
+ * {@see SyncZaaktypen} preserves the link too:
  * it skips own-instance municipalities when linking and only unlinks inactive
  * rows. Connection resolution stays correct because the resolver honours the
  * row's `connection` column.

--- a/app/Services/Zgw/ZaaktypeRefresher.php
+++ b/app/Services/Zgw/ZaaktypeRefresher.php
@@ -1,0 +1,274 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\Enums\ZaaktypeKoppelingIssue;
+use App\Enums\ZaaktypeRefreshStatus;
+use App\Models\Municipality;
+use App\Models\MunicipalityZaaktypeMapping;
+use App\Models\User;
+use App\Models\Users\AdminUser;
+use App\Models\Zaaktype;
+use App\Notifications\ZaaktypeKoppelingWarning;
+use App\ValueObjects\ZGW\BlueprintFinding;
+use App\ValueObjects\ZGW\ZaaktypeRefreshResult;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Notification;
+use Throwable;
+
+/**
+ * Orchestrates a targeted zaaktype refresh: syncs the local row, engages or
+ * logs the main fallback on availability transitions, clears the caches a
+ * version bump invalidates, runs the blueprint health check, and warns the
+ * platform admins plus the municipality's koppeling-beheerders.
+ *
+ * Used by the zaaktypen-kanaal webhook, the koppeling observer, and the
+ * app:sync-zaaktypen command, so every refresh path shares the same
+ * transition detection and (transition-gated or throttled) notifications.
+ */
+final class ZaaktypeRefresher
+{
+    public function __construct(
+        private readonly MappedZaaktypeSync $mappedSync,
+        private readonly ZaaktypeMainFallback $fallback,
+        private readonly ZaaktypeBlueprintHealth $health,
+        private readonly ZgwConnectionResolver $resolver,
+    ) {}
+
+    /**
+     * Refresh a mapped zaaktype of a municipality with its own ZGW instance.
+     */
+    public function refreshOwnInstance(Municipality $municipality, string $identificatie): ZaaktypeRefreshResult
+    {
+        $result = $this->mappedSync->refresh($municipality, $identificatie);
+        $connectionName = $this->resolver->forManagement($municipality);
+
+        $context = [
+            'connection' => $connectionName,
+            'municipality_id' => $municipality->id,
+            'identificatie' => $identificatie,
+        ];
+
+        if ($result->status === ZaaktypeRefreshStatus::Failed) {
+            // Already logged by MappedZaaktypeSync; a transient failure must not
+            // flip routing or notify anyone.
+            return $result;
+        }
+
+        if ($result->status === ZaaktypeRefreshStatus::Unavailable) {
+            if ($result->becameInactive && $result->zaaktype !== null) {
+                $fallbackZaaktype = $this->fallback->activate($municipality, $result->zaaktype);
+
+                Log::warning('Mapped zaaktype has no valid definitief version anymore; falling back to main.', [
+                    ...$context,
+                    'fallback_zaaktype_id' => $fallbackZaaktype?->id,
+                ]);
+
+                $this->notify(new ZaaktypeKoppelingWarning(
+                    $result->zaaktype,
+                    ZaaktypeKoppelingIssue::Unavailable,
+                    $municipality,
+                    fallbackZaaktypeName: $fallbackZaaktype?->name,
+                ), $municipality);
+            } else {
+                Log::debug('Zaaktype is still unavailable; nothing changed.', $context);
+            }
+
+            return $result;
+        }
+
+        if ($result->becameActive && $result->zaaktype !== null) {
+            Log::info('Zaaktype has a valid definitief version again; own-instance row reactivated.', $context);
+
+            $this->notify(new ZaaktypeKoppelingWarning(
+                $result->zaaktype,
+                ZaaktypeKoppelingIssue::Restored,
+                $municipality,
+            ), $municipality);
+        }
+
+        if ($result->urlChanged && $result->zaaktype !== null) {
+            $this->clearVersionCaches($connectionName, $municipality->id);
+
+            Log::info('Zaaktype refreshed to a new version.', [
+                ...$context,
+                'zaaktype_url' => $result->zaaktype->zgw_zaaktype_url,
+            ]);
+
+            $mapping = MunicipalityZaaktypeMapping::query()
+                ->where('municipality_id', $municipality->id)
+                ->where('zaaktype_identificatie', $identificatie)
+                ->first();
+
+            $this->checkBlueprint($result->zaaktype, $connectionName, $identificatie, $mapping, $municipality);
+        }
+
+        if (! $result->becameActive && ! $result->urlChanged) {
+            Log::debug('Zaaktype notification produced no changes.', $context);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Refresh an existing main-catalogus zaaktype row. Main has no fallback (it
+     * is the fallback), so an unavailable zaaktype is deactivated and unlinked,
+     * exactly like the next SyncZaaktypen run would.
+     */
+    public function refreshMain(string $identificatie): void
+    {
+        $connectionName = ZgwConnectionResolver::DEFAULT_CONNECTION;
+
+        $zaaktype = Zaaktype::query()
+            ->where('connection', $connectionName)
+            ->where('identificatie', $identificatie)
+            ->first();
+
+        $context = ['connection' => $connectionName, 'identificatie' => $identificatie];
+
+        if ($zaaktype === null) {
+            Log::debug('Zaaktype notification for an unknown main identificatie ignored.', $context);
+
+            return;
+        }
+
+        try {
+            $version = ZaaktypeVersion::currentDefinitief($connectionName, $identificatie);
+        } catch (Throwable $e) {
+            Log::warning('Could not read the main catalogus for a zaaktype refresh.', [
+                ...$context,
+                'exception' => $e->getMessage(),
+            ]);
+
+            return;
+        }
+
+        if ($version === null) {
+            $this->deactivateMain($zaaktype, $context);
+
+            return;
+        }
+
+        $municipality = $zaaktype->municipality;
+
+        $zaaktype->fill([
+            'zgw_zaaktype_url' => $version['url'],
+            'name' => $version['omschrijving'] ?? $identificatie,
+            'is_active' => true,
+        ]);
+
+        $urlChanged = $zaaktype->isDirty('zgw_zaaktype_url');
+        $zaaktype->save();
+
+        if (! $urlChanged) {
+            Log::debug('Zaaktype notification produced no changes.', $context);
+
+            return;
+        }
+
+        $this->clearVersionCaches($connectionName, $municipality?->id);
+
+        Log::info('Zaaktype refreshed to a new version.', [
+            ...$context,
+            'zaaktype_url' => $zaaktype->zgw_zaaktype_url,
+        ]);
+
+        if ($municipality !== null) {
+            // Main zaaktypen have no koppeling mapping; the health check runs on
+            // the heuristics alone.
+            $this->checkBlueprint($zaaktype, $connectionName, $identificatie, null, $municipality);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $context
+     */
+    private function deactivateMain(Zaaktype $zaaktype, array $context): void
+    {
+        if (! $zaaktype->is_active) {
+            Log::debug('Zaaktype is still unavailable; nothing changed.', $context);
+
+            return;
+        }
+
+        $municipality = $zaaktype->municipality;
+
+        $zaaktype->is_active = false;
+        $zaaktype->municipality_id = null;
+        $zaaktype->save();
+
+        Log::warning('Main zaaktype has no valid definitief version anymore; row deactivated.', [
+            ...$context,
+            'municipality_id' => $municipality?->id,
+        ]);
+
+        $this->notify(new ZaaktypeKoppelingWarning(
+            $zaaktype,
+            ZaaktypeKoppelingIssue::MainUnavailable,
+            $municipality,
+        ), $municipality);
+    }
+
+    private function checkBlueprint(Zaaktype $zaaktype, string $connectionName, string $identificatie, ?MunicipalityZaaktypeMapping $mapping, Municipality $municipality): void
+    {
+        $findings = $this->health->check($connectionName, $identificatie, $mapping);
+
+        if ($findings === []) {
+            return;
+        }
+
+        Log::warning('Zaaktype version misses blueprint prerequisites.', [
+            'connection' => $connectionName,
+            'municipality_id' => $municipality->id,
+            'identificatie' => $identificatie,
+            'findings' => array_map(fn (BlueprintFinding $finding) => $finding->key(), $findings),
+        ]);
+
+        // Suppress repeats of the same unresolved finding set for a day; a
+        // changed set notifies immediately.
+        $keys = array_map(fn (BlueprintFinding $finding) => $finding->key(), $findings);
+        sort($keys);
+        $cacheKey = 'zaaktype_blueprint_warning:'.$connectionName.':'.$identificatie.':'.md5(implode('|', $keys));
+
+        if (! Cache::add($cacheKey, true, now()->addDay())) {
+            return;
+        }
+
+        $this->notify(new ZaaktypeKoppelingWarning(
+            $zaaktype,
+            ZaaktypeKoppelingIssue::BlueprintIncomplete,
+            $municipality,
+            findings: $findings,
+        ), $municipality);
+    }
+
+    /**
+     * Forget the caches that hold pre-publish data after a version bump. The
+     * url-keyed zaaktype caches self-heal because the row's url advanced.
+     */
+    private function clearVersionCaches(string $connectionName, ?int $municipalityId): void
+    {
+        Cache::forget("statustypen.v2.{$connectionName}");
+        Cache::forget('zaak_status_name_options_global');
+
+        if ($municipalityId !== null) {
+            Cache::forget("zaak_status_name_options_{$municipalityId}");
+        }
+    }
+
+    private function notify(ZaaktypeKoppelingWarning $notification, ?Municipality $municipality): void
+    {
+        /** @var Collection<int, User> $recipients */
+        $recipients = AdminUser::all()->toBase();
+
+        if ($municipality !== null) {
+            $recipients = $recipients->merge($municipality->municipalityBeheerderUsers()->get()->toBase());
+        }
+
+        Notification::send($recipients->unique('id')->values(), $notification);
+    }
+}

--- a/app/Services/Zgw/ZaaktypeVersion.php
+++ b/app/Services/Zgw/ZaaktypeVersion.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use Woweb\Zgw\Facades\Zgw;
+
+/**
+ * Resolves the current definitief version of a zaaktype identificatie in a
+ * connection's catalogus: the version valid today, falling back to any
+ * definitief version. Mirrors the resolution used by
+ * {@see ZaaktypeCatalogusOptions} and zaak creation.
+ */
+final class ZaaktypeVersion
+{
+    /**
+     * Null means the catalogus read succeeded but no definitief version exists
+     * (deleted or never published). Transport errors bubble to the caller so it
+     * can distinguish "gone" from "unreachable".
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function currentDefinitief(string $connectionName, string $identificatie): ?array
+    {
+        $version = Zgw::connection($connectionName)->catalogi()->zaaktypen()->index([
+            'identificatie' => $identificatie,
+            'status' => 'definitief',
+            'datumGeldigheid' => now('Europe/Amsterdam')->toDateString(),
+        ])->first()
+            ?? Zgw::connection($connectionName)->catalogi()->zaaktypen()->index([
+                'identificatie' => $identificatie,
+                'status' => 'definitief',
+            ])->first();
+
+        if (! is_array($version) || ! is_string($version['url'] ?? null) || $version['url'] === '') {
+            return null;
+        }
+
+        return $version;
+    }
+}

--- a/app/Services/Zgw/ZgwConnectionResolver.php
+++ b/app/Services/Zgw/ZgwConnectionResolver.php
@@ -58,15 +58,40 @@ class ZgwConnectionResolver
 
     /**
      * Resolve the connection name for any context that carries a municipality.
+     *
+     * A zaak resolves through its zaaktype: the zaaktype row records which
+     * instance hosts it, so zaken created on a main-fallback zaaktype keep
+     * reading from main even though their municipality runs its own instance.
      */
     public function for(Municipality|Zaak|Zaaktype|null $context): string
     {
         return match (true) {
             $context instanceof Municipality => $this->forMunicipality($context),
-            $context instanceof Zaak => $this->forMunicipality($context->municipality),
-            $context instanceof Zaaktype => $this->forMunicipality($context->municipality),
+            $context instanceof Zaak => $this->forZaaktype($context->zaaktype),
+            $context instanceof Zaaktype => $this->forZaaktype($context),
             default => self::DEFAULT_CONNECTION,
         };
+    }
+
+    /**
+     * The zaaktype's `connection` column records which instance hosts it. A
+     * main-catalogus row always lives on main, even while it is linked to an
+     * own-instance municipality as a fallback; only own-instance rows resolve
+     * through the municipality (which keeps the activation gating).
+     */
+    private function forZaaktype(?Zaaktype $zaaktype): string
+    {
+        if ($zaaktype === null) {
+            return self::DEFAULT_CONNECTION;
+        }
+
+        // Read via getAttribute(): the column name collides with Eloquent's own
+        // $connection property when accessed from model scope.
+        if ($zaaktype->getAttribute('connection') === self::DEFAULT_CONNECTION) {
+            return self::DEFAULT_CONNECTION;
+        }
+
+        return $this->forMunicipality($zaaktype->municipality);
     }
 
     /**

--- a/app/ValueObjects/ZGW/BlueprintFinding.php
+++ b/app/ValueObjects/ZGW/BlueprintFinding.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObjects\ZGW;
+
+use App\Enums\BlueprintFindingType;
+
+/**
+ * One problem found while checking a zaaktype version against the blueprint
+ * prerequisites (see docs/functionaliteiten/zgw-koppelingbeheer.md, section 4.4).
+ */
+final readonly class BlueprintFinding
+{
+    /**
+     * @param  string  $slot  Blueprint slot, e.g. 'eind_statustype' or 'eigenschap:intern_zaaknummer'
+     * @param  string|null  $expected  The koppeling value that no longer matches, for MappedValueNotFound
+     */
+    public function __construct(
+        public string $slot,
+        public BlueprintFindingType $type,
+        public ?string $expected = null,
+    ) {}
+
+    /** Stable identity used for dedup/throttling of repeated identical findings. */
+    public function key(): string
+    {
+        return $this->slot.'|'.$this->type->value.'|'.($this->expected ?? '');
+    }
+}

--- a/app/ValueObjects/ZGW/ZaaktypeRefreshResult.php
+++ b/app/ValueObjects/ZGW/ZaaktypeRefreshResult.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObjects\ZGW;
+
+use App\Enums\ZaaktypeRefreshStatus;
+use App\Models\Zaaktype;
+
+/**
+ * Outcome of refreshing a single local zaaktype row against its catalogus.
+ * The transition flags let callers act only on state changes (fallback on
+ * becameInactive, restore on becameActive) instead of on every refresh.
+ */
+final readonly class ZaaktypeRefreshResult
+{
+    public function __construct(
+        public ZaaktypeRefreshStatus $status,
+        public ?Zaaktype $zaaktype = null,
+        public bool $urlChanged = false,
+        public bool $becameActive = false,
+        public bool $becameInactive = false,
+    ) {}
+}

--- a/lang/nl/notification/zaaktype-koppeling-warning.php
+++ b/lang/nl/notification/zaaktype-koppeling-warning.php
@@ -1,0 +1,54 @@
+<?php
+
+return [
+    'label' => 'Zaaktype-koppeling',
+
+    'mail' => [
+        'subject' => [
+            'unavailable' => 'Zaaktype ":zaaktype" is niet meer geldig',
+            'restored' => 'Zaaktype ":zaaktype" is weer geldig',
+            'blueprint_incomplete' => 'Zaaktype ":zaaktype" mist vereiste onderdelen',
+            'main_unavailable' => 'Zaaktype ":zaaktype" (hoofdkoppeling) is niet meer geldig',
+        ],
+        'greeting' => [
+            'unavailable' => 'Zaaktype niet meer geldig',
+            'restored' => 'Zaaktype weer geldig',
+            'blueprint_incomplete' => 'Zaaktype mist vereiste onderdelen',
+            'main_unavailable' => 'Zaaktype in hoofdkoppeling niet meer geldig',
+        ],
+        'button' => 'Koppeling bekijken',
+    ],
+
+    'database' => [
+        'title' => [
+            'unavailable' => 'Zaaktype ":zaaktype" is niet meer geldig',
+            'restored' => 'Zaaktype ":zaaktype" is weer geldig',
+            'blueprint_incomplete' => 'Zaaktype ":zaaktype" mist vereiste onderdelen',
+            'main_unavailable' => 'Zaaktype ":zaaktype" (hoofdkoppeling) is niet meer geldig',
+        ],
+    ],
+
+    'body' => [
+        'unavailable' => 'Het gekoppelde zaaktype ":zaaktype" van gemeente :municipality heeft geen geldige definitieve versie meer in de eigen ZGW-omgeving.',
+        'restored' => 'Het gekoppelde zaaktype ":zaaktype" van gemeente :municipality heeft weer een geldige definitieve versie en wordt weer gebruikt voor nieuwe aanvragen.',
+        'blueprint_incomplete' => 'De actuele versie van zaaktype ":zaaktype" mist onderdelen die Eventloket nodig heeft:',
+        'main_unavailable' => 'Zaaktype ":zaaktype" in de hoofdcatalogus heeft geen geldige definitieve versie meer en is gedeactiveerd.',
+        'fallback_active' => 'Nieuwe aanvragen gebruiken tijdelijk ":fallback" via de hoofdkoppeling.',
+        'fallback_missing' => 'Er is geen terugval-zaaktype in de hoofdcatalogus gevonden; nieuwe aanvragen voor deze rol zullen mislukken totdat de koppeling hersteld is.',
+    ],
+
+    'slot' => [
+        'initial_statustype' => 'Beginstatus',
+        'eind_statustype' => 'Eindstatus',
+        'initiator_roltype' => 'Initiator-roltype',
+        'ingetrokken_resultaattype' => 'Resultaattype "Ingetrokken"',
+        'aanvraag_informatieobjecttype' => 'Documenttype aanvraagformulier',
+        'bijlage_informatieobjecttype' => 'Documenttype bijlagen',
+        'eigenschap' => 'Eigenschap ":key"',
+    ],
+
+    'finding' => [
+        'missing' => ':slot ontbreekt op het zaaktype.',
+        'mapped_value_not_found' => ':slot: de gekoppelde waarde ":expected" bestaat niet meer.',
+    ],
+];

--- a/resources/views/mail/zaaktype-koppeling-warning.blade.php
+++ b/resources/views/mail/zaaktype-koppeling-warning.blade.php
@@ -1,0 +1,15 @@
+<x-mail::message>
+# {{ __("notification/zaaktype-koppeling-warning.mail.greeting.$issue") }}
+
+{{ $body }}
+
+@if (count($findingLines) > 0)
+@foreach ($findingLines as $line)
+- {{ $line }}
+@endforeach
+@endif
+
+<x-mail::button :url="$viewUrl">
+    {{ __('notification/zaaktype-koppeling-warning.mail.button') }}
+</x-mail::button>
+</x-mail::message>

--- a/tests/Feature/Console/Commands/Zaaktypen/SyncZaaktypeEigenschappenTest.php
+++ b/tests/Feature/Console/Commands/Zaaktypen/SyncZaaktypeEigenschappenTest.php
@@ -91,6 +91,9 @@ test('validates an external connection read-only and never creates eigenschappen
         'zgw_zaaktype_url' => $zaaktypeUrl,
         'is_active' => true,
         'municipality_id' => $municipality->id,
+        // Own-instance rows carry their connection name; the resolver routes by
+        // this column, so it must mark the row as externally hosted.
+        'connection' => "gemeente_{$municipality->id}",
     ]);
 
     Http::fake([

--- a/tests/Feature/Http/Controllers/Api/OpenNotitificationsTest.php
+++ b/tests/Feature/Http/Controllers/Api/OpenNotitificationsTest.php
@@ -144,6 +144,47 @@ test('Open notifications endpoint handles document update notification', functio
 
 });
 
+test('Open notifications endpoint accepts zaaktypen channel notifications', function () {
+    Queue::fake([
+        ProcessOpenNotification::class,
+    ]);
+
+    $response = $this->postJson(route('api.open-notifications.listen'), [
+        'actie' => 'partial_update',
+        'kanaal' => 'zaaktypen',
+        'resource' => 'zaaktype',
+        'kenmerken' => ['catalogus' => 'https://example.com/catalogi/api/v1/catalogussen/1'],
+        'hoofdObject' => 'https://example.com/catalogi/api/v1/zaaktypen/123',
+        'resourceUrl' => 'https://example.com/catalogi/api/v1/zaaktypen/123',
+        'aanmaakdatum' => now()->toIso8601String(),
+    ], [
+        'Authorization' => 'Bearer '.$this->access_token,
+    ]);
+
+    $response->assertStatus(200);
+    Queue::assertPushed(ProcessOpenNotification::class);
+});
+
+test('Open notifications endpoint accepts the standard destroy actie', function () {
+    Queue::fake([
+        ProcessOpenNotification::class,
+    ]);
+
+    $response = $this->postJson(route('api.open-notifications.listen'), [
+        'actie' => 'destroy',
+        'kanaal' => 'zaaktypen',
+        'resource' => 'zaaktype',
+        'hoofdObject' => 'https://example.com/catalogi/api/v1/zaaktypen/123',
+        'resourceUrl' => 'https://example.com/catalogi/api/v1/zaaktypen/123',
+        'aanmaakdatum' => now()->toIso8601String(),
+    ], [
+        'Authorization' => 'Bearer '.$this->access_token,
+    ]);
+
+    $response->assertStatus(200);
+    Queue::assertPushed(ProcessOpenNotification::class);
+});
+
 test('hoofdObject met vreemde host wordt geweigerd (SSRF-bescherming)', function () {
     $response = $this->postJson(route('api.open-notifications.listen'), [
         'actie' => 'create',

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -131,6 +131,9 @@ function doorkomstScenario(bool $hoofdOwnInstance): array
         'role' => ZaaktypeRole::Vergunning,
         'triggers_route_check' => true,
         'is_active' => true,
+        // The resolver routes by this column: an own-instance hoofdzaak carries
+        // its own connection name, a main hoofdzaak stays on main.
+        'connection' => $hoofdOwnInstance ? "gemeente_{$hoofd->id}" : 'main',
     ]);
 
     $hoofdzaak = Zaak::factory()->create([

--- a/tests/Feature/Jobs/ZaaktypeNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/ZaaktypeNotificationReceivedTest.php
@@ -1,0 +1,339 @@
+<?php
+
+use App\Enums\Role;
+use App\Enums\ZaaktypeRole;
+use App\Jobs\ZaaktypeNotificationReceived;
+use App\Models\Municipality;
+use App\Models\MunicipalityZaaktypeMapping;
+use App\Models\MunicipalityZgwConnection;
+use App\Models\User;
+use App\Models\Users\AdminUser;
+use App\Models\Users\MunicipalityUser;
+use App\Models\Zaaktype;
+use App\Notifications\ZaaktypeKoppelingWarning;
+use App\Services\Zgw\ZaaktypeRefresher;
+use App\ValueObjects\OpenNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Queue;
+use Tests\Fakes\ZgwHttpFake;
+
+uses(RefreshDatabase::class);
+
+const ZTN_OWN_BASE = 'https://gemeente.example.com';
+
+beforeEach(function () {
+    Cache::flush();
+    Notification::fake();
+});
+
+function zaaktypeNotification(string $hoofdObject, string $actie = 'partial_update'): OpenNotification
+{
+    return new OpenNotification(
+        actie: $actie,
+        kanaal: 'zaaktypen',
+        resource: 'zaaktype',
+        hoofdObject: $hoofdObject,
+        resourceUrl: $hoofdObject,
+        aanmaakdatum: now(),
+    );
+}
+
+/**
+ * A municipality with an active own ZGW connection (host gemeente.example.com,
+ * unique, so incoming urls attribute to it), a Vergunning koppeling for OWN-1
+ * and the matching local own-instance zaaktype row. The mapping is created
+ * without events: the observer-triggered refresh would need HTTP fakes that
+ * shadow the per-test fakes (earlier-registered stubs win on equal patterns).
+ *
+ * @return array{0: Municipality, 1: Zaaktype}
+ */
+function ownInstanceSetup(string $versionUrl, string $municipalityName = 'Heerlen'): array
+{
+    $municipality = Municipality::factory()->create(['name' => $municipalityName]);
+    MunicipalityZgwConnection::factory()->active()->create(['municipality_id' => $municipality->id]);
+
+    MunicipalityZaaktypeMapping::withoutEvents(fn () => MunicipalityZaaktypeMapping::create([
+        'municipality_id' => $municipality->id,
+        'role' => ZaaktypeRole::Vergunning,
+        'zaaktype_identificatie' => 'OWN-1',
+    ]));
+
+    $zaaktype = Zaaktype::factory()->create([
+        'identificatie' => 'OWN-1',
+        'connection' => "gemeente_{$municipality->id}",
+        'name' => 'Eigen evenementenvergunning',
+        'role' => ZaaktypeRole::Vergunning->value,
+        'is_active' => true,
+        'zgw_zaaktype_url' => $versionUrl,
+    ]);
+    $zaaktype->municipality_id = $municipality->id;
+    $zaaktype->save();
+
+    return [$municipality, $zaaktype];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function zaaktypeVersionData(string $url, string $identificatie = 'OWN-1', string $omschrijving = 'Eigen evenementenvergunning'): array
+{
+    return [
+        'url' => $url,
+        'identificatie' => $identificatie,
+        'omschrijving' => $omschrijving,
+        'concept' => false,
+        'beginGeldigheid' => '2026-01-01',
+        'versiedatum' => '2026-01-01',
+    ];
+}
+
+/**
+ * Healthy child lists for the blueprint health check: eindstatus, initiator
+ * roltype, Ingetrokken resultaattype, intern_zaaknummer eigenschap and an
+ * inline (RX-style) informatieobjecttype.
+ *
+ * @return array<string, mixed>
+ */
+function healthyCatalogusFakes(array $overrides = []): array
+{
+    return array_merge([
+        ZTN_OWN_BASE.'/catalogi/api/v1/statustypen*' => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Ontvangen', 'volgnummer' => 1, 'isEindstatus' => false],
+            ['omschrijving' => 'Afgehandeld', 'volgnummer' => 2, 'isEindstatus' => true],
+        ]), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/roltypen*' => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Aanvrager', 'omschrijvingGeneriek' => 'initiator'],
+        ]), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/resultaattypen*' => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Verleend', 'omschrijvingGeneriek' => 'Afgehandeld'],
+            ['omschrijving' => 'Ingetrokken', 'omschrijvingGeneriek' => 'Ingetrokken'],
+        ]), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/eigenschappen*' => Http::response(ZgwHttpFake::envelope([
+            ['naam' => 'intern_zaaknummer'],
+        ]), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobjecttype' => 'Bijlage'],
+        ]), 200),
+    ], $overrides);
+}
+
+test('a published new version refreshes the own-instance row and clears the version caches', function () {
+    $v1 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v1';
+    $v2 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v2';
+
+    [$municipality, $zaaktype] = ownInstanceSetup($v1);
+
+    Http::fake(array_merge([
+        $v2 => Http::response(zaaktypeVersionData($v2), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([zaaktypeVersionData($v2)]), 200),
+    ], healthyCatalogusFakes()));
+
+    Cache::put("statustypen.v2.gemeente_{$municipality->id}", ['stale']);
+    Cache::put("zaak_status_name_options_{$municipality->id}", ['stale']);
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($v2)))->handle(app(ZaaktypeRefresher::class));
+
+    expect($zaaktype->refresh())
+        ->zgw_zaaktype_url->toBe($v2)
+        ->is_active->toBeTrue()
+        ->and(Cache::has("statustypen.v2.gemeente_{$municipality->id}"))->toBeFalse()
+        ->and(Cache::has("zaak_status_name_options_{$municipality->id}"))->toBeFalse();
+
+    Notification::assertNothingSent();
+});
+
+test('a mapped zaaktype without a valid version engages the main fallback and warns once', function () {
+    $v1 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v1';
+
+    [$municipality, $zaaktype] = ownInstanceSetup($v1);
+
+    $mainZaaktype = Zaaktype::factory()->create([
+        'identificatie' => 'MAIN-1',
+        'connection' => 'main',
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'role' => ZaaktypeRole::Vergunning->value,
+        'is_active' => true,
+    ]);
+
+    $admin = User::factory()->create(['role' => Role::Admin]);
+    $beheerder = User::factory()->create(['role' => Role::KoppelingBeheerder]);
+    $beheerder->municipalities()->attach($municipality);
+
+    // The destroyed version 404s; the identificatie is matched locally by url.
+    Http::fake([
+        $v1 => Http::response([], 404),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([]), 200),
+    ]);
+
+    $job = new ZaaktypeNotificationReceived(zaaktypeNotification($v1, 'destroy'));
+    $job->handle(app(ZaaktypeRefresher::class));
+
+    expect($zaaktype->refresh()->is_active)->toBeFalse()
+        ->and($mainZaaktype->refresh()->municipality_id)->toBe($municipality->id);
+
+    Notification::assertSentTo(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class);
+    Notification::assertSentTo(MunicipalityUser::firstWhere('id', $beheerder->id), ZaaktypeKoppelingWarning::class);
+
+    // A second notification for the same (still broken) zaaktype stays silent:
+    // the warning fires on the transition only.
+    $job->handle(app(ZaaktypeRefresher::class));
+
+    Notification::assertSentToTimes(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class, 1);
+});
+
+test('a missing main fallback candidate still warns and deactivates the own row', function () {
+    $v1 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v1';
+
+    [, $zaaktype] = ownInstanceSetup($v1);
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    Http::fake([
+        $v1 => Http::response([], 404),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([]), 200),
+    ]);
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($v1, 'destroy')))->handle(app(ZaaktypeRefresher::class));
+
+    expect($zaaktype->refresh()->is_active)->toBeFalse()
+        ->and(Zaaktype::where('connection', 'main')->whereNotNull('municipality_id')->exists())->toBeFalse();
+
+    Notification::assertSentTo(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class);
+});
+
+test('a valid version again reactivates the own row, keeps the fallback link and notifies the restore', function () {
+    $v2 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v2';
+
+    [$municipality, $zaaktype] = ownInstanceSetup($v2);
+    $zaaktype->update(['is_active' => false]);
+
+    // The fallback main row linked during the outage.
+    $mainZaaktype = Zaaktype::factory()->create([
+        'identificatie' => 'MAIN-1',
+        'connection' => 'main',
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'role' => ZaaktypeRole::Vergunning->value,
+        'is_active' => true,
+    ]);
+    $mainZaaktype->municipality_id = $municipality->id;
+    $mainZaaktype->save();
+
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    Http::fake(array_merge([
+        $v2 => Http::response(zaaktypeVersionData($v2), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([zaaktypeVersionData($v2)]), 200),
+    ], healthyCatalogusFakes()));
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($v2)))->handle(app(ZaaktypeRefresher::class));
+
+    // The own row wins again through the resolve ordering; the main link stays
+    // so zaken created during the fallback keep their municipality.
+    expect($zaaktype->refresh()->is_active)->toBeTrue()
+        ->and($mainZaaktype->refresh()->municipality_id)->toBe($municipality->id);
+
+    Notification::assertSentTo(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class);
+});
+
+test('a new version missing an eindstatus warns without engaging the fallback', function () {
+    $v1 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v1';
+    $v2 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v2';
+
+    [, $zaaktype] = ownInstanceSetup($v1);
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    Http::fake(array_merge([
+        $v2 => Http::response(zaaktypeVersionData($v2), 200),
+        ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([zaaktypeVersionData($v2)]), 200),
+    ], healthyCatalogusFakes([
+        ZTN_OWN_BASE.'/catalogi/api/v1/statustypen*' => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Ontvangen', 'volgnummer' => 1, 'isEindstatus' => false],
+        ]), 200),
+    ])));
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($v2)))->handle(app(ZaaktypeRefresher::class));
+
+    expect($zaaktype->refresh())
+        ->is_active->toBeTrue()
+        ->zgw_zaaktype_url->toBe($v2)
+        ->and(Zaaktype::where('connection', 'main')->whereNotNull('municipality_id')->exists())->toBeFalse();
+
+    Notification::assertSentTo(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class);
+});
+
+test('an unmapped own-instance identificatie is ignored', function () {
+    $v1 = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v1';
+    $other = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/other';
+
+    [, $zaaktype] = ownInstanceSetup($v1);
+
+    Http::fake([
+        $other => Http::response(zaaktypeVersionData($other, 'UNMAPPED'), 200),
+    ]);
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($other)))->handle(app(ZaaktypeRefresher::class));
+
+    expect($zaaktype->refresh())
+        ->is_active->toBeTrue()
+        ->zgw_zaaktype_url->toBe($v1);
+
+    Notification::assertNothingSent();
+});
+
+test('a destroy without any local url match is ignored', function () {
+    $unknown = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/unknown';
+
+    User::factory()->create(['role' => Role::Admin]);
+
+    Http::fake([
+        $unknown => Http::response([], 404),
+    ]);
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($unknown, 'destroy')))->handle(app(ZaaktypeRefresher::class));
+
+    Notification::assertNothingSent();
+});
+
+test('a main zaaktype without a valid version is deactivated, unlinked and warned about', function () {
+    $mainUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/main-1';
+
+    $municipality = Municipality::factory()->create();
+    $mainZaaktype = Zaaktype::factory()->create([
+        'identificatie' => 'MAIN-1',
+        'connection' => 'main',
+        'name' => 'Evenementenvergunning gemeente '.$municipality->name,
+        'role' => ZaaktypeRole::Vergunning->value,
+        'is_active' => true,
+        'zgw_zaaktype_url' => $mainUrl,
+    ]);
+    $mainZaaktype->municipality_id = $municipality->id;
+    $mainZaaktype->save();
+
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    Http::fake([
+        $mainUrl => Http::response([], 404),
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen?*' => Http::response(ZgwHttpFake::envelope([]), 200),
+    ]);
+
+    (new ZaaktypeNotificationReceived(zaaktypeNotification($mainUrl, 'destroy')))->handle(app(ZaaktypeRefresher::class));
+
+    expect($mainZaaktype->refresh())
+        ->is_active->toBeFalse()
+        ->municipality_id->toBeNull();
+
+    Notification::assertSentTo(AdminUser::firstWhere('id', $admin->id), ZaaktypeKoppelingWarning::class);
+});
+
+test('notifications for the same version url collapse into one unique job', function () {
+    Queue::fake([ZaaktypeNotificationReceived::class]);
+
+    $url = ZTN_OWN_BASE.'/catalogi/api/v1/zaaktypen/v2';
+
+    ZaaktypeNotificationReceived::dispatch(zaaktypeNotification($url));
+    ZaaktypeNotificationReceived::dispatch(zaaktypeNotification($url, 'create'));
+
+    Queue::assertPushed(ZaaktypeNotificationReceived::class, 1);
+});

--- a/tests/Feature/Zgw/ZgwConnectionResolverTest.php
+++ b/tests/Feature/Zgw/ZgwConnectionResolverTest.php
@@ -57,6 +57,44 @@ it('resolves a zaak through its zaaktype', function () {
         ->and($zaak->zgwConnectionName())->toBe('main');
 });
 
+it('resolves an own-instance zaaktype to the municipality connection', function () {
+    $municipality = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->for($municipality)->active()->create();
+
+    $zaaktype = Zaaktype::factory()->for($municipality)->create([
+        'connection' => "gemeente_{$municipality->id}",
+    ]);
+
+    expect($this->resolver->for($zaaktype))->toBe("gemeente_{$municipality->id}");
+});
+
+it('resolves a main zaaktype linked to an own-instance municipality to main', function () {
+    $municipality = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->for($municipality)->active()->create();
+
+    // A main-catalogus row linked as a per-zaaktype fallback: the connection
+    // column wins over the municipality's own connection.
+    $fallback = Zaaktype::factory()->for($municipality)->create([
+        'connection' => 'main',
+    ]);
+
+    expect($this->resolver->for($fallback))->toBe('main')
+        ->and($fallback->zgwConnectionName())->toBe('main');
+});
+
+it('resolves a zaak on a fallback zaaktype to main, not the municipality connection', function () {
+    $municipality = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->for($municipality)->active()->create();
+
+    $fallback = Zaaktype::factory()->for($municipality)->create([
+        'connection' => 'main',
+    ]);
+    $zaak = Zaak::factory()->for($fallback)->create();
+
+    expect($this->resolver->for($zaak))->toBe('main')
+        ->and($zaak->zgwConnectionName())->toBe('main');
+});
+
 it('maps an incoming zaak url back to a connection, falling back to main', function () {
     $municipality = Municipality::factory()->create();
     $zaaktype = Zaaktype::factory()->for($municipality)->create();

--- a/tests/Unit/Actions/GetIncommingNotificationTypeTest.php
+++ b/tests/Unit/Actions/GetIncommingNotificationTypeTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use App\Actions\OpenNotification\GetIncommingNotificationType;
+use App\Enums\OpenNotificationType;
+use App\ValueObjects\OpenNotification;
+
+function classify(string $actie, string $kanaal, string $resource): ?OpenNotificationType
+{
+    return (new GetIncommingNotificationType)->handle(new OpenNotification(
+        actie: $actie,
+        kanaal: $kanaal,
+        resource: $resource,
+        hoofdObject: 'https://example.com/resource/1',
+        resourceUrl: 'https://example.com/resource/1',
+        aanmaakdatum: now(),
+    ));
+}
+
+test('every actie and resource on the zaaktypen channel classifies as ZaaktypeChanged', function (string $actie, string $resource) {
+    expect(classify($actie, 'zaaktypen', $resource))->toBe(OpenNotificationType::ZaaktypeChanged);
+})->with([
+    ['create', 'zaaktype'],
+    ['partial_update', 'zaaktype'],
+    ['destroy', 'zaaktype'],
+    ['create', 'statustype'],
+    ['destroy', 'resultaattype'],
+]);
+
+test('existing channels keep their classification', function () {
+    expect(classify('partial_update', 'zaken', 'zaakeigenschap'))->toBe(OpenNotificationType::UpdateZaakEigenschap)
+        ->and(classify('create', 'zaken', 'status'))->toBe(OpenNotificationType::ZaakStatusChanged)
+        ->and(classify('create', 'documenten', 'enkelvoudiginformatieobject'))->toBe(OpenNotificationType::NewZaakDocument)
+        ->and(classify('update', 'documenten', 'enkelvoudiginformatieobject'))->toBe(OpenNotificationType::UpdatedZaakDocument)
+        ->and(classify('create', 'besluiten', 'besluit'))->toBeNull();
+});

--- a/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
+++ b/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
@@ -22,6 +22,7 @@ use App\EventForm\State\FormState;
 use App\EventForm\Submit\DetermineAanvraagType;
 use App\EventForm\Submit\ResolveZaaktype;
 use App\Models\Municipality;
+use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaaktype;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -126,4 +127,104 @@ test('gemeente uit state matcht niets in de DB → exception', function () {
 
     expect(fn () => $this->resolve->forState($state))
         ->toThrow(RuntimeException::class);
+});
+
+test('valt terug op de gekoppelde main-rij als het eigen zaaktype inactief is', function () {
+    $heerlen = Municipality::factory()->create(['name' => 'Heerlen', 'brk_identification' => 'GM0917']);
+
+    MunicipalityZaaktypeMapping::withoutEvents(fn () => MunicipalityZaaktypeMapping::create([
+        'municipality_id' => $heerlen->id,
+        'role' => ZaaktypeRole::Vergunning,
+        'zaaktype_identificatie' => 'OWN-1',
+    ]));
+
+    // The mapped own-instance row lost its valid version and was deactivated.
+    Zaaktype::factory()->create([
+        'name' => 'Eigen evenementenvergunning',
+        'identificatie' => 'OWN-1',
+        'connection' => "gemeente_{$heerlen->id}",
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => false,
+    ]);
+
+    $fallback = Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'connection' => 'main',
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0917'],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect($this->resolve->forState($state)->id)->toBe($fallback->id);
+});
+
+test('een weer actief eigen zaaktype wint van een nog gekoppelde main-fallback', function () {
+    $heerlen = Municipality::factory()->create(['name' => 'Heerlen', 'brk_identification' => 'GM0917']);
+
+    MunicipalityZaaktypeMapping::withoutEvents(fn () => MunicipalityZaaktypeMapping::create([
+        'municipality_id' => $heerlen->id,
+        'role' => ZaaktypeRole::Vergunning,
+        'zaaktype_identificatie' => 'OWN-1',
+    ]));
+
+    $eigen = Zaaktype::factory()->create([
+        'name' => 'Eigen evenementenvergunning',
+        'identificatie' => 'OWN-1',
+        'connection' => "gemeente_{$heerlen->id}",
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    // The fallback link deliberately survives a restore (zaken created during
+    // the fallback derive their municipality through this row).
+    Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'connection' => 'main',
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0917'],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect($this->resolve->forState($state)->id)->toBe($eigen->id);
+});
+
+test('eigen-connectie-rij wint ook op de role-route als beide gekoppeld en actief zijn', function () {
+    $heerlen = Municipality::factory()->create(['name' => 'Heerlen', 'brk_identification' => 'GM0917']);
+
+    // No mapping: resolution goes through the role column for both rows.
+    Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'connection' => 'main',
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $eigen = Zaaktype::factory()->create([
+        'name' => 'Eigen evenementenvergunning',
+        'identificatie' => 'OWN-1',
+        'connection' => "gemeente_{$heerlen->id}",
+        'role' => ZaaktypeRole::Vergunning,
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0917'],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect($this->resolve->forState($state)->id)->toBe($eigen->id);
 });


### PR DESCRIPTION
## What

The Open Notificaties abonnement already subscribed to the zaaktypen kanaal, but incoming notifications were rejected at validation and dropped by the classifier, so local zaaktype rows went stale whenever a new version was published. This handles those notifications end to end.

## Changes

- **Targeted refresh on notification.** Incoming zaaktypen notifications trigger a refresh of the local zaaktype row via a debounced unique job (`ZaaktypeNotificationReceived`). A publish fires a burst of notifications sharing one hoofdObject; the dispatch delay plus `ShouldBeUnique` collapses that into a single, idempotent refresh.
- **Shared refresher.** `ZaaktypeRefresher` (also used by the koppeling observer and `app:sync-zaaktypen`) detects availability transitions, clears the version-bound caches, and validates the blueprint prerequisites: begin/eindstatus, initiator roltype, Ingetrokken resultaattype, informatieobjecttypen, mapped eigenschappen, intern_zaaknummer.
- **Main-catalogus fallback.** When a mapped own-instance zaaktype no longer has a valid definitief version, the matching main-catalogus zaaktype is linked to the municipality as a per-zaaktype fallback so new aanvragen keep working. Restores flip back automatically.
- **Warnings.** Problems are reported to platform admins and the municipality's koppeling-beheerders by mail and Filament database notification, throttled to transitions or a 24h window.
- **Connection resolver.** Now honours the zaaktype row's connection column (a main row always resolves to main) and resolves a zaak through its zaaktype, keeping fallback-created zaken on the right instance.

## Tests

New coverage for the job (`ZaaktypeNotificationReceivedTest`), the notification-type classifier, the resolver, `ResolveZaaktype`, and the OpenNotifications endpoint.