### PR TITLE
Handle degenerate map geometries in the event form

### DIFF
--- a/app/Actions/Geospatial/GeoJsonGeometryValidator.php
+++ b/app/Actions/Geospatial/GeoJsonGeometryValidator.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Geospatial;
+
+/**
+ * Validates that a decoded GeoJSON geometry is complete enough for the
+ * geometry engine (PostGIS) to process.
+ *
+ * A user drawing on the map can produce a degenerate geometry, for example a
+ * polygon whose ring has fewer than four positions (an unfinished shape). The
+ * live location check would then send it to PostGIS, which rejects it with
+ * "Polygon must have at least four points in each ring" and the whole Livewire
+ * update fails with a 500. Skipping such geometries up front avoids that.
+ */
+final class GeoJsonGeometryValidator
+{
+    /**
+     * A closed polygon ring needs at least four positions
+     * (three distinct corners plus the closing position).
+     */
+    private const MIN_RING_POSITIONS = 4;
+
+    /**
+     * A line needs at least two positions to have a start and an end.
+     */
+    private const MIN_LINE_POSITIONS = 2;
+
+    /**
+     * @param  array<string, mixed>  $geometry  A decoded GeoJSON geometry object.
+     */
+    public static function isProcessable(array $geometry): bool
+    {
+        $type = $geometry['type'] ?? null;
+        $coordinates = $geometry['coordinates'] ?? null;
+
+        if (! is_string($type) || ! is_array($coordinates)) {
+            return false;
+        }
+
+        return match ($type) {
+            'Polygon' => self::ringsAreValid($coordinates),
+            'MultiPolygon' => $coordinates !== [] && array_all(
+                $coordinates,
+                fn (mixed $polygon): bool => is_array($polygon) && self::ringsAreValid($polygon),
+            ),
+            'LineString' => self::hasAtLeast($coordinates, self::MIN_LINE_POSITIONS),
+            'MultiLineString' => $coordinates !== [] && array_all(
+                $coordinates,
+                fn (mixed $line): bool => is_array($line) && self::hasAtLeast($line, self::MIN_LINE_POSITIONS),
+            ),
+            default => $coordinates !== [],
+        };
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $rings
+     */
+    private static function ringsAreValid(array $rings): bool
+    {
+        return $rings !== [] && array_all(
+            $rings,
+            fn (mixed $ring): bool => is_array($ring) && self::hasAtLeast($ring, self::MIN_RING_POSITIONS),
+        );
+    }
+
+    /**
+     * @param  array<int|string, mixed>  $positions
+     */
+    private static function hasAtLeast(array $positions, int $minimum): bool
+    {
+        return count($positions) >= $minimum;
+    }
+}

--- a/app/EventForm/Schema/Patches/LocatiePolygonsPatch.php
+++ b/app/EventForm/Schema/Patches/LocatiePolygonsPatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Schema\Patches;
 
 use App\EventForm\Components\InfoText;
+use App\EventForm\Validation\CompleteMapGeometry;
 use Dotswan\MapPicker\Fields\Map;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
@@ -129,6 +130,7 @@ final class LocatiePolygonsPatch
                             }
                         }
                     })
+                    ->rule(new CompleteMapGeometry)
                     ->hidden($hiddenCallback);
 
                 $patched[] = InfoText::warning('waarschuwingPlattegrondVereist', '<p><strong>Let op: </strong>het intekenen van de locatie of het terrein in het aanvraagformulier vervangt niet de verplichte plattegrond. Voeg daarom steeds een afzonderlijke plattegrond toe. De vereisten voor deze plattegrond kunnen verschillen per gemeente. Hiervoor kunt u terecht op de gemeentelijke website of neemt u contact op met de betreffende gemeente.</p>')->hidden($hiddenCallback);
@@ -218,7 +220,8 @@ final class LocatiePolygonsPatch
                                 }
                             }
                         }
-                    });
+                    })
+                    ->rule(new CompleteMapGeometry);
 
                 continue;
             }

--- a/app/EventForm/Services/LocationServerCheckService.php
+++ b/app/EventForm/Services/LocationServerCheckService.php
@@ -6,16 +6,18 @@ namespace App\EventForm\Services;
 
 use App\Actions\Geospatial\CheckIntersects;
 use App\Actions\Geospatial\CheckWithin;
+use App\Actions\Geospatial\GeoJsonGeometryValidator;
 use App\Models\Municipality;
 use App\Services\LocatieserverService;
 use Brick\Geo\Engine\GeometryEngine;
 use Brick\Geo\Engine\PdoEngine;
+use Brick\Geo\Geometry;
 use Brick\Geo\Io\GeoJsonReader;
 use Brick\Geo\LineString;
-use Brick\Geo\Polygon;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 
 /**
  * Bepaalt welke gemeenten geraakt of doorkruist worden door opgegeven
@@ -46,8 +48,10 @@ class LocationServerCheckService
         if ($input->polygons !== null) {
             [$engine, $intersects, $within] = $this->ensureEngine($engine, $intersects, $within);
             foreach ($input->polygons as $polygonObject) {
-                /** @var Polygon $polygon */
-                $polygon = (new GeoJsonReader)->read((string) json_encode($polygonObject));
+                $polygon = $this->readProcessableGeometry($polygonObject);
+                if ($polygon === null) {
+                    continue;
+                }
                 $items = $intersects->checkIntersectsWithModels($polygon);
                 $response = $this->mergeItems($response, $items, ['all.items', 'polygons.items']);
                 $response = $this->mergeWithin(
@@ -60,19 +64,21 @@ class LocationServerCheckService
 
         if ($input->line !== null) {
             [$engine, $intersects, $within] = $this->ensureEngine($engine, $intersects, $within);
-            /** @var LineString $line */
-            $line = (new GeoJsonReader)->read((string) json_encode($input->line));
-            $response = $this->absorbLineIntoSingleLine($response, $line, $intersects, $within);
+            $line = $this->readProcessableGeometry($input->line);
+            if ($line instanceof LineString) {
+                $response = $this->absorbLineIntoSingleLine($response, $line, $intersects, $within);
+            }
         }
 
         if ($input->lines !== null) {
             [$engine, $intersects, $within] = $this->ensureEngine($engine, $intersects, $within);
             foreach ($input->lines as $lineObject) {
-                $line = (new GeoJsonReader)->read((string) json_encode($lineObject));
+                $line = $this->readProcessableGeometry($lineObject);
                 if (! $line instanceof LineString) {
-                    // Sla geometrieën over die geen lijn zijn; de collect-laag
-                    // filtert dit al af, maar dit vangt edge-cases in oude
-                    // draft-state op.
+                    // Sla geometrieën over die geen (bruikbare) lijn zijn; de
+                    // collect-laag filtert dit al af, maar dit vangt
+                    // edge-cases in oude draft-state en half-getekende
+                    // routes op.
                     continue;
                 }
                 $response = $this->appendLineToLinesArray($response, $line, $intersects, $within);
@@ -133,6 +139,33 @@ class LocationServerCheckService
             $intersects ?? new CheckIntersects($engine),
             $within ?? new CheckWithin($engine),
         ];
+    }
+
+    /**
+     * Read a decoded GeoJSON geometry into a Brick geometry, or return null
+     * when it is degenerate (e.g. an unfinished polygon with fewer than four
+     * ring positions) or otherwise unreadable. Passing such a geometry to the
+     * engine makes PostGIS throw and crashes the whole Livewire update.
+     */
+    private function readProcessableGeometry(mixed $geometryObject): ?Geometry
+    {
+        if (! is_array($geometryObject) || ! GeoJsonGeometryValidator::isProcessable($geometryObject)) {
+            Log::info('Skipping degenerate GeoJSON geometry in location check.', [
+                'type' => is_array($geometryObject) ? ($geometryObject['type'] ?? null) : null,
+            ]);
+
+            return null;
+        }
+
+        try {
+            return (new GeoJsonReader)->read((string) json_encode($geometryObject));
+        } catch (\Throwable $e) {
+            Log::warning('Failed to read GeoJSON geometry in location check.', [
+                'message' => $e->getMessage(),
+            ]);
+
+            return null;
+        }
     }
 
     /**

--- a/app/EventForm/Validation/CompleteMapGeometry.php
+++ b/app/EventForm/Validation/CompleteMapGeometry.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Validation;
+
+use App\Actions\Geospatial\GeoJsonGeometryValidator;
+use Closure;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Requires a map field to hold at least one finished shape, and rejects any
+ * unfinished one (a polygon with fewer than four ring positions or a line with
+ * a single point).
+ *
+ * Selecting "buiten"/"route" seeds the field with a non-empty placeholder, so
+ * `->required()` is fooled into passing even when nothing (or only an
+ * unfinished shape that the map never committed) was drawn. This rule only runs
+ * when the field is visible (Filament skips hidden fields), i.e. when a shape is
+ * actually expected, so demanding a complete geometry here is correct. Reuses
+ * {@see GeoJsonGeometryValidator}, the same check that guards the geometry
+ * engine server-side.
+ */
+class CompleteMapGeometry implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($this->isBlank($value)) {
+            // A genuinely empty field is left to the field's own ->required().
+            return;
+        }
+
+        $geometries = $this->geometriesFromMapState($value);
+
+        if ($geometries === []) {
+            $fail('Teken een volledige vorm op de kaart voordat u verder gaat.');
+
+            return;
+        }
+
+        foreach ($geometries as $geometry) {
+            if (! GeoJsonGeometryValidator::isProcessable($geometry)) {
+                $fail('De op de kaart getekende vorm is niet compleet. Maak de tekening af of verwijder hem voordat u verder gaat.');
+
+                return;
+            }
+        }
+    }
+
+    private function isBlank(mixed $value): bool
+    {
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            $value = is_array($decoded) ? $decoded : $value;
+        }
+
+        return $value === null || $value === '' || $value === [];
+    }
+
+    /**
+     * Pull the GeoJSON geometry objects out of a Map-state value
+     * (`{lat, lng, geojson: {features: [{geometry: {...}}, ...]}}`). The Map
+     * field can hand its state over as a JSON string, so decode that first.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function geometriesFromMapState(mixed $value): array
+    {
+        if (is_string($value)) {
+            $value = json_decode($value, true);
+        }
+
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $features = $value['geojson']['features'] ?? null;
+        if (! is_array($features)) {
+            return [];
+        }
+
+        $geometries = [];
+        foreach ($features as $feature) {
+            $geometry = is_array($feature) ? ($feature['geometry'] ?? null) : null;
+            if (is_array($geometry)) {
+                $geometries[] = $geometry;
+            }
+        }
+
+        return $geometries;
+    }
+}

--- a/tests/Feature/EventForm/Schema/LocatieMapValidationTest.php
+++ b/tests/Feature/EventForm/Schema/LocatieMapValidationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
+use App\EventForm\State\FormState;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Organisation;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Validation\ValidationException;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach($this->organisation->id, ['role' => 'admin']);
+    $this->actingAs($this->user);
+    Filament::setCurrentPanel(Filament::getPanel('organiser'));
+    Filament::setTenant($this->organisation);
+});
+
+/**
+ * Validate the Locatie step of a freshly mounted form for the given draft state,
+ * and return the validation error messages for the locatieSOpKaart field.
+ *
+ * @param  array<string, mixed>  $values
+ * @return list<string>
+ */
+function validateLocatieStep(array $values): array
+{
+    $state = FormState::empty();
+    foreach ($values as $key => $value) {
+        $state->setField($key, $value);
+    }
+
+    $draft = Draft::create([
+        'user_id' => test()->user->id,
+        'organisation_id' => test()->organisation->id,
+        'state' => $state->toSnapshot(),
+        'current_step_key' => LocatieVanHetEvenement2Step::UUID,
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $draft->id])->instance();
+
+    $wizard = $page->form->getComponents(withHidden: true)[0];
+    $locatieStep = null;
+    foreach ($wizard->getChildSchema()->getComponents(withHidden: true) as $step) {
+        $key = $step->getKey();
+        $uuid = str_starts_with($key, 'form.') ? substr($key, 5) : $key;
+        if ($uuid === LocatieVanHetEvenement2Step::UUID) {
+            $locatieStep = $step;
+        }
+    }
+
+    try {
+        $locatieStep->getChildSchema()->validate();
+    } catch (ValidationException $e) {
+        return $e->errors()['data.locatieSOpKaart'] ?? [];
+    }
+
+    return [];
+}
+
+function polygonMapState(array $ring): array
+{
+    return [
+        'lat' => 50.85,
+        'lng' => 5.69,
+        'geojson' => [
+            'type' => 'FeatureCollection',
+            'features' => [[
+                'type' => 'Feature',
+                'geometry' => ['type' => 'Polygon', 'coordinates' => [$ring]],
+            ]],
+        ],
+    ];
+}
+
+test('buiten selected with only the placeholder (no drawn shape) blocks the step', function () {
+    // Selecting "buiten" seeds locatieSOpKaart with a non-empty placeholder,
+    // which fooled ->required(). This is the reported scenario.
+    $errors = validateLocatieStep([
+        'waarVindtHetEvenementPlaats' => ['buiten'],
+        'naamVanDeLocatieKaart' => 'Testlocatie',
+        'locatieSOpKaart' => ['6dd157f3-f46e-4465-b4aa-5916da0c6b4f' => []],
+    ]);
+
+    expect($errors)->toContain('Teken een volledige vorm op de kaart voordat u verder gaat.');
+});
+
+test('buiten selected with an incomplete polygon blocks the step', function () {
+    $errors = validateLocatieStep([
+        'waarVindtHetEvenementPlaats' => ['buiten'],
+        'naamVanDeLocatieKaart' => 'Testlocatie',
+        'locatieSOpKaart' => polygonMapState([[5.69, 50.85], [5.70, 50.85], [5.69, 50.85]]),
+    ]);
+
+    expect($errors)->toContain('De op de kaart getekende vorm is niet compleet. Maak de tekening af of verwijder hem voordat u verder gaat.');
+});
+
+test('buiten selected with a complete polygon passes the map validation', function () {
+    $errors = validateLocatieStep([
+        'waarVindtHetEvenementPlaats' => ['buiten'],
+        'naamVanDeLocatieKaart' => 'Testlocatie',
+        'locatieSOpKaart' => polygonMapState([[5.69, 50.85], [5.70, 50.85], [5.70, 50.86], [5.69, 50.86], [5.69, 50.85]]),
+    ]);
+
+    expect($errors)->toBe([]);
+});

--- a/tests/Feature/EventForm/Services/LocationServerCheckServiceTest.php
+++ b/tests/Feature/EventForm/Services/LocationServerCheckServiceTest.php
@@ -73,3 +73,33 @@ test('unknown postcode yields within=false and empty items', function () {
         ->and($result['all']['within'])->toBeFalse()
         ->and($result['all']['items'])->toBe([]);
 });
+
+test('a degenerate polygon is skipped instead of crashing the engine', function () {
+    // Een half-getekende polygoon (ring met minder dan vier punten) liet
+    // PostGIS crashen ("Polygon must have at least four points in each ring"),
+    // wat als 500 tijdens de Livewire-update naar buiten kwam (Sentry
+    // EVENTLOKET-Z). De service slaat zo'n geometrie nu over.
+    $service = new LocationServerCheckService;
+
+    $result = $service->execute(new LocationServerCheckInput(
+        polygons: [
+            ['type' => 'Polygon', 'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [0.5, 0.5]]]],
+        ],
+    ));
+
+    expect($result['polygons']['items'])->toHaveCount(0)
+        ->and($result['all']['items'])->toBe([]);
+});
+
+test('a valid polygon is still processed by the engine', function () {
+    $service = new LocationServerCheckService;
+
+    $result = $service->execute(new LocationServerCheckInput(
+        polygons: [
+            ['type' => 'Polygon', 'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [1.5, 1.5], [1.5, 0.5], [0.5, 0.5]]]],
+        ],
+    ));
+
+    expect($result['polygons']['items'])->toHaveCount(1)
+        ->and($result['polygons']['items']->first()['brk_identification'])->toBe('GM0882');
+});

--- a/tests/Unit/Actions/Geospatial/GeoJsonGeometryValidatorTest.php
+++ b/tests/Unit/Actions/Geospatial/GeoJsonGeometryValidatorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Geospatial\GeoJsonGeometryValidator;
+
+test('a polygon with enough ring positions is processable', function () {
+    $polygon = [
+        'type' => 'Polygon',
+        'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [1.5, 1.5], [1.5, 0.5], [0.5, 0.5]]],
+    ];
+
+    expect(GeoJsonGeometryValidator::isProcessable($polygon))->toBeTrue();
+});
+
+test('a polygon whose ring is degenerate is not processable', function (array $ring) {
+    $polygon = ['type' => 'Polygon', 'coordinates' => [$ring]];
+
+    expect(GeoJsonGeometryValidator::isProcessable($polygon))->toBeFalse();
+})->with([
+    'two positions' => [[[0.5, 0.5], [0.5, 1.5]]],
+    'three positions' => [[[0.5, 0.5], [0.5, 1.5], [0.5, 0.5]]],
+    'empty ring' => [[]],
+]);
+
+test('a multipolygon is processable only when every ring is valid', function () {
+    $valid = [
+        'type' => 'MultiPolygon',
+        'coordinates' => [[[[0, 0], [0, 2], [2, 2], [2, 0], [0, 0]]]],
+    ];
+    $invalid = [
+        'type' => 'MultiPolygon',
+        'coordinates' => [[[[0, 0], [0, 2], [0, 0]]]],
+    ];
+
+    expect(GeoJsonGeometryValidator::isProcessable($valid))->toBeTrue()
+        ->and(GeoJsonGeometryValidator::isProcessable($invalid))->toBeFalse();
+});
+
+test('a line is processable only with at least two positions', function () {
+    $valid = ['type' => 'LineString', 'coordinates' => [[0, 0], [1, 1]]];
+    $invalid = ['type' => 'LineString', 'coordinates' => [[0, 0]]];
+
+    expect(GeoJsonGeometryValidator::isProcessable($valid))->toBeTrue()
+        ->and(GeoJsonGeometryValidator::isProcessable($invalid))->toBeFalse();
+});
+
+test('a point with coordinates is processable', function () {
+    expect(GeoJsonGeometryValidator::isProcessable(['type' => 'Point', 'coordinates' => [5.69, 50.85]]))->toBeTrue();
+});
+
+test('malformed geometry objects are not processable', function (array $geometry) {
+    expect(GeoJsonGeometryValidator::isProcessable($geometry))->toBeFalse();
+})->with([
+    'missing coordinates' => [['type' => 'Polygon']],
+    'missing type' => [['coordinates' => [[[0, 0], [0, 1], [1, 1], [0, 0]]]]],
+    'non-array coordinates' => [['type' => 'Polygon', 'coordinates' => 'nope']],
+]);

--- a/tests/Unit/EventForm/Validation/CompleteMapGeometryTest.php
+++ b/tests/Unit/EventForm/Validation/CompleteMapGeometryTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\EventForm\Validation\CompleteMapGeometry;
+
+function completeMapGeometryFails(mixed $value): bool
+{
+    $failed = false;
+    (new CompleteMapGeometry)->validate('kaart', $value, function () use (&$failed) {
+        $failed = true;
+    });
+
+    return $failed;
+}
+
+function mapStateWithGeometry(array $geometry): array
+{
+    return [
+        'lat' => 50.85,
+        'lng' => 5.69,
+        'geojson' => ['features' => [['type' => 'Feature', 'geometry' => $geometry]]],
+    ];
+}
+
+test('a complete polygon passes validation', function () {
+    $value = mapStateWithGeometry([
+        'type' => 'Polygon',
+        'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [1.5, 1.5], [1.5, 0.5], [0.5, 0.5]]],
+    ]);
+
+    expect(completeMapGeometryFails($value))->toBeFalse();
+});
+
+test('an incomplete shape fails validation', function (array $geometry) {
+    expect(completeMapGeometryFails(mapStateWithGeometry($geometry)))->toBeTrue();
+})->with([
+    'polygon with three ring positions' => [['type' => 'Polygon', 'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [0.5, 0.5]]]]],
+    'line with one position' => [['type' => 'LineString', 'coordinates' => [[0, 0]]]],
+]);
+
+test('an incomplete polygon fails when the map state is a json string', function () {
+    $value = json_encode(mapStateWithGeometry([
+        'type' => 'Polygon',
+        'coordinates' => [[[0.5, 0.5], [0.5, 1.5], [0.5, 0.5]]],
+    ]));
+
+    expect(completeMapGeometryFails($value))->toBeTrue();
+});
+
+test('a present-but-shapeless map fails validation (nothing complete drawn)', function (mixed $value) {
+    expect(completeMapGeometryFails($value))->toBeTrue();
+})->with([
+    // Placeholder that selecting "buiten"/"route" seeds into the field.
+    'repeater placeholder' => [['6dd157f3-f46e-4465-b4aa-5916da0c6b4f' => []]],
+    'empty feature collection' => [['lat' => 50.85, 'lng' => 5.69, 'geojson' => ['features' => []]]],
+    'centre only, nothing drawn' => [['lat' => 50.85, 'lng' => 5.69]],
+]);
+
+test('a genuinely empty value passes (the field\'s own required rule handles it)', function (mixed $value) {
+    expect(completeMapGeometryFails($value))->toBeFalse();
+})->with([
+    'null' => null,
+    'empty string' => '',
+    'empty array' => [[]],
+]);


### PR DESCRIPTION
## What

Two related problems around unfinished map drawings in the organiser event form:

1. **Crash (Sentry EVENTLOKET-Z).** An incomplete polygon (a ring with fewer than four points) was sent to PostGIS during the live location check, which rejects it (`Polygon must have at least four points in each ring`). This became an unhandled 500 during the Livewire update.
2. **Advancing without a complete shape.** Selecting "buiten"/"route" seeds the map field with a non-empty placeholder, which fooled `->required()`. You could move to the next step even though no (complete) shape had been drawn.

## Approach

- **Backend guard:** `GeoJsonGeometryValidator` plus guards in `LocationServerCheckService` skip degenerate geometries before they reach the engine (polygon ring < 4 points, line < 2 points), and `GeoJsonReader::read()` is wrapped in a try/catch. This protects both the live form check and the `POST /api/locationserver/check` endpoint.
- **Form validation:** the `CompleteMapGeometry` rule on the patched location and route map fields requires at least one complete shape when the map is applicable, and rejects any incomplete shape. So "Volgende"/submit are blocked until the drawing is complete. A genuinely empty field is left to `->required()`.

## Tests

- Unit: `GeoJsonGeometryValidator` and `CompleteMapGeometry` (complete, incomplete, placeholder, empty, JSON string).
- Feature: the service skips a degenerate polygon without crashing and still processes a valid one; the Locatie step blocks a placeholder and an incomplete polygon and passes a complete one (via a real page mount plus step validation).
- Full `tests/Feature/EventForm` + `tests/Unit/EventForm` + geospatial: 485 passed. Pint and PHPStan clean.

## Note

Validation is now stricter: with "buiten"/"route" a complete drawn shape is required before you can proceed. Previously you could advance with only the placeholder.