### PR TITLE
Add intern zaaknummer translations and fix municipality_admin key

### DIFF
--- a/app/Filament/Shared/Resources/MunicipalityAdminUsers/Tables/MunicipalityAdminUserTable.php
+++ b/app/Filament/Shared/Resources/MunicipalityAdminUsers/Tables/MunicipalityAdminUserTable.php
@@ -38,7 +38,7 @@ class MunicipalityAdminUserTable
                     ->selectablePlaceholder(false)
                     ->afterStateUpdated(function () {
                         Notification::make()
-                            ->title(__('resources/municipality_admin.columns.role.notification'))
+                            ->title(__('municipality/resources/municipality_admin.columns.role.notification'))
                             ->success()
                             ->send();
                     }),

--- a/lang/nl/municipality/resources/zaak.php
+++ b/lang/nl/municipality/resources/zaak.php
@@ -141,6 +141,18 @@ return [
                     'edit_status' => [
                         'label' => 'Wijzigen',
                     ],
+                    'edit_intern_zaaknummer' => [
+                        'label' => 'Wijzigen',
+                        'placeholder' => 'Niet ingesteld',
+                        'fields' => [
+                            'intern_zaaknummer' => [
+                                'label' => 'Intern zaaknummer',
+                            ],
+                        ],
+                    ],
+                    'delete_intern_zaaknummer' => [
+                        'label' => 'Verwijderen',
+                    ],
                 ],
             ],
         ],


### PR DESCRIPTION
The intern zaaknummer edit/delete actions rendered their raw translation keys because the nl translations were never present in the `infolist` block on this branch. This is the next/v1.2 counterpart of #429 (which fixes the same on main).

## Fix
- Add `edit_intern_zaaknummer` and `delete_intern_zaaknummer` under `infolist.sections.actions.actions` in `lang/nl/municipality/resources/zaak.php`. The text and position are identical to #429.
- Fix `MunicipalityAdminUserTable`, which built the role-change notification title from `resources/municipality_admin.columns.role.notification` instead of the correct `municipality/resources/municipality_admin.columns.role.notification` key.

The `locations`/`related_cases` tabs were already correct on next/v1.2, so no change there.

## No future merge conflict
Because the `intern_zaaknummer` block is added with the same text as #429, a later next/v1.2 to main merge sees both sides making the same change and merges cleanly. Verified with `git merge-tree`: no conflict.

Verified with `Lang::has()` that all four intern_zaaknummer keys and the municipality_admin key now resolve. Pint clean.