### PR TITLE
Build the doorkomst initiator from the form, not the copied ZGW rol

### DIFF
--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -12,6 +12,7 @@ use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use App\Normalizers\OpenFormsNormalizer;
+use App\Services\Zgw\InitiatorRolBuilder;
 use App\Services\Zgw\ZaakReadModel;
 use App\Services\Zgw\ZaaktypeBlueprint;
 use App\Services\Zgw\ZgwResource;
@@ -89,8 +90,14 @@ class CreateDoorkomstZaken implements ShouldQueue
             $this->zaak->zgw_zaak_url.'?expand=zaakobjecten,eigenschappen,rollen,zaakinformatieobjecten'
         ));
 
+        // The initiator is rebuilt from the form's aanvrager data (same source as
+        // the hoofdzaak), not copied from the hoofdzaak ZGW rol: that rol's
+        // betrokkeneIdentificatie is empty and its betrokkene url is not portable
+        // across instances.
+        $initiator = $map->buildInitiator($state);
+
         foreach ($passing as $muniRef) {
-            $this->createDeelzaakFor($hoofdConnectionName, $ozZaak, $muniRef, $state);
+            $this->createDeelzaakFor($hoofdConnectionName, $ozZaak, $muniRef, $state, $initiator);
         }
     }
 
@@ -114,7 +121,10 @@ class CreateDoorkomstZaken implements ShouldQueue
         return ArrayHelper::findElementWithKey($decoded, 'coordinates');
     }
 
-    private function createDeelzaakFor(string $hoofdConnectionName, ZaakReadModel $hoofdZaak, Municipality $muniRef, FormState $state): void
+    /**
+     * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
+     */
+    private function createDeelzaakFor(string $hoofdConnectionName, ZaakReadModel $hoofdZaak, Municipality $muniRef, FormState $state, array $initiator): void
     {
         /** @var Municipality|null $municipality */
         $municipality = Municipality::where('brk_identification', $muniRef->brk_identification)->first();
@@ -180,8 +190,8 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
 
         $this->copyZaakeigenschappen($deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
-        $this->copyInitiator($deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
-        $this->copyDocumenten($hoofdConnectionName, $deelConnection, $hoofdZaak, $newZaakUrl);
+        $this->createInitiator($deelConnection, $newZaakUrl, $doorkomstZaaktype, $state, $initiator);
+        $this->copyDocumenten($hoofdConnectionName, $deelConnectionName, $deelConnection, $hoofdZaak, $newZaakUrl);
         $this->createInitieleStatus($deelConnection, $newZaakUrl, $doorkomstZaaktype);
 
         $newOzZaak = ZaakReadModel::fromArray(ZgwResource::byUrl(
@@ -266,34 +276,50 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
     }
 
-    private function copyInitiator(ZgwConnection $deelConnection, ZaakReadModel $ozZaak, string $newZaakUrl, Zaaktype $doorkomstZaaktype): void
+    /**
+     * Register the initiator on the deelzaak from the form's aanvrager data,
+     * mirroring the hoofdzaak initiator ({@see UpdateInitiatorZGW}).
+     * The hoofdzaak ZGW rol is deliberately not copied: its betrokkeneIdentificatie
+     * is empty and its betrokkene url points at the source instance.
+     *
+     * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
+     */
+    private function createInitiator(ZgwConnection $deelConnection, string $newZaakUrl, Zaaktype $doorkomstZaaktype, FormState $state, array $initiator): void
     {
-        if (! $ozZaak->initiator) {
+        if ($initiator === []) {
             return;
         }
 
         $roltypen = $deelConnection->catalogi()->roltypen()->index(['zaaktype' => $doorkomstZaaktype->zgw_zaaktype_url]);
         $mapping = MunicipalityZaaktypeMapping::forZaaktype($doorkomstZaaktype);
-        $initiator = ZaaktypeBlueprint::initiatorRoltype($mapping, $roltypen);
-        if (! $initiator) {
+        $roltype = ZaaktypeBlueprint::initiatorRoltype($mapping, $roltypen);
+        if (! $roltype) {
             Log::warning('CreateDoorkomstZaken: no initiator roltype', ['zaak' => $newZaakUrl]);
 
             return;
         }
 
-        $source = $ozZaak->initiator;
-        $deelConnection->zaken()->rollen()->store([
-            'zaak' => $newZaakUrl,
-            'betrokkeneType' => $source['betrokkeneType'] ?? null,
-            'roltype' => $initiator['url'],
-            'roltoelichting' => $source['omschrijving'] ?? null,
-            'betrokkeneIdentificatie' => $source['betrokkeneIdentificatie'] ?? null,
-            'contactpersoonRol' => ($source['contactpersoonRol'] ?? null) ?: null,
-        ]);
+        $rolData = InitiatorRolBuilder::build($newZaakUrl, $roltype['url'], $state, $initiator);
+        if ($rolData === null) {
+            return;
+        }
+
+        $deelConnection->zaken()->rollen()->store($rolData);
     }
 
-    private function copyDocumenten(string $hoofdConnectionName, ZgwConnection $deelConnection, ZaakReadModel $ozZaak, string $newZaakUrl): void
+    private function copyDocumenten(string $hoofdConnectionName, string $deelConnectionName, ZgwConnection $deelConnection, ZaakReadModel $ozZaak, string $newZaakUrl): void
     {
+        // Documents are linked by informatieobject url. That url lives in the
+        // hoofdzaak's documenten API, which a different-instance target does not
+        // know ("unknown-service"), so cross-instance document links are skipped.
+        // Copying them would require downloading and re-uploading into the target
+        // documenten API.
+        if ($deelConnectionName !== $hoofdConnectionName) {
+            Log::warning('CreateDoorkomstZaken: skipping cross-instance document links', ['zaak' => $newZaakUrl]);
+
+            return;
+        }
+
         $zios = Zgw::connection($hoofdConnectionName)->zaken()->zaakinformatieobjecten()->index(['zaak' => $ozZaak->url]);
         foreach ($zios as $zio) {
             $informatieobjectUrl = Arr::get($zio, 'informatieobject');

--- a/app/Jobs/Zaak/UpdateInitiatorZGW.php
+++ b/app/Jobs/Zaak/UpdateInitiatorZGW.php
@@ -8,13 +8,12 @@ use App\EventForm\State\FormState;
 use App\EventForm\Submit\ZaakeigenschappenMap;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaak;
+use App\Services\Zgw\InitiatorRolBuilder;
 use App\Services\Zgw\ZaakReadModel;
 use App\Services\Zgw\ZaaktypeBlueprint;
 use App\Services\Zgw\ZgwResource;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use Woweb\Zgw\Connection\ZgwConnection;
 use Woweb\Zgw\Facades\Zgw;
 
@@ -58,9 +57,10 @@ class UpdateInitiatorZGW implements ShouldQueue
             return;
         }
 
-        $rolData = isset($initiator['kvk']) && $initiator['kvk']
-            ? $this->buildNietNatuurlijkPersoonRol($ozZaak->url, $roltype, $initiator)
-            : $this->buildNatuurlijkPersoonRol($ozZaak->url, $roltype, $state, $initiator);
+        $rolData = InitiatorRolBuilder::build($ozZaak->url, $roltype, $state, $initiator);
+        if ($rolData === null) {
+            return;
+        }
 
         $connection->zaken()->rollen()->store($rolData);
     }
@@ -72,60 +72,5 @@ class UpdateInitiatorZGW implements ShouldQueue
         $initiator = ZaaktypeBlueprint::initiatorRoltype($mapping, $roltypen);
 
         return $initiator['url'] ?? null;
-    }
-
-    /** @param  array<string, mixed>  $initiator */
-    private function buildNietNatuurlijkPersoonRol(string $zaakUrl, string $roltype, array $initiator): array
-    {
-        return [
-            'zaak' => $zaakUrl,
-            'betrokkeneType' => 'niet_natuurlijk_persoon',
-            'roltype' => $roltype,
-            'roltoelichting' => 'inzender formulier',
-            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
-            // We send only kvkNummer as the company identifier, for every
-            // connection (OpenZaak included). annIdentificatie is deliberately
-            // omitted: not every ZGW instance accepts it and the KvK number is
-            // the canonical identifier.
-            'betrokkeneIdentificatie' => array_filter([
-                'statutaireNaam' => $initiator['organisatie_naam'] ?? null,
-                'kvkNummer' => $initiator['kvk'],
-            ]),
-        ];
-    }
-
-    /** @param  array<string, mixed>  $initiator */
-    private function buildNatuurlijkPersoonRol(string $zaakUrl, string $roltype, FormState $state, array $initiator): array
-    {
-        $voornaam = (string) $state->get('watIsUwVoornaam');
-        $achternaam = (string) $state->get('watIsUwAchternaam');
-        $adres = $state->get('natuurlijkPersoonAdres');
-
-        $rolData = [
-            'zaak' => $zaakUrl,
-            'betrokkeneType' => 'natuurlijk_persoon',
-            'roltype' => $roltype,
-            'roltoelichting' => 'inzender formulier',
-            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
-            'betrokkeneIdentificatie' => array_filter([
-                'geslachtsnaam' => $achternaam !== '' ? $achternaam : null,
-                'voornamen' => $voornaam !== '' ? $voornaam : null,
-            ]),
-        ];
-
-        if (is_array($adres) && Arr::has($adres, ['postcode', 'plaatsnaam', 'huisnummer'])
-            && (empty($adres['land']) || strtolower((string) $adres['land']) === 'nederland')) {
-            $rolData['betrokkeneIdentificatie']['verblijfsadres'] = [
-                'aoaIdentificatie' => config('app.name').'-persoonsadres-'.Str::uuid(),
-                'wplWoonplaatsNaam' => $adres['plaatsnaam'] ?? null,
-                'gorOpenbareRuimteNaam' => 'adres',
-                'aoaPostcode' => $adres['postcode'] ?? null,
-                'aoaHuisnummer' => $adres['huisnummer'] ?? null,
-                'aoaHuisletter' => $adres['huisletter'] ?? null,
-                'aoaHuisnummertoevoeging' => $adres['huisnummertoevoeging'] ?? null,
-            ];
-        }
-
-        return $rolData;
     }
 }

--- a/app/Services/Zgw/InitiatorRolBuilder.php
+++ b/app/Services/Zgw/InitiatorRolBuilder.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\EventForm\State\FormState;
+use App\Jobs\Zaak\CreateDoorkomstZaken;
+use App\Jobs\Zaak\UpdateInitiatorZGW;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+
+/**
+ * Builds the initiator rol payload from the form's initiator block. Shared by
+ * {@see UpdateInitiatorZGW} (the hoofdzaak) and
+ * {@see CreateDoorkomstZaken} (each doorkomst deelzaak), so a
+ * deelzaak gets the same, properly filled aanvrager identification instead of a
+ * copied ZGW rol whose betrokkeneIdentificatie is empty across instances.
+ *
+ * Two variants, matching the aanvrager:
+ * - has a KvK number → niet_natuurlijk_persoon (statutaireNaam, kvkNummer)
+ * - otherwise        → natuurlijk_persoon (voornamen, geslachtsnaam, adres)
+ */
+final class InitiatorRolBuilder
+{
+    /**
+     * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
+     * @return array<string, mixed>|null rol payload, or null when there is no initiator data
+     */
+    public static function build(string $zaakUrl, string $roltype, FormState $state, array $initiator): ?array
+    {
+        if ($initiator === []) {
+            return null;
+        }
+
+        return isset($initiator['kvk']) && $initiator['kvk']
+            ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator)
+            : self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator);
+    }
+
+    /**
+     * @param  array<string, mixed>  $initiator
+     * @return array<string, mixed>
+     */
+    private static function nietNatuurlijkPersoon(string $zaakUrl, string $roltype, array $initiator): array
+    {
+        return [
+            'zaak' => $zaakUrl,
+            'betrokkeneType' => 'niet_natuurlijk_persoon',
+            'roltype' => $roltype,
+            'roltoelichting' => 'inzender formulier',
+            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            // We send only kvkNummer as the company identifier, for every
+            // connection (OpenZaak included). annIdentificatie is deliberately
+            // omitted: not every ZGW instance accepts it and the KvK number is
+            // the canonical identifier.
+            'betrokkeneIdentificatie' => array_filter([
+                'statutaireNaam' => $initiator['organisatie_naam'] ?? null,
+                'kvkNummer' => $initiator['kvk'],
+            ]),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $initiator
+     * @return array<string, mixed>
+     */
+    private static function natuurlijkPersoon(string $zaakUrl, string $roltype, FormState $state, array $initiator): array
+    {
+        $voornaam = (string) $state->get('watIsUwVoornaam');
+        $achternaam = (string) $state->get('watIsUwAchternaam');
+        $adres = $state->get('natuurlijkPersoonAdres');
+
+        $rolData = [
+            'zaak' => $zaakUrl,
+            'betrokkeneType' => 'natuurlijk_persoon',
+            'roltype' => $roltype,
+            'roltoelichting' => 'inzender formulier',
+            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            'betrokkeneIdentificatie' => array_filter([
+                'geslachtsnaam' => $achternaam !== '' ? $achternaam : null,
+                'voornamen' => $voornaam !== '' ? $voornaam : null,
+            ]),
+        ];
+
+        if (is_array($adres) && Arr::has($adres, ['postcode', 'plaatsnaam', 'huisnummer'])
+            && (empty($adres['land']) || strtolower((string) $adres['land']) === 'nederland')) {
+            $rolData['betrokkeneIdentificatie']['verblijfsadres'] = [
+                'aoaIdentificatie' => config('app.name').'-persoonsadres-'.Str::uuid(),
+                'wplWoonplaatsNaam' => $adres['plaatsnaam'] ?? null,
+                'gorOpenbareRuimteNaam' => 'adres',
+                'aoaPostcode' => $adres['postcode'] ?? null,
+                'aoaHuisnummer' => $adres['huisnummer'] ?? null,
+                'aoaHuisletter' => $adres['huisletter'] ?? null,
+                'aoaHuisnummertoevoeging' => $adres['huisnummertoevoeging'] ?? null,
+            ];
+        }
+
+        return $rolData;
+    }
+}

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -288,6 +288,29 @@ test('registers the initiator on the deelzaak from the form aanvrager data, not 
         && ($request->data()['betrokkeneIdentificatie']['statutaireNaam'] ?? null) === 'Woweb');
 });
 
+test('registers a natuurlijk_persoon initiator from the form name when there is no KvK', function () {
+    // A private aanvrager (no KvK). The name is not among the hashed snapshot
+    // keys, and the builder sends no BSN, so a valid natuurlijk_persoon rol is
+    // registered on the deelzaak.
+    fakeDoorkomstForInitiator();
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    $scenario['hoofdzaak']->update(['form_state_snapshot' => routeSnapshotWithValues([
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Jansen',
+    ])]);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen')
+        && $request->data()['betrokkeneType'] === 'natuurlijk_persoon'
+        && ($request->data()['betrokkeneIdentificatie']['geslachtsnaam'] ?? null) === 'Jansen'
+        && ($request->data()['betrokkeneIdentificatie']['voornamen'] ?? null) === 'Jan'
+        && ! array_key_exists('kvkNummer', $request->data()['betrokkeneIdentificatie']));
+});
+
 test('skips the initiator when the form has no aanvrager data', function () {
     fakeDoorkomstForInitiator();
 

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -215,6 +215,93 @@ test('sets the ZGW hoofdzaak reference when the doorkomst gemeente shares the ho
         && ($request->data()['hoofdzaak'] ?? null) === ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1');
 });
 
+/**
+ * Fake a cross-instance doorkomst (own-instance hoofdzaak, main deelzaak). The
+ * target roltypen expose an initiator roltype so the initiator is registered,
+ * and the rollen POST is captured.
+ */
+function fakeDoorkomstForInitiator(): void
+{
+    Http::fake([
+        OWN_HOST.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => OWN_HOST.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => OWN_HOST.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        OWN_HOST.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/roltypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/roltypen/init', 'omschrijvingGeneriek' => 'initiator'],
+        ]), 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen*' => Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen/1'], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(deelZaakReadResponse(), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+}
+
+function withPassingDoorkomstZaaktype(Municipality $passing): void
+{
+    Zaaktype::factory()->create([
+        'municipality_id' => $passing->id,
+        'role' => ZaaktypeRole::Doorkomst,
+        'connection' => 'main',
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/dk-m',
+        'is_active' => true,
+    ]);
+}
+
+/** A route snapshot plus the given aanvrager form values. */
+function routeSnapshotWithValues(array $values): array
+{
+    return ['values' => array_merge(routeSnapshot()['values'], $values)];
+}
+
+test('registers the initiator on the deelzaak from the form aanvrager data, not the copied ZGW rol', function () {
+    // The initiator is rebuilt from the form (KvK + organisation name), matching
+    // the hoofdzaak. The hoofdzaak ZGW rol is not copied: its identificatie is
+    // empty and its betrokkene url is not portable across instances.
+    fakeDoorkomstForInitiator();
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    $scenario['hoofdzaak']->update(['form_state_snapshot' => routeSnapshotWithValues([
+        'watIsHetKamerVanKoophandelNummerVanUwOrganisatie' => '12345678',
+        'watIsDeNaamVanUwOrganisatie' => 'Woweb',
+    ])]);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen')
+        && $request->data()['betrokkeneType'] === 'niet_natuurlijk_persoon'
+        && $request->data()['roltype'] === ZgwHttpFake::$baseUrl.'/catalogi/api/v1/roltypen/init'
+        && ($request->data()['betrokkeneIdentificatie']['kvkNummer'] ?? null) === '12345678'
+        && ($request->data()['betrokkeneIdentificatie']['statutaireNaam'] ?? null) === 'Woweb');
+});
+
+test('skips the initiator when the form has no aanvrager data', function () {
+    fakeDoorkomstForInitiator();
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    // Only the route, no aanvrager fields → buildInitiator() is empty.
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    expect(Zaak::where('hoofdzaak_id', $scenario['hoofdzaak']->id)->count())->toBe(1);
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen'));
+});
+
 test('does not create a doorkomst zaak when the passing gemeente has no doorkomst zaaktype', function () {
     fakeDoorkomstZgw();
     $scenario = doorkomstScenario(hoofdOwnInstance: true);

--- a/tests/Unit/Zgw/InitiatorRolBuilderTest.php
+++ b/tests/Unit/Zgw/InitiatorRolBuilderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\EventForm\State\FormState;
+use App\Services\Zgw\InitiatorRolBuilder;
+
+test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => 'Organisator Test'],
+    ]);
+
+    expect($rol['betrokkeneType'])->toBe('niet_natuurlijk_persoon')
+        ->and($rol['roltype'])->toBe('https://zgw/roltype/1')
+        ->and($rol['betrokkeneIdentificatie']['kvkNummer'])->toBe('12345678')
+        ->and($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
+        ->and($rol['contactpersoonRol'])->toBe(['naam' => 'Organisator Test']);
+});
+
+test('builds a natuurlijk_persoon rol from name when there is no KvK', function () {
+    $state = FormState::fromSnapshot(['values' => [
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Jansen',
+    ]]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'contactpersoon' => ['naam' => 'Jan Jansen'],
+    ]);
+
+    expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
+        ->and($rol['betrokkeneIdentificatie']['geslachtsnaam'])->toBe('Jansen')
+        ->and($rol['betrokkeneIdentificatie']['voornamen'])->toBe('Jan');
+});
+
+test('returns null when there is no initiator data', function () {
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    expect(InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, []))->toBeNull();
+});


### PR DESCRIPTION
## Why

Creating doorkomst gemeenten fails. A cross-instance doorkomst reads the hoofdzaak from one ZGW instance (RX Mission / OneGround) and creates the deelzaak on another (main OpenZaak). `CreateDoorkomstZaken` copied the hoofdzaak initiator rol verbatim to the deelzaak.

On the source instance the initiator rol has an empty `betrokkeneIdentificatie` (all fields null) and its identity sits behind a `betrokkene` url in the source instance. Sent verbatim, the target OpenZaak rejects it (`POST /rollen` 400: "Dit veld mag niet leeg zijn."), which aborts the whole deelzaak creation.

## What

Rebuild the initiator from the form's aanvrager data instead of copying the ZGW rol, exactly like the hoofdzaak (`UpdateInitiatorZGW`):

- New shared `InitiatorRolBuilder` produces a filled rol: `niet_natuurlijk_persoon` (KvK + statutaireNaam) or `natuurlijk_persoon` (name + address). `UpdateInitiatorZGW` and `CreateDoorkomstZaken` both use it.
- `CreateDoorkomstZaken` builds the initiator via `ZaakeigenschappenMap::buildInitiator()` from the form state. It runs before `HashIdentifyingAttributes` in the submit chain, so the KvK is still plain.
- Cross-instance document links are skipped: an informatieobject url from the hoofdzaak documenten API is unknown to a different-instance target (`unknown-service`), so those links are skipped rather than aborting the deelzaak.

Verified against staging data: the deelzaak is created with an initiator `niet_natuurlijk_persoon` carrying the real `kvkNummer` and `statutaireNaam`. Covered by an `InitiatorRolBuilder` unit test and `CreateDoorkomstZaken` feature tests (initiator registered from the form; skipped when there is no aanvrager data).