### PR TITLE
Add per-connection toggle for organiser withdrawal

### DIFF
--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZaaktypeMappings/MunicipalityZaaktypeMappingResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZaaktypeMappings/MunicipalityZaaktypeMappingResource.php
@@ -125,9 +125,11 @@ class MunicipalityZaaktypeMappingResource extends Resource
                     ->visible(fn (Get $get): bool => filled($get('zaaktype_identificatie')))
                     ->schema([
                         self::catalogusSelect('initial_statustype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::statustypen($conn, $id)),
-                        self::catalogusSelect('eind_statustype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::statustypen($conn, $id)),
+                        self::catalogusSelect('eind_statustype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::statustypen($conn, $id))
+                            ->visible(fn (): bool => self::organiserWithdrawalAllowed()),
                         self::catalogusSelect('initiator_roltype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::roltypen($conn, $id)),
-                        self::catalogusSelect('ingetrokken_resultaattype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::resultaattypen($conn, $id)),
+                        self::catalogusSelect('ingetrokken_resultaattype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::resultaattypen($conn, $id))
+                            ->visible(fn (): bool => self::organiserWithdrawalAllowed()),
                         self::catalogusSelect('aanvraag_informatieobjecttype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::informatieobjecttypen($conn, $id)),
                         self::catalogusSelect('bijlage_informatieobjecttype', fn (string $conn, string $id) => ZaaktypeCatalogusOptions::informatieobjecttypen($conn, $id)),
                     ]),
@@ -299,5 +301,19 @@ class MunicipalityZaaktypeMappingResource extends Resource
         $tenant = Filament::getTenant();
 
         return $tenant instanceof Municipality && $tenant->zgwConnection !== null;
+    }
+
+    /**
+     * Whether an organiser may withdraw a zaak on this municipality's connection.
+     * When disabled the eind-statustype and ingetrokken-resultaattype do not need
+     * to be configured, so those two flow selects are hidden. The global "main"
+     * connection (no row) always allows withdrawal.
+     */
+    private static function organiserWithdrawalAllowed(): bool
+    {
+        $tenant = Filament::getTenant();
+        $connection = $tenant instanceof Municipality ? $tenant->zgwConnection : null;
+
+        return $connection === null || $connection->allow_organiser_withdrawal;
     }
 }

--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -145,6 +145,10 @@ class MunicipalityZgwConnectionResource extends Resource
                         Toggle::make('suppress_notifications')
                             ->label(__('municipality/resources/zgw_connection.fields.suppress_notifications.label'))
                             ->helperText(__('municipality/resources/zgw_connection.fields.suppress_notifications.helper')),
+                        Toggle::make('allow_organiser_withdrawal')
+                            ->label(__('municipality/resources/zgw_connection.fields.allow_organiser_withdrawal.label'))
+                            ->helperText(__('municipality/resources/zgw_connection.fields.allow_organiser_withdrawal.helper'))
+                            ->default(true),
                     ]),
 
                 Section::make(__('municipality/resources/zgw_connection.sections.vertrouwelijkheid.heading'))

--- a/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
@@ -46,7 +46,7 @@ class ViewZaak extends ViewRecord
                 ->label('Aanvraag intrekken')
                 ->color('danger')
                 ->requiresConfirmation()
-                ->visible(fn (Zaak $record): bool => ($record->openzaak && ! $record->openzaak->resultaat) && $record->intrekkenResultaatType !== null)
+                ->visible(fn (Zaak $record): bool => $record->organiserCanWithdraw() && ($record->openzaak && ! $record->openzaak->resultaat) && $record->intrekkenResultaatType !== null)
                 ->action(function (Zaak $record) {
                     /** @var OrganiserUser $user */
                     $user = auth()->user();

--- a/app/Models/MunicipalityZgwConnection.php
+++ b/app/Models/MunicipalityZgwConnection.php
@@ -48,6 +48,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property bool $show_adviesvragen_tab
  * @property bool $show_organisatievragen_tab
  * @property bool $suppress_notifications
+ * @property bool $allow_organiser_withdrawal
  * @property Carbon|null $last_verified_at
  * @property Carbon|null $activated_at
  */
@@ -82,6 +83,7 @@ class MunicipalityZgwConnection extends Model
         'show_adviesvragen_tab',
         'show_organisatievragen_tab',
         'suppress_notifications',
+        'allow_organiser_withdrawal',
         'last_verified_at',
         'activated_at',
     ];
@@ -126,6 +128,7 @@ class MunicipalityZgwConnection extends Model
             'show_adviesvragen_tab' => 'boolean',
             'show_organisatievragen_tab' => 'boolean',
             'suppress_notifications' => 'boolean',
+            'allow_organiser_withdrawal' => 'boolean',
             'last_verified_at' => 'datetime',
             'activated_at' => 'datetime',
         ];

--- a/app/Models/MunicipalityZgwConnection.php
+++ b/app/Models/MunicipalityZgwConnection.php
@@ -243,6 +243,7 @@ class MunicipalityZgwConnection extends Model
             'allowed_hosts' => $this->allowed_hosts,
             'bronorganisatie_rsin' => $this->bronorganisatie_rsin,
             'vertrouwelijkheid_map' => $this->vertrouwelijkheid_map,
+            'allow_organiser_withdrawal' => $this->allow_organiser_withdrawal,
         ];
 
         foreach ($overrides as $key => $value) {

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -138,6 +138,20 @@ class Zaak extends Model implements Eventable
     }
 
     /**
+     * Whether an organiser may withdraw ("intrekken") this zaak from inside
+     * Eventloket. Disabled per connection for a OneGround (RX Mission) backend,
+     * where setting the eind-status archives the zaak immediately and is
+     * rejected unless all related documents are already 'gearchiveerd'. The
+     * global "main" connection (no row) always allows withdrawal.
+     */
+    public function organiserCanWithdraw(): bool
+    {
+        $connection = $this->zgwConnectionModel();
+
+        return $connection === null || $connection->allow_organiser_withdrawal;
+    }
+
+    /**
      * Whether a behandelaar may change the risico classificatie (and toelichting)
      * from inside Eventloket. The edit writes these eigenschappen by hardcoded
      * naam and bypasses the per-municipality blueprint, so it is only offered on

--- a/app/Services/Zgw/ZaaktypeBlueprintHealth.php
+++ b/app/Services/Zgw/ZaaktypeBlueprintHealth.php
@@ -80,10 +80,14 @@ final class ZaaktypeBlueprintHealth
             $findings[] = new BlueprintFinding('initial_statustype', BlueprintFindingType::MappedValueNotFound, $mapping->initial_statustype);
         }
 
-        if (ZaaktypeBlueprint::eindStatustype($mapping, $statustypen) === null) {
-            $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::Missing);
-        } elseif ($mapping?->eind_statustype && $statustypen->firstWhere('omschrijving', $mapping->eind_statustype) === null) {
-            $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::MappedValueNotFound, $mapping->eind_statustype);
+        // The eind-statustype only needs configuring when withdrawal is enabled;
+        // when it is off the koppeling form hides the field, so do not report it.
+        if (ZgwConnectionConfig::allowsOrganiserWithdrawal($connectionName)) {
+            if (ZaaktypeBlueprint::eindStatustype($mapping, $statustypen) === null) {
+                $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::Missing);
+            } elseif ($mapping?->eind_statustype && $statustypen->firstWhere('omschrijving', $mapping->eind_statustype) === null) {
+                $findings[] = new BlueprintFinding('eind_statustype', BlueprintFindingType::MappedValueNotFound, $mapping->eind_statustype);
+            }
         }
 
         return $findings;
@@ -118,6 +122,12 @@ final class ZaaktypeBlueprintHealth
      */
     private function checkResultaattypen(string $connectionName, string $identificatie, string $url, ?MunicipalityZaaktypeMapping $mapping): array
     {
+        // The ingetrokken-resultaattype only applies to organiser withdrawal;
+        // when that is off the koppeling form hides the field, so do not report it.
+        if (! ZgwConnectionConfig::allowsOrganiserWithdrawal($connectionName)) {
+            return [];
+        }
+
         $resultaattypen = $this->index($connectionName, $identificatie, 'resultaattypen', $url);
 
         if ($resultaattypen === null) {

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -114,4 +114,17 @@ class ZgwConnectionConfig
 
         return DocumentVertrouwelijkheden::Zaakvertrouwelijk->value;
     }
+
+    /**
+     * Whether an organiser may withdraw a zaak on this connection. Defaults to
+     * true, so the global "main" connection (and any connection without the key)
+     * keeps withdrawal enabled. Disabled per connection for a OneGround (RX
+     * Mission) backend, where the eind-status archives the zaak immediately.
+     */
+    public static function allowsOrganiserWithdrawal(string $connectionName): bool
+    {
+        $value = config("zgw.connections.{$connectionName}.allow_organiser_withdrawal");
+
+        return $value === null ? true : (bool) $value;
+    }
 }

--- a/database/factories/MunicipalityZgwConnectionFactory.php
+++ b/database/factories/MunicipalityZgwConnectionFactory.php
@@ -45,6 +45,7 @@ class MunicipalityZgwConnectionFactory extends Factory
             'show_adviesvragen_tab' => true,
             'show_organisatievragen_tab' => true,
             'suppress_notifications' => false,
+            'allow_organiser_withdrawal' => true,
         ];
     }
 

--- a/database/migrations/2026_07_02_202045_add_allow_organiser_withdrawal_to_municipality_zgw_connections.php
+++ b/database/migrations/2026_07_02_202045_add_allow_organiser_withdrawal_to_municipality_zgw_connections.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Whether an organiser may withdraw ("intrekken") a zaak from inside
+     * Eventloket. The default preserves the current behaviour (withdrawal
+     * allowed). It must be turned off for a OneGround (RX Mission) connection:
+     * there, setting the eind-status archives the zaak immediately and OneGround
+     * rejects it unless all related documents are already 'gearchiveerd', so
+     * the withdrawal flow cannot complete.
+     */
+    public function up(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table) {
+            $table->boolean('allow_organiser_withdrawal')->default(true)->after('suppress_notifications');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table) {
+            $table->dropColumn('allow_organiser_withdrawal');
+        });
+    }
+};

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -69,7 +69,7 @@ return [
         ],
         'lock_status_for_behandelaar' => [
             'label' => 'Status niet wijzigbaar door behandelaar',
-            'helper' => 'De behandelaar kan de status niet wijzigen en de zaak niet afronden in Eventloket. Intrekken door de organisator blijft mogelijk.',
+            'helper' => 'De behandelaar kan de status niet wijzigen en de zaak niet afronden in Eventloket. Intrekken door de organisator wordt apart geregeld met de instelling hieronder.',
         ],
         'show_besluiten_tab' => [
             'label' => 'Tabblad besluiten tonen',
@@ -90,6 +90,10 @@ return [
         'suppress_notifications' => [
             'label' => 'Geen notificaties versturen',
             'helper' => 'Onderdruk alle notificaties voor een zaak. Alleen de ontvangstbevestiging bij indienen wordt nog verstuurd.',
+        ],
+        'allow_organiser_withdrawal' => [
+            'label' => 'Intrekken door organisator toestaan',
+            'helper' => 'Sta toe dat een organisator een aanvraag intrekt via Eventloket. Zet dit uit voor een OneGround (RX Mission) koppeling: daar mislukt het intrekken omdat het zetten van de eindstatus de zaak meteen archiveert, wat pas mag als alle documenten gearchiveerd zijn.',
         ],
     ],
 

--- a/tests/Feature/Filament/Municipality/Resources/MunicipalityZaaktypeMappingResourceTest.php
+++ b/tests/Feature/Filament/Municipality/Resources/MunicipalityZaaktypeMappingResourceTest.php
@@ -7,6 +7,7 @@ use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZaaktypeMa
 use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZaaktypeMappings\Pages\EditMunicipalityZaaktypeMapping;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
+use App\Models\MunicipalityZgwConnection;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Cache;
@@ -132,6 +133,41 @@ it('does not eagerly read the dependent catalogi when opening the edit form', fu
     Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/resultaattypen'));
     Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/eigenschappen'));
     Http::assertNotSent(fn ($request): bool => str_contains($request->url(), '/zaaktype-informatieobjecttypen'));
+});
+
+it('hides the eind-statustype and ingetrokken-resultaattype when withdrawal is disabled', function () {
+    $base = 'https://gemeente.example.com';
+
+    MunicipalityZgwConnection::factory()->active()->create([
+        'municipality_id' => $this->municipality->id,
+        'allow_organiser_withdrawal' => false,
+    ]);
+
+    Http::fake([
+        "{$base}/catalogi/api/v1/zaaktypen*" => Http::response(ZgwHttpFake::envelope([
+            ['identificatie' => 'EVT-1', 'omschrijving' => 'Evenementenvergunning', 'url' => "{$base}/catalogi/api/v1/zaaktypen/1"],
+        ])),
+        "{$base}/catalogi/api/v1/statustypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Afgehandeld', 'volgnummer' => 1, 'isEindstatus' => true],
+        ])),
+        "{$base}/catalogi/api/v1/roltypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Aanvrager', 'omschrijvingGeneriek' => 'initiator'],
+        ])),
+        "{$base}/catalogi/api/v1/resultaattypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Afgebroken', 'omschrijvingGeneriek' => 'Afgebroken'],
+        ])),
+        "{$base}/catalogi/api/v1/*" => Http::response(ZgwHttpFake::envelope([])),
+    ]);
+
+    livewire(CreateMunicipalityZaaktypeMapping::class)
+        ->fillForm([
+            'role' => ZaaktypeRole::Vergunning->value,
+            'zaaktype_identificatie' => 'EVT-1',
+        ])
+        ->assertFormFieldIsHidden('eind_statustype')
+        ->assertFormFieldIsHidden('ingetrokken_resultaattype')
+        ->assertFormFieldIsVisible('initial_statustype')
+        ->assertFormFieldIsVisible('initiator_roltype');
 });
 
 it('rejects a second mapping for the same role', function () {

--- a/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
+++ b/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
@@ -35,6 +35,7 @@ test('without a connection row all behaviour defaults to the full feature set', 
     expect($zaak->showsTab('adviesvragen'))->toBeTrue();
     expect($zaak->showsTab('organisatievragen'))->toBeTrue();
     expect($zaak->suppressesNotifications())->toBeFalse();
+    expect($zaak->organiserCanWithdraw())->toBeTrue();
 });
 
 test('a municipality with its own connection cannot edit the risico classificatie', function () {
@@ -69,4 +70,16 @@ test('suppress_notifications is reflected by suppressesNotifications', function 
     $zaak = zaakForConnection(['suppress_notifications' => true]);
 
     expect($zaak->suppressesNotifications())->toBeTrue();
+});
+
+test('a connection allows organiser withdrawal by default', function () {
+    $zaak = zaakForConnection();
+
+    expect($zaak->organiserCanWithdraw())->toBeTrue();
+});
+
+test('allow_organiser_withdrawal disabled blocks organiser withdrawal', function () {
+    $zaak = zaakForConnection(['allow_organiser_withdrawal' => false]);
+
+    expect($zaak->organiserCanWithdraw())->toBeFalse();
 });

--- a/tests/Feature/Zgw/ZaaktypeBlueprintHealthWithdrawalTest.php
+++ b/tests/Feature/Zgw/ZaaktypeBlueprintHealthWithdrawalTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
+use App\Services\Zgw\ZaaktypeBlueprintHealth;
+use App\Services\Zgw\ZgwConnectionResolver;
+use App\ValueObjects\ZGW\BlueprintFinding;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+/**
+ * Fake a catalogus that lacks both an eind-statustype (no isEindstatus) and an
+ * Ingetrokken resultaattype, so those two blueprint slots would be reported as
+ * Missing unless withdrawal suppression kicks in.
+ */
+function fakeCatalogusWithoutEindOrIngetrokken(string $base): void
+{
+    Http::fake([
+        "{$base}/catalogi/api/v1/zaaktypen*" => Http::response(ZgwHttpFake::envelope([
+            ['identificatie' => 'EVT-1', 'omschrijving' => 'Evenementenvergunning', 'url' => "{$base}/catalogi/api/v1/zaaktypen/1"],
+        ])),
+        "{$base}/catalogi/api/v1/statustypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Ontvangen', 'volgnummer' => 1],
+        ])),
+        "{$base}/catalogi/api/v1/roltypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Aanvrager', 'omschrijvingGeneriek' => 'initiator'],
+        ])),
+        "{$base}/catalogi/api/v1/resultaattypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Verleend', 'omschrijvingGeneriek' => 'Verleend'],
+        ])),
+        "{$base}/catalogi/api/v1/zaaktype-informatieobjecttypen*" => Http::response(ZgwHttpFake::envelope([
+            ['informatieobjecttype' => "{$base}/catalogi/api/v1/informatieobjecttypen/1"],
+        ])),
+        "{$base}/catalogi/api/v1/informatieobjecttypen/1" => Http::response([
+            'url' => "{$base}/catalogi/api/v1/informatieobjecttypen/1",
+            'omschrijving' => 'Aanvraag',
+        ]),
+        "{$base}/catalogi/api/v1/eigenschappen*" => Http::response(ZgwHttpFake::envelope([
+            ['naam' => 'intern_zaaknummer'],
+        ])),
+    ]);
+}
+
+/**
+ * @return list<string>
+ */
+function healthSlots(Municipality $municipality): array
+{
+    $connectionName = app(ZgwConnectionResolver::class)->forManagement($municipality);
+
+    return array_map(
+        fn (BlueprintFinding $finding): string => $finding->slot,
+        app(ZaaktypeBlueprintHealth::class)->check($connectionName, 'EVT-1', null),
+    );
+}
+
+beforeEach(function () {
+    Cache::flush();
+    $this->municipality = Municipality::factory()->create();
+});
+
+test('withdrawal disabled suppresses eind-statustype and ingetrokken-resultaattype findings', function () {
+    MunicipalityZgwConnection::factory()->create([
+        'municipality_id' => $this->municipality->id,
+        'allow_organiser_withdrawal' => false,
+    ]);
+    fakeCatalogusWithoutEindOrIngetrokken('https://gemeente.example.com');
+
+    $slots = healthSlots($this->municipality);
+
+    expect($slots)->not->toContain('eind_statustype')
+        ->and($slots)->not->toContain('ingetrokken_resultaattype');
+});
+
+test('withdrawal enabled still reports the missing eind-statustype and ingetrokken-resultaattype', function () {
+    MunicipalityZgwConnection::factory()->create([
+        'municipality_id' => $this->municipality->id,
+        'allow_organiser_withdrawal' => true,
+    ]);
+    fakeCatalogusWithoutEindOrIngetrokken('https://gemeente.example.com');
+
+    $slots = healthSlots($this->municipality);
+
+    expect($slots)->toContain('eind_statustype')
+        ->and($slots)->toContain('ingetrokken_resultaattype');
+});


### PR DESCRIPTION
## Why

On a OneGround (RX Mission) connection an organiser cannot withdraw a zaak. Setting the eind-status archives the zaak immediately (the `archiefstatus` jumps to `gearchiveerd`), and OpenZaak rejects that with `documents-not-archived` as long as not all related documents are already `gearchiveerd`. As a result the withdrawal flow (`AddResultaatZGW` + `AddFinalStatusZGW`) cannot complete. Forcing the documents to `gearchiveerd` is not an option: it locks them irreversibly and also affects internal documents.

Until this is resolved on the catalogus/OneGround side, withdrawal must be switchable per connection.

## What

A new per-connection option `allow_organiser_withdrawal` (same pattern as `lock_status_for_behandelaar`):

- Migration: boolean `allow_organiser_withdrawal`, default `true` (current behaviour preserved; the main connection and existing rows are unaffected).
- Model: property, `$fillable` and boolean cast.
- `Zaak::organiserCanWithdraw()`: the main connection always allows it, otherwise it follows the connection flag.
- The "Aanvraag intrekken" action in the organiser view is hidden when the option is off.
- Toggle in the ZGW connection form, with helper text noting it must be turned off for now for a OneGround (RX Mission) connection.
- Tests extended in `ConnectionFeatureFlagsTest`.

Note: this hides the action in the UI (consistent with the other per-connection flags); it is not a server-side guard on the action itself.