### PR TITLE
Fix missing zaak infolist translations (intern zaaknummer, locations, related cases)

### DIFF
--- a/app/Filament/Shared/Resources/MunicipalityAdminUsers/Tables/MunicipalityAdminUserTable.php
+++ b/app/Filament/Shared/Resources/MunicipalityAdminUsers/Tables/MunicipalityAdminUserTable.php
@@ -37,7 +37,7 @@ class MunicipalityAdminUserTable
                     ->selectablePlaceholder(false)
                     ->afterStateUpdated(function () {
                         Notification::make()
-                            ->title(__('resources/municipality_admin.columns.role.notification'))
+                            ->title(__('municipality/resources/municipality_admin.columns.role.notification'))
                             ->success()
                             ->send();
                     }),

--- a/lang/nl/municipality/resources/zaak.php
+++ b/lang/nl/municipality/resources/zaak.php
@@ -141,49 +141,6 @@ return [
                     'edit_status' => [
                         'label' => 'Wijzigen',
                     ],
-                ],
-            ],
-        ],
-        'tabs' => [
-            'decisions' => [
-                'label' => 'Besluiten',
-            ],
-            'documents' => [
-                'label' => 'Bestanden',
-            ],
-            'messages' => [
-                'label' => 'Organisatievragen',
-            ],
-            'advice_requests' => [
-                'label' => 'Adviesvragen',
-            ],
-        ],
-    ],
-    'infolist_legacy' => [
-        'sections' => [
-            'information' => [
-                'label' => 'Informatie',
-                'description' => 'Informatie over de zaak',
-            ],
-            'actions' => [
-                'label' => 'Acties',
-                'description' => 'Voer wijzigingen uit binnen de zaak',
-                'actions' => [
-                    'edit_risico_classificatie' => [
-                        'label' => 'Wijzigen',
-                        'fields' => [
-                            'risico_classificatie' => [
-                                'label' => 'Risicoclassificatie',
-                            ],
-                            'risico_classificatie_toelichting' => [
-                                'label' => 'Toelichting risicoclassificatie',
-                                'helper_text' => 'Beargumenteer waarom je de risico classificatie wijzigt.',
-                            ],
-                        ],
-                    ],
-                    'edit_status' => [
-                        'label' => 'Wijzigen',
-                    ],
                     'edit_intern_zaaknummer' => [
                         'label' => 'Wijzigen',
                         'placeholder' => 'Niet ingesteld',
@@ -196,9 +153,6 @@ return [
                     'delete_intern_zaaknummer' => [
                         'label' => 'Verwijderen',
                     ],
-                ],
-                'handled_status_set_by' => [
-                    'label' => 'Door :user',
                 ],
             ],
         ],
@@ -232,9 +186,6 @@ return [
                 'map' => [
                     'label' => 'Kaart',
                 ],
-            ],
-            'log' => [
-                'label' => 'Log',
             ],
             'related_cases' => [
                 'label' => 'Gerelateerde zaken',


### PR DESCRIPTION
Several translation keys rendered their raw key path in the UI instead of the Dutch label.

## Cause
In `lang/nl/municipality/resources/zaak.php` the translations for the intern zaaknummer edit/delete actions, the Locations tab and the Related cases tab lived under an orphaned top-level `infolist_legacy` block, while the code reads them under `infolist`. `infolist_legacy` was not referenced anywhere in the codebase.

Confirmed with `Lang::has()`: 12 referenced keys did not resolve (`edit_intern_zaaknummer`/`delete_intern_zaaknummer` labels, placeholder and field label; the `locations` tab keys; `related_cases.label`).

## Fix
- Move the missing keys into the live `infolist` block: `edit_intern_zaaknummer` and `delete_intern_zaaknummer` under `sections.actions.actions`, and `locations` and `related_cases` under `tabs`.
- Drop the now-redundant `infolist_legacy` block and its unreferenced `log` tab.
- Fix `MunicipalityAdminUserTable`, which built the role-change notification title from `resources/municipality_admin.columns.role.notification` instead of the real `municipality/resources/municipality_admin.columns.role.notification` key (the sibling `ReviewerUsersTable` already used the correct prefix).

## Verification
A full scan of all 644 namespaced `__()` keys against the nl translations now reports only one unresolved key, `zaak.actions.download.label`, which is a false positive (it appears only in a commented-out line). Pint clean.

## Note on next/v1.2
`next/v1.2` already has `locations`/`related_cases` under the live `infolist`, but it is still missing the `edit_intern_zaaknummer`/`delete_intern_zaaknummer` translations and has the same `MunicipalityAdminUserTable` prefix bug. That branch needs a separate (smaller) fix.