### PR TITLE
Prevent datetime parse crash in event form

### DIFF
--- a/app/EventForm/Components/Concerns/HasSafeDateTimeStateCast.php
+++ b/app/EventForm/Components/Concerns/HasSafeDateTimeStateCast.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Components\Concerns;
+
+use App\EventForm\Components\StateCasts\SafeDateTimeStateCast;
+use Filament\Schemas\Components\StateCasts\DateTimeStateCast;
+
+/**
+ * Replaces the default {@see DateTimeStateCast} with the null-safe
+ * {@see SafeDateTimeStateCast} on the component's state casts.
+ *
+ * The default cast is appended by Filament before any `->stateCast()` cast and
+ * runs first on the read path, so it can only be swapped by overriding
+ * `getDefaultStateCasts()` on a component subclass, which is what this trait
+ * does.
+ */
+trait HasSafeDateTimeStateCast
+{
+    /**
+     * @return array<int, mixed>
+     */
+    public function getDefaultStateCasts(): array
+    {
+        return array_map(
+            fn (mixed $cast): mixed => $cast instanceof DateTimeStateCast
+                ? app(SafeDateTimeStateCast::class, [
+                    'format' => $this->getFormat(),
+                    'internalFormat' => $this->getInternalFormat(),
+                    'timezone' => $this->getTimezone(),
+                ])
+                : $cast,
+            parent::getDefaultStateCasts(),
+        );
+    }
+}

--- a/app/EventForm/Components/EventDatePicker.php
+++ b/app/EventForm/Components/EventDatePicker.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Components;
+
+use App\EventForm\Components\Concerns\HasSafeDateTimeStateCast;
+use Filament\Forms\Components\DatePicker;
+
+/**
+ * DatePicker that never 500s on a malformed stored value.
+ *
+ * @see HasSafeDateTimeStateCast
+ */
+class EventDatePicker extends DatePicker
+{
+    use HasSafeDateTimeStateCast;
+}

--- a/app/EventForm/Components/EventDateTimePicker.php
+++ b/app/EventForm/Components/EventDateTimePicker.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Components;
+
+use App\EventForm\Components\Concerns\HasSafeDateTimeStateCast;
+use Filament\Forms\Components\DateTimePicker;
+
+/**
+ * DateTimePicker that never 500s on a malformed stored value.
+ *
+ * @see HasSafeDateTimeStateCast
+ */
+class EventDateTimePicker extends DateTimePicker
+{
+    use HasSafeDateTimeStateCast;
+}

--- a/app/EventForm/Components/StateCasts/SafeDateTimeStateCast.php
+++ b/app/EventForm/Components/StateCasts/SafeDateTimeStateCast.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Components\StateCasts;
+
+use Filament\Schemas\Components\StateCasts\DateTimeStateCast;
+
+/**
+ * Null-safe variant of Filament's {@see DateTimeStateCast}.
+ *
+ * The parent `get()` runs an unguarded `Carbon::parse()` on the raw state,
+ * which throws on a malformed value (e.g. a year with too many digits) and
+ * surfaces as a 500 during a Livewire update. Here we return `null` instead so
+ * an invalid value renders as an empty field rather than crashing the page.
+ */
+class SafeDateTimeStateCast extends DateTimeStateCast
+{
+    public function get(mixed $state): ?string
+    {
+        try {
+            return parent::get($state);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/EventForm/Schema/Steps/RisicoscanStep.php
+++ b/app/EventForm/Schema/Steps/RisicoscanStep.php
@@ -7,7 +7,7 @@ namespace App\EventForm\Schema\Steps;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Schema\Hidden;
 use App\EventForm\State\FormState;
-use Carbon\Carbon;
+use App\EventForm\Support\SafeDateTime;
 use Filament\Forms\Components\Radio;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Icon;
@@ -188,12 +188,12 @@ final class RisicoscanStep
                         if ($state !== null) {
                             return;
                         }
-                        $start = $get('EvenementStart');
+                        $start = SafeDateTime::parse($get('EvenementStart'));
                         if (! $start) {
                             return;
                         }
                         // Lente (mrt–mei) en herfst (sep–nov) → 0.25; zomer (jun–aug) en winter (dec–feb) → 0.5
-                        $month = Carbon::parse($start)->month;
+                        $month = $start->month;
                         $set('inWelkSeizoenVindtHetEvenementPlaats', in_array($month, [3, 4, 5, 9, 10, 11], strict: true) ? '0.25' : '0.5');
                     })
                     ->required()

--- a/app/EventForm/Schema/Steps/TijdenStep.php
+++ b/app/EventForm/Schema/Steps/TijdenStep.php
@@ -4,16 +4,16 @@ declare(strict_types=1);
 
 namespace App\EventForm\Schema\Steps;
 
+use App\EventForm\Components\EventDateTimePicker;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Components\JaNeeOptions;
 use App\EventForm\Schema\Hidden;
 use App\EventForm\Schema\Label;
 use App\EventForm\State\FormState;
+use App\EventForm\Support\SafeDateTime;
 use App\EventForm\Template\LabelRenderer;
 use App\Filament\Organiser\Pages\Calendar;
 use App\Models\Organisation;
-use Carbon\Carbon;
-use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Grid;
@@ -60,7 +60,7 @@ final class TijdenStep
                 }),
                 Grid::make(1)
                     ->schema([
-                        DateTimePicker::make('EvenementStart')
+                        EventDateTimePicker::make('EvenementStart')
                             ->label(Label::render('Wat is de start datum en tijdstip van uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(today())
@@ -70,10 +70,11 @@ final class TijdenStep
                             ])
                             ->required()
                             ->afterStateUpdated(function (?string $state, Set $set): void {
-                                if (! $state) {
+                                $parsed = SafeDateTime::parse($state);
+                                if (! $parsed) {
                                     return;
                                 }
-                                $month = Carbon::parse($state)->month;
+                                $month = $parsed->month;
                                 $set('inWelkSeizoenVindtHetEvenementPlaats', in_array($month, [3, 4, 5, 9, 10, 11], strict: true) ? '0.25' : '0.5');
                             })
                             ->belowContent([
@@ -81,7 +82,7 @@ final class TijdenStep
                                 'Dit is het startmoment wanneer u bezoekers of deelnemers verwacht.',
                             ])
                             ->live(),
-                        DateTimePicker::make('EvenementEind')
+                        EventDateTimePicker::make('EvenementEind')
                             ->label(Label::render('Wat is de eind datum en tijdstip van uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(fn (Get $get) => $get('EvenementStart') ?: today())
@@ -127,7 +128,7 @@ final class TijdenStep
                     ->live(),
                 Grid::make(1)
                     ->schema([
-                        DateTimePicker::make('OpbouwStart')
+                        EventDateTimePicker::make('OpbouwStart')
                             ->label(Label::render('Wat is de start datum en tijd van de opbouw uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(today())
@@ -146,7 +147,7 @@ final class TijdenStep
                                 return ! ($get('zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten') === 'Ja');
                             })
                             ->live(),
-                        DateTimePicker::make('OpbouwEind')
+                        EventDateTimePicker::make('OpbouwEind')
                             ->label(Label::render('Wat is de eind datum en tijd van de opbouw van uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(fn (Get $get) => $get('OpbouwStart') ?: today())
@@ -177,7 +178,7 @@ final class TijdenStep
                     ->live(),
                 Grid::make(1)
                     ->schema([
-                        DateTimePicker::make('AfbouwStart')
+                        EventDateTimePicker::make('AfbouwStart')
                             ->label(Label::render('Wat is de start datum en tijdstip van de afbouw uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(fn (Get $get) => $get('EvenementEind') ?: today())
@@ -196,7 +197,7 @@ final class TijdenStep
                                 return ! ($get('zijnErAansluitendAanHetEvenementAfbouwactiviteiten') === 'Ja');
                             })
                             ->live(),
-                        DateTimePicker::make('AfbouwEind')
+                        EventDateTimePicker::make('AfbouwEind')
                             ->label(Label::render('Wat is de eind datum en tijdstip van de afbouw van uw evenement {{ watIsDeNaamVanHetEvenementVergunning }}?'))
                             ->seconds(false)
                             ->minDate(fn (Get $get) => $get('AfbouwStart') ?: $get('EvenementEind'))

--- a/app/EventForm/Schema/Steps/VergunningaanvraagMaatregelenStep.php
+++ b/app/EventForm/Schema/Steps/VergunningaanvraagMaatregelenStep.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\EventForm\Schema\Steps;
 
+use App\EventForm\Components\EventDateTimePicker;
 use App\EventForm\Components\EventloketFileUpload;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Components\JaNeeOptions;
 use App\EventForm\Schema\Hidden;
 use App\EventForm\Schema\Label;
 use App\Models\Organisation;
-use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
@@ -61,11 +61,11 @@ final class VergunningaanvraagMaatregelenStep
                                     ->label('Door wie?')
                                     ->required()
                                     ->maxLength(1000),
-                                DateTimePicker::make('starttijdSchoonmaak')
+                                EventDateTimePicker::make('starttijdSchoonmaak')
                                     ->label('Starttijd schoonmaak')
                                     ->seconds(false)
                                     ->required(),
-                                DateTimePicker::make('eindtijdSchoonmaak')
+                                EventDateTimePicker::make('eindtijdSchoonmaak')
                                     ->label('Eindtijd schoonmaak')
                                     ->seconds(false)
                                     ->afterOrEqual('starttijdSchoonmaak')

--- a/app/EventForm/Schema/Steps/VergunningaanvraagOverigStep.php
+++ b/app/EventForm/Schema/Steps/VergunningaanvraagOverigStep.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventForm\Schema\Steps;
 
+use App\EventForm\Components\EventDateTimePicker;
 use App\EventForm\Components\EventloketFileUpload;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Components\JaNeeOptions;
@@ -12,7 +13,6 @@ use App\EventForm\Schema\Label;
 use App\Models\Organisation;
 use Dotswan\MapPicker\Fields\Map;
 use Filament\Forms\Components\CheckboxList;
-use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
@@ -72,11 +72,11 @@ final class VergunningaanvraagOverigStep
                                     ->columnSpanFull()
                                     ->showMyLocationButton(false)
                                     ->required(),
-                                DateTimePicker::make('startTijdstipVoorwerp')
+                                EventDateTimePicker::make('startTijdstipVoorwerp')
                                     ->label('Start tijdstip')
                                     ->seconds(false)
                                     ->required(),
-                                DateTimePicker::make('eindTijdstipVoorwerp')
+                                EventDateTimePicker::make('eindTijdstipVoorwerp')
                                     ->label('Eind tijdstip')
                                     ->seconds(false)
                                     ->afterOrEqual('startTijdstipVoorwerp')

--- a/app/EventForm/Schema/Steps/VergunningaanvraagVervolgvragenStep.php
+++ b/app/EventForm/Schema/Steps/VergunningaanvraagVervolgvragenStep.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace App\EventForm\Schema\Steps;
 
+use App\EventForm\Components\EventDatePicker;
+use App\EventForm\Components\EventDateTimePicker;
 use App\EventForm\Components\EventloketFileUpload;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Components\JaNeeOptions;
 use App\EventForm\Schema\Hidden;
 use App\EventForm\Schema\Label;
+use App\EventForm\Support\SafeDateTime;
 use App\Models\Organisation;
-use Carbon\Carbon;
 use Dotswan\MapPicker\Fields\Map;
 use Filament\Forms\Components\CheckboxList;
-use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Textarea;
@@ -329,12 +329,13 @@ final class VergunningaanvraagVervolgvragenStep
                                     ->label('Achternaam van de persoon')
                                     ->required()
                                     ->maxLength(1000),
-                                DatePicker::make('geboortedatumPersoonAlcohol')
+                                EventDatePicker::make('geboortedatumPersoonAlcohol')
                                     ->label('Geboortedatum persoon')
                                     ->required()
                                     ->live()
                                     ->afterStateUpdated(function (?string $state, callable $set): void {
-                                        $bereikt = $state ? Carbon::parse($state)->age >= 21 : null;
+                                        $geboortedatum = SafeDateTime::parse($state);
+                                        $bereikt = $geboortedatum ? $geboortedatum->age >= 21 : null;
                                         $set('heeftDeLeeftijdVan21JaarBereiktPersoonAlcohol', match ($bereikt) {
                                             true => 'Ja',
                                             false => 'Nee',
@@ -553,11 +554,11 @@ final class VergunningaanvraagVervolgvragenStep
                                     ->label('Naam van de doorgang')
                                     ->required()
                                     ->maxLength(1000),
-                                DateTimePicker::make('startVanDeAfsluiting')
+                                EventDateTimePicker::make('startVanDeAfsluiting')
                                     ->label('Start van de afsluiting')
                                     ->seconds(false)
                                     ->required(),
-                                DateTimePicker::make('eindVanDeAfsluiting')
+                                EventDateTimePicker::make('eindVanDeAfsluiting')
                                     ->label('Eind van de afsluiting')
                                     ->seconds(false)
                                     ->afterOrEqual('startVanDeAfsluiting')

--- a/app/EventForm/State/FormState.php
+++ b/app/EventForm/State/FormState.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventForm\State;
 
+use App\EventForm\Support\SafeDateTime;
 use Illuminate\Contracts\Support\Arrayable;
 
 /**
@@ -266,6 +267,11 @@ class FormState implements Arrayable
             self::arrayFrom($snapshot, 'variables'),
             self::arrayFrom($snapshot, 'values'),
         );
+
+        // Heel drafts die een misvormde datumwaarde bevatten (jaartal met te
+        // veel cijfers). Zonder dit crasht Filaments datetime-cast bij het
+        // renderen van zo'n opgeslagen concept.
+        $values = SafeDateTime::sanitizeState($values);
 
         return new self(
             values: $values,

--- a/app/EventForm/Support/SafeDateTime.php
+++ b/app/EventForm/Support/SafeDateTime.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Support;
+
+use Carbon\CarbonInterface;
+use Illuminate\Support\Carbon;
+
+/**
+ * Null-safe helpers for the datetime values that flow through the event form.
+ *
+ * A native `datetime-local` input lets a user type a year with more than four
+ * digits (e.g. `20256-09-20T16:00`). Carbon then throws
+ * `InvalidFormatException` ("Double time specification"), which surfaced as a
+ * hard 500 during Livewire updates. These helpers turn such values into `null`
+ * instead of throwing.
+ */
+final class SafeDateTime
+{
+    /**
+     * A clean ISO date or datetime with a four-digit year.
+     */
+    private const VALID_PATTERN = '/^\d{4}-\d{2}-\d{2}([ T]\d{2}:\d{2}(:\d{2})?)?$/';
+
+    /**
+     * A datetime-shaped string whose year has five or more digits. This is the
+     * malformed shape we heal; it is specific enough not to touch UUIDs, free
+     * text or valid four-digit dates.
+     */
+    private const OVERLONG_YEAR_PATTERN = '/^\d{5,}-\d{1,2}-\d{1,2}/';
+
+    /**
+     * Parse a value into a Carbon instance, or return null when it is blank or
+     * cannot be parsed cleanly.
+     */
+    public static function parse(mixed $value): ?CarbonInterface
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value;
+        }
+
+        if (! is_string($value) || ! preg_match(self::VALID_PATTERN, $value)) {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($value);
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Recursively null out any datetime string with an over-long (5+ digit)
+     * year. Non-datetime values are left untouched, so this is safe to run over
+     * a whole form-state snapshot (including nested repeater arrays).
+     *
+     * @param  array<array-key, mixed>  $state
+     * @return array<array-key, mixed>
+     */
+    public static function sanitizeState(array $state): array
+    {
+        foreach ($state as $key => $value) {
+            if (is_array($value)) {
+                $state[$key] = self::sanitizeState($value);
+            } elseif (is_string($value) && preg_match(self::OVERLONG_YEAR_PATTERN, $value)) {
+                $state[$key] = null;
+            }
+        }
+
+        return $state;
+    }
+}

--- a/tests/Feature/EventForm/Pages/EventFormPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageTest.php
@@ -320,3 +320,29 @@ test('na adres-invul → gemeenteVariabelen wordt automatisch gefetched (label-p
     // de waarde 500 kan invullen.
     expect($page->state()->get('gemeenteVariabelen.aanwezigen'))->toBe(500.0);
 });
+
+test('a draft with a malformed datetime year mounts without crashing', function (string $badValue) {
+    // Een native datetime-local input laat een organisator een jaartal met te
+    // veel cijfers typen. Die waarde is in het concept opgeslagen en liet
+    // Filaments datetime-cast crashen bij het heropenen (Sentry EVENTLOKET-10).
+    $state = FormState::empty();
+    $state->setField('EvenementStart', $badValue);
+    // Ook een geneste repeater-waarde (het pad waar EVENTLOKET-10 vandaan kwam).
+    $state->setField(
+        'geefAanOpWelkeDataEnTijdenUDeVoorwerpenWiltPlaatsenOpDeOpenbareWegOfGroteVoertuigenWiltParkerenInDeBuurtVanHetEvenement',
+        [['voorwerp' => 'kraam', 'startTijdstipVoorwerp' => $badValue]],
+    );
+    $this->draft->update(['state' => $state->toSnapshot()]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])
+        ->assertOk();
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
+    // De misvormde waarde is bij het laden opgeschoond naar null.
+    expect($page->state()->get('EvenementStart'))->toBeNull();
+})->with([
+    'five digit year' => '20256-09-20T16:00',
+    'six digit year' => '202026-08-22T13:00',
+]);

--- a/tests/Unit/EventForm/Components/SafeDateTimeStateCastTest.php
+++ b/tests/Unit/EventForm/Components/SafeDateTimeStateCastTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\EventForm\Components\StateCasts\SafeDateTimeStateCast;
+
+beforeEach(function () {
+    $this->cast = new SafeDateTimeStateCast(
+        format: 'Y-m-d H:i:s',
+        internalFormat: 'Y-m-d H:i:s',
+        timezone: 'Europe/Amsterdam',
+    );
+});
+
+test('get returns null instead of throwing on a malformed value', function (string $value) {
+    expect($this->cast->get($value))->toBeNull();
+})->with([
+    'five digit year' => '20256-09-20T16:00',
+    'six digit year' => '202026-08-22T13:00',
+]);
+
+test('get still formats a clean value', function () {
+    expect($this->cast->get('2026-08-22T13:00'))->toBeString();
+});
+
+test('get returns null for a blank value', function () {
+    expect($this->cast->get(null))->toBeNull()
+        ->and($this->cast->get(''))->toBeNull();
+});

--- a/tests/Unit/EventForm/Support/SafeDateTimeTest.php
+++ b/tests/Unit/EventForm/Support/SafeDateTimeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\EventForm\Support\SafeDateTime;
+use Carbon\CarbonInterface;
+
+test('parse returns a Carbon instance for a clean value', function (string $value) {
+    expect(SafeDateTime::parse($value))
+        ->toBeInstanceOf(CarbonInterface::class);
+})->with([
+    'datetime' => '2026-08-22T13:00',
+    'datetime with seconds' => '2026-08-22T13:00:00',
+    'date only' => '2026-08-22',
+    'space separator' => '2026-08-22 13:00',
+]);
+
+test('parse returns null for a malformed or blank value', function (mixed $value) {
+    expect(SafeDateTime::parse($value))->toBeNull();
+})->with([
+    'five digit year' => '20256-09-20T16:00',
+    'six digit year' => '202026-08-22T13:00',
+    'empty string' => '',
+    'null' => null,
+    'not a date' => 'geen datum',
+    'integer' => 2026,
+]);
+
+test('sanitizeState nulls out datetime strings with an over-long year, recursively', function () {
+    $state = [
+        'EvenementStart' => '202026-08-22T13:00',
+        'EvenementEind' => '2026-08-22T18:00',
+        'naam' => 'Een gewoon evenement',
+        'repeater' => [
+            ['startTijdstipVoorwerp' => '20256-09-20T16:00', 'voorwerp' => 'kraam'],
+        ],
+    ];
+
+    expect(SafeDateTime::sanitizeState($state))->toBe([
+        'EvenementStart' => null,
+        'EvenementEind' => '2026-08-22T18:00',
+        'naam' => 'Een gewoon evenement',
+        'repeater' => [
+            ['startTijdstipVoorwerp' => null, 'voorwerp' => 'kraam'],
+        ],
+    ]);
+});
+
+test('sanitizeState leaves valid dates and non-date values untouched', function () {
+    $state = [
+        'EvenementStart' => '2026-08-22T13:00',
+        'uuid' => '00f09aee-fedd-44d6-b82c-3e3754d67b7a',
+        'aantal' => 1500,
+        'geometry' => [5.6910, 50.8514],
+    ];
+
+    expect(SafeDateTime::sanitizeState($state))->toBe($state);
+});


### PR DESCRIPTION
## What

An organiser can type a year with more than four digits into a native `datetime-local` field (e.g. `20256-09-20T16:00` or `202026-08-22T13:00`). Filament's `DateTimeStateCast::get()` runs an unguarded `Carbon::parse()` on that value, throws `InvalidFormatException` ("Double time specification"), and this became an unhandled 500 during a Livewire update. Two Sentry issues share this cause:

- **EVENTLOKET-R**: crash during a live field update on a `->live()` field.
- **EVENTLOKET-10**: crash while re-rendering a Repeater from a saved draft. The bad value was stored in the draft, so the organiser could no longer open their own application.

## Approach

- **Null-safe cast (core):** `SafeDateTimeStateCast` wraps `get()` in a try/catch and returns `null` for an unparseable value. A trait (`HasSafeDateTimeStateCast`) overrides `getDefaultStateCasts()` to swap in the safe cast. Applied through `EventDateTimePicker`/`EventDatePicker` on every date/datetime field in the event form. The default cast runs before any appended cast, so a component subclass is the only place this can be fixed.
- **Snapshot sanitisation:** `FormState::fromSnapshot()` cleans datetime values on load, so existing stuck drafts open again. The three direct `Carbon::parse()` calls in the step files now go through `SafeDateTime::parse()`.

Deliberate choice: no `->native(false)`. The native picker stays; an invalid year is silently emptied (the fields are `->required()`).

## Tests

- Unit: `SafeDateTime` (parse/sanitizeState) and `SafeDateTimeStateCast` (null-safe get).
- Feature: a draft with a 5- or 6-digit year mounts without crashing and the value is cleaned.
- Full `tests/Feature/EventForm` + `tests/Unit/EventForm`: 488 passed. Pint and PHPStan clean.