### PR TITLE
Fix report question null value and reorder unique constraint violations

### DIFF
--- a/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReportQuestionsRelationManager.php
+++ b/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReportQuestionsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\MunicipalityResource\RelationManagers;
 
+use App\Filament\Shared\Resources\ReportQuestions\Concerns\SafelyReordersReportQuestions;
 use App\Filament\Shared\Resources\ReportQuestions\Schemas\ReportQuestionForm;
 use App\Filament\Shared\Resources\ReportQuestions\Tables\ReportQuestionsTable;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReportQuestionsRelationManager extends RelationManager
 {
+    use SafelyReordersReportQuestions;
+
     protected static string $relationship = 'reportQuestions';
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string

--- a/app/Filament/Municipality/Clusters/Settings/Resources/ReportQuestions/Pages/ListReportQuestions.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/ReportQuestions/Pages/ListReportQuestions.php
@@ -3,8 +3,8 @@
 namespace App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages;
 
 use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\ReportQuestionResource;
+use App\Filament\Shared\Resources\ReportQuestions\Concerns\SafelyReordersReportQuestions;
 use App\Models\Municipality;
-use App\Models\ReportQuestion;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
@@ -15,13 +15,14 @@ use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\View\PanelsRenderHook;
-use Illuminate\Support\Facades\DB;
 
 /**
  * @property Schema $municipalitySettingsForm
  */
 class ListReportQuestions extends ListRecords
 {
+    use SafelyReordersReportQuestions;
+
     protected static string $resource = ReportQuestionResource::class;
 
     /**
@@ -77,40 +78,5 @@ class ListReportQuestions extends ListRecords
                 ->compact(),
             RenderHook::make(PanelsRenderHook::RESOURCE_PAGES_LIST_RECORDS_TABLE_AFTER),
         ]);
-    }
-
-    /**
-     * Override Filament's default bulk CASE WHEN update to avoid unique constraint
-     * violations on (municipality_id, order). Works on both PostgreSQL and MySQL.
-     *
-     * Strategy: first shift all affected orders to a temporary high value (no conflicts
-     * within the same municipality), then set the final values one by one.
-     *
-     * @param  array<int|string>  $order
-     */
-    public function reorderTable(array $order, int|string|null $draggedRecordKey = null): void
-    {
-        if (! $this->getTable()->isReorderable()) {
-            return;
-        }
-
-        $this->getTable()->callBeforeReordering($order);
-
-        DB::transaction(function () use ($order): void {
-            $ids = array_values($order);
-
-            // Pass 1: shift all to high values so none of the 1-10 slots are occupied.
-            // Max 10 records with order values 1–10; adding 200 safely stays within
-            // the unsignedTinyInteger range (max 255).
-            ReportQuestion::whereIn('id', $ids)->increment('order', 200);
-
-            // Pass 2: write the final positions. No conflicts because all targeted
-            // records are currently sitting at 201–210.
-            foreach ($order as $index => $id) {
-                ReportQuestion::where('id', $id)->update(['order' => $index + 1]);
-            }
-        });
-
-        $this->getTable()->callAfterReordering($order);
     }
 }

--- a/app/Filament/Shared/Resources/ReportQuestions/Concerns/SafelyReordersReportQuestions.php
+++ b/app/Filament/Shared/Resources/ReportQuestions/Concerns/SafelyReordersReportQuestions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Shared\Resources\ReportQuestions\Concerns;
+
+use App\Models\ReportQuestion;
+use Illuminate\Support\Facades\DB;
+
+trait SafelyReordersReportQuestions
+{
+    /**
+     * Override Filament's default bulk CASE WHEN update to avoid unique
+     * constraint violations on (municipality_id, order). Works on both
+     * PostgreSQL and MySQL.
+     *
+     * Strategy: first shift all affected orders to a temporary high value
+     * (no conflicts within the same municipality), then set the final
+     * values one by one.
+     *
+     * @param  array<int|string>  $order
+     */
+    public function reorderTable(array $order, int|string|null $draggedRecordKey = null): void
+    {
+        if (! $this->getTable()->isReorderable()) {
+            return;
+        }
+
+        $this->getTable()->callBeforeReordering($order);
+
+        DB::transaction(function () use ($order): void {
+            $ids = array_values($order);
+
+            // Pass 1: shift all to high values so none of the 1-10 slots are occupied.
+            // Max 10 records with order values 1–10; adding 200 safely stays within
+            // the unsignedTinyInteger range (max 255).
+            ReportQuestion::whereIn('id', $ids)->increment('order', 200);
+
+            // Pass 2: write the final positions. No conflicts because all targeted
+            // records are currently sitting at 201–210.
+            foreach ($order as $index => $id) {
+                ReportQuestion::where('id', $id)->update(['order' => $index + 1]);
+            }
+        });
+
+        $this->getTable()->callAfterReordering($order);
+    }
+}

--- a/app/Filament/Shared/Resources/ReportQuestions/Schemas/ReportQuestionForm.php
+++ b/app/Filament/Shared/Resources/ReportQuestions/Schemas/ReportQuestionForm.php
@@ -20,6 +20,7 @@ class ReportQuestionForm
                 TextInput::make('question')
                     ->label(__('resources/report_question.form.question.label'))
                     ->helperText(__('resources/report_question.form.question.helper_text'))
+                    ->required()
                     ->maxLength(1000)
                     ->columnSpanFull(),
                 Toggle::make('is_active')

--- a/tests/Feature/ReportQuestion/ReportQuestionTest.php
+++ b/tests/Feature/ReportQuestion/ReportQuestionTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Enums\Role;
+use App\Filament\Admin\Resources\MunicipalityResource\Pages\EditMunicipality;
+use App\Filament\Admin\Resources\MunicipalityResource\RelationManagers\ReportQuestionsRelationManager;
+use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages\EditReportQuestion;
 use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages\ListReportQuestions;
 use App\Models\Municipality;
 use App\Models\ReportQuestion;
@@ -159,6 +162,65 @@ test('reordering does not affect report questions of other municipalities', func
     expect($q2->fresh()->order)->toBe(1);
     expect($q1->fresh()->order)->toBe(2);
     expect($other->fresh()->order)->toBe(1); // untouched
+});
+
+test('reordering via admin relation manager does not cause unique constraint violations', function () {
+    $admin = User::factory()->create(['role' => Role::Admin]);
+    $municipality = Municipality::factory()->create();
+    $municipality->reportQuestions()->delete();
+
+    $questions = collect(range(1, 5))->map(fn ($i) => ReportQuestion::factory()->create([
+        'municipality_id' => $municipality->id,
+        'order' => $i,
+        'question' => "Question $i?",
+    ]));
+
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    // Reverse the entire order (worst case for constraint violations)
+    $reversed = $questions->reverse()->pluck('id')->all();
+
+    livewire(ReportQuestionsRelationManager::class, [
+        'ownerRecord' => $municipality,
+        'pageClass' => EditMunicipality::class,
+    ])->call('reorderTable', $reversed);
+
+    foreach ($questions->reverse()->values() as $newPosition => $question) {
+        expect($question->fresh()->order)->toBe($newPosition + 1);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// EditReportQuestion form validation
+// ---------------------------------------------------------------------------
+
+test('editing a report question with an empty question fails validation instead of writing null', function () {
+    $municipality = Municipality::factory()->create();
+    $municipality->reportQuestions()->delete();
+
+    $question = ReportQuestion::factory()->create([
+        'municipality_id' => $municipality->id,
+        'order' => 1,
+        'question' => 'Original question?',
+        'is_active' => true,
+    ]);
+
+    $user = User::factory()->create(['role' => Role::ReviewerMunicipalityAdmin]);
+    $user->municipalities()->attach($municipality);
+
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+    Filament::setTenant($municipality);
+
+    livewire(EditReportQuestion::class, ['record' => $question->id])
+        ->fillForm(['question' => '', 'is_active' => false])
+        ->call('save')
+        ->assertHasFormErrors(['question' => 'required']);
+
+    // The original value must be untouched (no NULL written to the NOT NULL column).
+    expect($question->fresh()->question)->toBe('Original question?');
+    expect($question->fresh()->is_active)->toBeTrue();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Aanleiding

Twee Sentry-fouten op staging (`next/v1.2`), beide op de `report_questions`-tabel via een Livewire-update:

- **EVENTLOKET-1E** `QueryException: Column 'question' cannot be null`. Het gedeelde edit-formulier liet het `question`-veld leeg toe, terwijl de DB-kolom `text` NOT NULL is. Een lege vraag opslaan stuurde `question = NULL`.
- **EVENTLOKET-1F** `UniqueConstraintViolationException` op `(municipality_id, order)`. Er bestond al een veilige two-pass reorder, maar die zat alleen op de Municipality-panel pagina. Reorderen in de Admin-panel relation manager viel terug op Filaments standaard CASE-WHEN bulk-update en botste op de unique-index.

## Wijzigingen

- `question`-`TextInput` in het gedeelde `ReportQuestionForm` op `->required()` gezet. Blokkeert de lege submit vóór de DB-write, in beide panels.
- De two-pass reorder-logica geëxtraheerd naar een herbruikbare trait `SafelyReordersReportQuestions` en toegepast op zowel `ListReportQuestions` als `ReportQuestionsRelationManager`. Dit sluit het admin-panel gat en verwijdert de duplicatie.
- Regressietests toegevoegd voor beide faalpaden (lege vraag → validatiefout, admin-reorder → geen unique-violation).

## Verificatie

- `sail artisan test --filter=ReportQuestion`: 37 passed.
- Pint en PHPStan (level 5): schoon.

Datamodel blijft ongewijzigd.