### PR TITLE
Set doorkomst document confidentiality from the target connection

### DIFF
--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -425,7 +425,10 @@ class CreateDoorkomstZaken implements ShouldQueue
         $payload = [
             'bronorganisatie' => $bronorganisatie,
             'creatiedatum' => $eio['creatiedatum'] ?? now()->format('Y-m-d'),
-            'vertrouwelijkheidaanduiding' => $eio['vertrouwelijkheidaanduiding'] ?? ZgwConnectionConfig::systemUploadDefault($deelConnectionName),
+            // Determined by the target connection, not copied from the source: the
+            // source instance's confidentiality scheme need not match the target's,
+            // so a copied value can be wrong on the deel connection.
+            'vertrouwelijkheidaanduiding' => ZgwConnectionConfig::systemUploadDefault($deelConnectionName),
             'titel' => $eio['titel'] ?? ($eio['bestandsnaam'] ?? 'Document'),
             'auteur' => $eio['auteur'] ?? 'Onbekend',
             'taal' => $eio['taal'] ?? 'dut',

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -422,7 +422,9 @@ test('copies documents cross-instance: downloads from the hoofdzaak and re-creat
         && $request->data()['bronorganisatie'] === '123456789'
         && $request->data()['titel'] === 'Situatietekening'
         && $request->data()['auteur'] === 'Jan Jansen'
-        && $request->data()['vertrouwelijkheidaanduiding'] === 'vertrouwelijk'
+        // Determined by the target connection (systemUploadDefault → zaakvertrouwelijk),
+        // not copied from the source document (which is 'vertrouwelijk').
+        && $request->data()['vertrouwelijkheidaanduiding'] === 'zaakvertrouwelijk'
         && $request->data()['bestandsomvang'] === strlen('PDFBYTES'));
 
     // The new copy is linked to the deelzaak, and the source url is never linked.


### PR DESCRIPTION
## Context

Follow-up to the cross-instance doorkomst document copy (#423). When a document is copied to a doorkomst deelzaak in another ZGW instance, `copyDocumentToTargetInstance()` took the `vertrouwelijkheidaanduiding` from the source document. The source instance's confidentiality scheme does not necessarily match the target's, so the copy could land with a value that is wrong on the deel connection. This was seen on staging: documents copied onto a `main`-connection doorkomst zaak ended up as `openbaar` instead of the confidentiality that belongs to the target connection.

## Change

The `vertrouwelijkheidaanduiding` of a copied document is now determined by the target connection via `ZgwConnectionConfig::systemUploadDefault()`, the same source of truth used for the aanvraag pdf and organiser attachments (falls back to `zaakvertrouwelijk`). It is no longer copied from the source document. Other metadata (titel, auteur, formaat, bestandsnaam) is still copied from the source.

## Verification

- `CreateDoorkomstZakenTest`: 11 passed. The cross-instance copy test now asserts the target-connection value (`zaakvertrouwelijk`) instead of the source value.
- Pint and PHPStan (level 5) clean on the changed job.