### PR TITLE
Copy doorkomst documents across ZGW instances

### DIFF
--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -15,6 +15,7 @@ use App\Normalizers\OpenFormsNormalizer;
 use App\Services\Zgw\InitiatorRolBuilder;
 use App\Services\Zgw\ZaakReadModel;
 use App\Services\Zgw\ZaaktypeBlueprint;
+use App\Services\Zgw\ZgwConnectionConfig;
 use App\Services\Zgw\ZgwResource;
 use App\Support\Helpers\ArrayHelper;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
@@ -26,6 +27,7 @@ use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 use Woweb\Zgw\Connection\ZgwConnection;
 use Woweb\Zgw\Data\Generated\Catalogi\EigenschapData;
 use Woweb\Zgw\Facades\Zgw;
@@ -42,6 +44,15 @@ use Woweb\Zgw\Facades\Zgw;
 class CreateDoorkomstZaken implements ShouldQueue
 {
     use Queueable;
+
+    /**
+     * Memoized omschrijving of the hoofdzaak's aanvraag informatieobjecttype, used
+     * to recognise the aanvraag PDF when copying documents cross-instance. Resolved
+     * lazily once per job run ({@see self::hoofdAanvraagOmschrijving()}).
+     */
+    private ?string $hoofdAanvraagOmschrijving = null;
+
+    private bool $hoofdAanvraagResolved = false;
 
     public function __construct(public readonly Zaak $zaak) {}
 
@@ -191,7 +202,7 @@ class CreateDoorkomstZaken implements ShouldQueue
 
         $this->copyZaakeigenschappen($deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
         $this->createInitiator($deelConnection, $newZaakUrl, $doorkomstZaaktype, $state, $initiator);
-        $this->copyDocumenten($hoofdConnectionName, $deelConnectionName, $deelConnection, $hoofdZaak, $newZaakUrl);
+        $this->copyDocumenten($hoofdConnectionName, $deelConnectionName, $deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
         $this->createInitieleStatus($deelConnection, $newZaakUrl, $doorkomstZaaktype);
 
         $newOzZaak = ZaakReadModel::fromArray(ZgwResource::byUrl(
@@ -307,18 +318,19 @@ class CreateDoorkomstZaken implements ShouldQueue
         $deelConnection->zaken()->rollen()->store($rolData);
     }
 
-    private function copyDocumenten(string $hoofdConnectionName, string $deelConnectionName, ZgwConnection $deelConnection, ZaakReadModel $ozZaak, string $newZaakUrl): void
+    private function copyDocumenten(string $hoofdConnectionName, string $deelConnectionName, ZgwConnection $deelConnection, ZaakReadModel $ozZaak, string $newZaakUrl, Zaaktype $doorkomstZaaktype): void
     {
-        // Documents are linked by informatieobject url. That url lives in the
-        // hoofdzaak's documenten API, which a different-instance target does not
-        // know ("unknown-service"), so cross-instance document links are skipped.
-        // Copying them would require downloading and re-uploading into the target
-        // documenten API.
-        if ($deelConnectionName !== $hoofdConnectionName) {
-            Log::warning('CreateDoorkomstZaken: skipping cross-instance document links', ['zaak' => $newZaakUrl]);
+        // Same instance: the informatieobject url is directly linkable. Cross
+        // instance: the url lives in the hoofdzaak's documenten API, which the
+        // target does not know, so each document is downloaded and re-created in the
+        // target documenten API before linking (see copyDocumentToTargetInstance).
+        $sameInstance = $deelConnectionName === $hoofdConnectionName;
 
-            return;
-        }
+        // Resolving a target informatieobjecttype is only needed cross-instance; the
+        // source type url is not portable and must be re-mapped by omschrijving. The
+        // mapping and the source-type omschrijvingen are resolved at most once here.
+        $deelMapping = $sameInstance ? null : MunicipalityZaaktypeMapping::forZaaktype($doorkomstZaaktype);
+        $sourceTypeOmschrijvingen = [];
 
         $zios = Zgw::connection($hoofdConnectionName)->zaken()->zaakinformatieobjecten()->index(['zaak' => $ozZaak->url]);
         foreach ($zios as $zio) {
@@ -326,11 +338,211 @@ class CreateDoorkomstZaken implements ShouldQueue
             if (! $informatieobjectUrl) {
                 continue;
             }
+
+            if ($sameInstance) {
+                $deelConnection->zaken()->zaakinformatieobjecten()->store([
+                    'zaak' => $newZaakUrl,
+                    'informatieobject' => $informatieobjectUrl,
+                ]);
+
+                continue;
+            }
+
+            // A single failing document is logged and skipped so the remaining
+            // documents and the deelzaak's status/local record are still created:
+            // re-running the job would create a duplicate ZGW deelzaak (the
+            // idempotency check is local), so aborting here is worse than losing
+            // one document, which can be re-added by hand.
+            try {
+                $targetUrl = $this->copyDocumentToTargetInstance(
+                    $hoofdConnectionName,
+                    $deelConnectionName,
+                    $deelConnection,
+                    (string) $informatieobjectUrl,
+                    $ozZaak->bronorganisatie,
+                    $doorkomstZaaktype,
+                    $deelMapping,
+                    $sourceTypeOmschrijvingen,
+                );
+            } catch (Throwable $e) {
+                Log::error('CreateDoorkomstZaken: failed to copy document to target instance', [
+                    'zaak' => $newZaakUrl,
+                    'informatieobject' => $informatieobjectUrl,
+                    'exception' => $e->getMessage(),
+                ]);
+
+                continue;
+            }
+
+            if ($targetUrl === null) {
+                continue;
+            }
+
             $deelConnection->zaken()->zaakinformatieobjecten()->store([
                 'zaak' => $newZaakUrl,
-                'informatieobject' => $informatieobjectUrl,
+                'informatieobject' => $targetUrl,
             ]);
         }
+    }
+
+    /**
+     * Download an enkelvoudiginformatieobject from the hoofdzaak's documenten API
+     * and re-create it in the deelzaak's instance. Returns the new EIO url, or null
+     * when no target informatieobjecttype could be resolved (document then skipped).
+     *
+     * @param  array<string, string>  $sourceTypeOmschrijvingen  memo: source type url => omschrijving
+     */
+    private function copyDocumentToTargetInstance(
+        string $hoofdConnectionName,
+        string $deelConnectionName,
+        ZgwConnection $deelConnection,
+        string $informatieobjectUrl,
+        string $bronorganisatie,
+        Zaaktype $doorkomstZaaktype,
+        ?MunicipalityZaaktypeMapping $deelMapping,
+        array &$sourceTypeOmschrijvingen,
+    ): ?string {
+        $eio = ZgwResource::byUrl($hoofdConnectionName, $informatieobjectUrl);
+
+        $targetType = $this->resolveTargetInformatieobjecttype(
+            $hoofdConnectionName,
+            (string) ($eio['informatieobjecttype'] ?? ''),
+            $doorkomstZaaktype,
+            $deelMapping,
+            $sourceTypeOmschrijvingen,
+        );
+        if ($targetType === null) {
+            Log::warning('CreateDoorkomstZaken: no target informatieobjecttype for document copy', [
+                'informatieobject' => $informatieobjectUrl,
+                'zaaktype' => $doorkomstZaaktype->zgw_zaaktype_url,
+            ]);
+
+            return null;
+        }
+
+        $content = ZgwResource::downloadDocument($hoofdConnectionName, (string) ($eio['uuid'] ?? ''));
+
+        $payload = [
+            'bronorganisatie' => $bronorganisatie,
+            'creatiedatum' => $eio['creatiedatum'] ?? now()->format('Y-m-d'),
+            'vertrouwelijkheidaanduiding' => $eio['vertrouwelijkheidaanduiding'] ?? ZgwConnectionConfig::systemUploadDefault($deelConnectionName),
+            'titel' => $eio['titel'] ?? ($eio['bestandsnaam'] ?? 'Document'),
+            'auteur' => $eio['auteur'] ?? 'Onbekend',
+            'taal' => $eio['taal'] ?? 'dut',
+            'bestandsnaam' => $eio['bestandsnaam'] ?? '',
+            'bestandsomvang' => strlen($content),
+            'formaat' => ($eio['formaat'] ?? '') ?: 'application/octet-stream',
+            'inhoud' => base64_encode($content),
+            'informatieobjecttype' => $targetType,
+            'indicatieGebruiksrecht' => false,
+        ];
+
+        // Preserve draft/definitief and the description when the source carries them.
+        if (! empty($eio['status'])) {
+            $payload['status'] = $eio['status'];
+        }
+        if (! empty($eio['beschrijving'])) {
+            $payload['beschrijving'] = $eio['beschrijving'];
+        }
+
+        $response = $deelConnection->documenten()->enkelvoudiginformatieobjecten()->store($payload);
+
+        $newUrl = $response['url'] ?? null;
+        if (! $newUrl) {
+            Log::error('CreateDoorkomstZaken: target documenten store returned no url', [
+                'informatieobject' => $informatieobjectUrl,
+            ]);
+
+            return null;
+        }
+
+        return (string) $newUrl;
+    }
+
+    /**
+     * Resolve the target-instance informatieobjecttype url for a copied document.
+     * The source type url is not portable across instances, so match by omschrijving:
+     * an exact omschrijving match on the deelzaaktype's types, else the aanvraag or
+     * bijlage blueprint slot, else null.
+     *
+     * @param  array<string, string>  $sourceTypeOmschrijvingen  memo: source type url => omschrijving
+     */
+    private function resolveTargetInformatieobjecttype(
+        string $hoofdConnectionName,
+        string $sourceTypeValue,
+        Zaaktype $doorkomstZaaktype,
+        ?MunicipalityZaaktypeMapping $deelMapping,
+        array &$sourceTypeOmschrijvingen,
+    ): ?string {
+        $types = $doorkomstZaaktype->documentTypesForUser();
+        if ($types->isEmpty()) {
+            return null;
+        }
+
+        $sourceOmschrijving = $this->sourceTypeOmschrijving($hoofdConnectionName, $sourceTypeValue, $sourceTypeOmschrijvingen);
+
+        if ($sourceOmschrijving !== '') {
+            $exact = $types->first(fn ($type) => property_exists($type, 'omschrijving') && $type->omschrijving === $sourceOmschrijving);
+            if ($exact) {
+                return (string) $exact->url;
+            }
+        }
+
+        // The aanvraag PDF maps to the deelzaaktype's aanvraag slot; anything else is
+        // treated as a bijlage.
+        $isAanvraag = $sourceOmschrijving !== '' && $sourceOmschrijving === $this->hoofdAanvraagOmschrijving();
+        $target = $isAanvraag
+            ? ZaaktypeBlueprint::aanvraagInformatieobjecttype($deelMapping, $types)
+            : ZaaktypeBlueprint::bijlageInformatieobjecttype($deelMapping, $types);
+
+        return $target ? (string) $target->url : null;
+    }
+
+    /**
+     * The omschrijving of a source informatieobjecttype value: a followable url is
+     * fetched (and memoized), an inline value is the omschrijving itself.
+     *
+     * @param  array<string, string>  $memo  source type url => omschrijving
+     */
+    private function sourceTypeOmschrijving(string $hoofdConnectionName, string $value, array &$memo): string
+    {
+        if ($value === '') {
+            return '';
+        }
+        if (! str_starts_with($value, 'http')) {
+            return $value;
+        }
+        if (array_key_exists($value, $memo)) {
+            return $memo[$value];
+        }
+
+        $type = ZgwResource::byUrl($hoofdConnectionName, $value);
+
+        return $memo[$value] = (string) ($type['omschrijving'] ?? '');
+    }
+
+    /**
+     * The omschrijving of the hoofdzaak's aanvraag informatieobjecttype, resolved
+     * from its own zaaktype blueprint and memoized for the whole job run.
+     */
+    private function hoofdAanvraagOmschrijving(): ?string
+    {
+        if ($this->hoofdAanvraagResolved) {
+            return $this->hoofdAanvraagOmschrijving;
+        }
+        $this->hoofdAanvraagResolved = true;
+
+        $zaaktype = $this->zaak->zaaktype;
+        if (! $zaaktype) {
+            return $this->hoofdAanvraagOmschrijving = null;
+        }
+
+        $mapping = MunicipalityZaaktypeMapping::forZaaktype($zaaktype);
+        $aanvraag = ZaaktypeBlueprint::aanvraagInformatieobjecttype($mapping, $zaaktype->documentTypesForUser());
+
+        return $this->hoofdAanvraagOmschrijving = ($aanvraag && property_exists($aanvraag, 'omschrijving'))
+            ? $aanvraag->omschrijving
+            : null;
     }
 
     private function createInitieleStatus(ZgwConnection $deelConnection, string $newZaakUrl, Zaaktype $doorkomstZaaktype): void

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -335,6 +335,276 @@ test('does not create a doorkomst zaak when the passing gemeente has no doorkoms
     expect(Zaak::where('hoofdzaak_id', $scenario['hoofdzaak']->id)->count())->toBe(0);
 });
 
+/**
+ * Metadata for a source enkelvoudiginformatieobject on the hoofdzaak's instance.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function sourceEioMeta(string $uuid, array $overrides = []): array
+{
+    return array_merge([
+        'url' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/'.$uuid,
+        'titel' => 'Situatietekening',
+        'auteur' => 'Jan Jansen',
+        'taal' => 'dut',
+        'bestandsnaam' => 'situatie.pdf',
+        'formaat' => 'application/pdf',
+        'vertrouwelijkheidaanduiding' => 'vertrouwelijk',
+        'creatiedatum' => '2026-06-15',
+        'informatieobjecttype' => OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage',
+    ], $overrides);
+}
+
+test('copies documents cross-instance: downloads from the hoofdzaak and re-creates them in the deelzaak instance', function () {
+    Http::fake([
+        OWN_HOST.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => OWN_HOST.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => OWN_HOST.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        // One document on the hoofdzaak.
+        OWN_HOST.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobject' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1'],
+        ]), 200),
+        // The download must be matched before the EIO-metadata glob.
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1/download*' => Http::response('PDFBYTES', 200),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1*' => Http::response(sourceEioMeta('doc-1'), 200),
+        // Source informatieobjecttype omschrijving (matched exactly on the target).
+        OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage*' => Http::response([
+            'url' => OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage',
+            'omschrijving' => 'Bijlage',
+        ], 200),
+        // Target document types on the deel connection (main).
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobjecttype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage'],
+        ]), 200),
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage',
+            'omschrijving' => 'Bijlage',
+        ], 200),
+        // Target documenten store + zaakinformatieobjecten link.
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/new-doc-1',
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(deelZaakReadResponse(), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    // The source document was downloaded.
+    Http::assertSent(fn ($request) => $request->method() === 'GET'
+        && str_starts_with($request->url(), OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1/download'));
+
+    // A new document was created in the target instance from the downloaded bytes,
+    // with the target-mapped informatieobjecttype and copied metadata.
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten')
+        && $request->data()['inhoud'] === base64_encode('PDFBYTES')
+        && $request->data()['informatieobjecttype'] === ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage'
+        && $request->data()['bronorganisatie'] === '123456789'
+        && $request->data()['titel'] === 'Situatietekening'
+        && $request->data()['auteur'] === 'Jan Jansen'
+        && $request->data()['vertrouwelijkheidaanduiding'] === 'vertrouwelijk'
+        && $request->data()['bestandsomvang'] === strlen('PDFBYTES'));
+
+    // The new copy is linked to the deelzaak, and the source url is never linked.
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten')
+        && ($request->data()['zaak'] ?? null) === ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'
+        && ($request->data()['informatieobject'] ?? null) === ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/new-doc-1');
+
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten')
+        && ($request->data()['informatieobject'] ?? null) === OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1');
+});
+
+test('links the existing document url and does not copy when the deelzaak shares the hoofdzaak instance', function () {
+    // Hoofdzaak on main; doorkomst zaaktype on main too, so both live in one
+    // instance and the document url is directly linkable.
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1'], 201);
+            }
+
+            return Http::response(ZgwHttpFake::envelope([
+                ['informatieobject' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1'],
+            ]), 200);
+        },
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(deelZaakReadResponse(), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: false);
+    $scenario['hoofdzaak']->update(['zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1']);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    // The original informatieobject url is linked directly.
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten')
+        && ($request->data()['informatieobject'] ?? null) === ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1');
+
+    // No download and no re-upload happened.
+    Http::assertNotSent(fn ($request) => str_contains($request->url(), '/download'));
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten'));
+});
+
+test('skips a document cross-instance when no target informatieobjecttype resolves, but still creates the deelzaak and its status', function () {
+    Http::fake([
+        OWN_HOST.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => OWN_HOST.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => OWN_HOST.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        OWN_HOST.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobject' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1'],
+        ]), 200),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1/download*' => Http::response('PDFBYTES', 200),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1*' => Http::response(sourceEioMeta('doc-1'), 200),
+        OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage*' => Http::response([
+            'url' => OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage',
+            'omschrijving' => 'Bijlage',
+        ], 200),
+        // Target has no document types: nothing to map to.
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        // Target statustype so the initial status is still set.
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/statustypen/1', 'volgnummer' => 1, 'omschrijving' => 'Ontvangen'],
+        ]), 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/statussen*' => Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/statussen/1'], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(deelZaakReadResponse(), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    // The deelzaak is still created locally.
+    expect(Zaak::where('hoofdzaak_id', $scenario['hoofdzaak']->id)->count())->toBe(1);
+
+    // No document was re-created in the target instance.
+    Http::assertNotSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten'));
+
+    // The initial status was still set.
+    Http::assertSent(fn ($request) => $request->method() === 'POST'
+        && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/statussen'));
+});
+
+test('a failing document copy does not abort the remaining documents or the deelzaak', function () {
+    Http::fake([
+        OWN_HOST.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => OWN_HOST.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => OWN_HOST.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        OWN_HOST.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobject' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1'],
+            ['informatieobject' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-2'],
+        ]), 200),
+        // First document's download fails; the second succeeds.
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1/download*' => Http::response('', 500),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-1*' => Http::response(sourceEioMeta('doc-1'), 200),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-2/download*' => Http::response('BYTES2', 200),
+        OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-2*' => Http::response(sourceEioMeta('doc-2', [
+            'url' => OWN_HOST.'/documenten/api/v1/enkelvoudiginformatieobjecten/doc-2',
+        ]), 200),
+        OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage*' => Http::response([
+            'url' => OWN_HOST.'/catalogi/api/v1/informatieobjecttypen/src-bijlage',
+            'omschrijving' => 'Bijlage',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            ['informatieobjecttype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage'],
+        ]), 200),
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/tgt-bijlage',
+            'omschrijving' => 'Bijlage',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/new-doc-2',
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+        ], 201),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(deelZaakReadResponse(), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: true);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    // Exactly one document was re-created (the second): the failure of the first
+    // did not abort the loop.
+    $documentenPosts = collect(Http::recorded())
+        ->filter(fn ($pair) => $pair[0]->method() === 'POST'
+            && str_starts_with($pair[0]->url(), ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten'))
+        ->count();
+    expect($documentenPosts)->toBe(1);
+
+    // The deelzaak is still created locally.
+    expect(Zaak::where('hoofdzaak_id', $scenario['hoofdzaak']->id)->count())->toBe(1);
+});
+
 test('is idempotent: running twice does not create a second doorkomst zaak', function () {
     fakeDoorkomstZgw();
     $scenario = doorkomstScenario(hoofdOwnInstance: true);


### PR DESCRIPTION
## Context

When a doorkomst deelzaak is created in a different ZGW instance than its hoofdzaak (for example a hoofdzaak on a municipality's own instance and the doorkomst zaken on `main`), the informatieobject url of the source document is not known to the target instance. `copyDocumenten()` therefore skipped the documents entirely, so the doorkomst zaken were created without the aanvraag pdf or its attachments. This was reproduced on staging with an application at a ZGW-connected municipality (Heerlen).

## Change

`CreateDoorkomstZaken::copyDocumenten()` now branches on the connection:

- **Same instance**: unchanged. The existing informatieobject url is linked directly to the deelzaak.
- **Different instance**: each document is downloaded from the hoofdzaak documenten API, re-created in the target documenten API, and then linked. The `informatieobjecttype` is not portable across instances, so it is re-mapped by omschrijving (exact match on the deelzaaktype's document types, otherwise the aanvraag or bijlage blueprint slot). Metadata (titel, auteur, vertrouwelijkheidaanduiding, formaat) is copied from the source; `bronorganisatie` follows the hoofdzaak, consistent with the deelzaak payload.

Error handling: a single failing document is logged and skipped rather than aborting. Aborting would leave the ZGW deelzaak created while a retry would produce a duplicate (the idempotency check is local), so losing one recoverable document is the safer trade-off. The remaining documents, the initial status and the local zaak are still created.

## Notes

A doorkomst zaaktype needs at least one informatieobjecttype for the blueprint fallback to resolve a target type; without any, a document is still skipped (with a warning, no crash).

## Verification

- `CreateDoorkomstZakenTest`: 11 passed (4 new cross-instance scenarios: copy, same-instance link without copy, no resolvable target type, one failing document does not abort).
- Pint and PHPStan (level 5) clean on the changed files.