### PR TITLE
Stop reporting InviteNotFoundException to Sentry

### DIFF
--- a/app/Exceptions/InviteNotFoundException.php
+++ b/app/Exceptions/InviteNotFoundException.php
@@ -5,9 +5,23 @@ namespace App\Exceptions;
 use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Log;
 
 class InviteNotFoundException extends Exception
 {
+    /**
+     * Report the exception.
+     *
+     * Opening an invalid or expired invite link is a benign, visitor-triggered
+     * event that already shows a friendly 404 page via render(). Returning void
+     * (anything other than false) suppresses the default reporting to Sentry, so
+     * we only leave a log line instead of raising an error alert.
+     */
+    public function report(): void
+    {
+        Log::info('Invite accept attempt with an invalid or expired token.');
+    }
+
     /**
      * Render the exception as an HTTP response.
      */

--- a/tests/Unit/Exceptions/InviteNotFoundExceptionTest.php
+++ b/tests/Unit/Exceptions/InviteNotFoundExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use App\Exceptions\InviteNotFoundException;
+use Illuminate\Support\Facades\Log;
+
+test('report logs an info line instead of reporting to Sentry', function () {
+    Log::shouldReceive('info')
+        ->once()
+        ->with('Invite accept attempt with an invalid or expired token.');
+
+    // Returning anything other than false tells Laravel's handler to skip the
+    // default reporting (Sentry). A void report() returns null, so an invalid or
+    // expired invite only produces the log line above.
+    $result = (new InviteNotFoundException)->report();
+
+    expect($result)->toBeNull();
+});


### PR DESCRIPTION
## What

Opening an invalid or expired invite link (Sentry EVENTLOKET-G) is a benign, visitor-triggered event. The visitor already sees a friendly 404 page via `InviteNotFoundException::render()`, but the exception was still reported to Sentry as an error, producing recurring noise.

Both throw sites in `AbstractAcceptInvite::mount()` are covered:
* token not found (or already used)
* invite expired

## Change

Add a `report()` method to `InviteNotFoundException` that writes an `info` log line and returns `void`. Returning anything other than `false` makes Laravel's exception handler skip the default reporting to Sentry, so these cases only produce a log line while keeping the existing 404 page intact.

A small unit test verifies that `report()` logs the message and returns `null` (so default reporting is suppressed).