### PR TITLE
Bump woweb/laravel-zgw-client to v1.2.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10897,16 +10897,16 @@
         },
         {
             "name": "woweb/laravel-zgw-client",
-            "version": "v1.2.1",
+            "version": "v1.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WowebNL/laravel-zgw-client.git",
-                "reference": "7d97193561c03b4109da2aaf42134a23a2f04be0"
+                "reference": "1c67993c8c1895085e3c54014fa300a7243998d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/7d97193561c03b4109da2aaf42134a23a2f04be0",
-                "reference": "7d97193561c03b4109da2aaf42134a23a2f04be0",
+                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/1c67993c8c1895085e3c54014fa300a7243998d8",
+                "reference": "1c67993c8c1895085e3c54014fa300a7243998d8",
                 "shasum": ""
             },
             "require": {
@@ -10964,9 +10964,9 @@
             ],
             "support": {
                 "issues": "https://github.com/WowebNL/laravel-zgw-client/issues",
-                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.1"
+                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.2"
             },
-            "time": "2026-07-02T13:50:56+00:00"
+            "time": "2026-07-03T10:46:58+00:00"
         },
         {
             "name": "woweb/openzaak",


### PR DESCRIPTION
Updates `woweb/laravel-zgw-client` from v1.2.1 to v1.2.2 (lock only, the `^1.2` constraint already allows it).

v1.2.2 fixes document downloads: `Enkelvoudiginformatieobjecten::download()` now sends a wildcard `Accept` header instead of inheriting `Accept: application/json`, so Open Zaak no longer rejects the binary download with `406 Not Acceptable`. This resolves the staging error where no file could be opened from the main connection (EVENTLOKET-1C).

Only `composer.lock` changes; no other dependencies are touched. Document feature tests pass against v1.2.2.