### PR TITLE
Add a signed /__version endpoint for the service-register probe

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,3 +117,9 @@ OBJECTSAPI_TOKEN="objectsapi-token"
 #
 # OPEN_FORMS_BASE_URL=http://open-forms:8000
 # OPEN_FORMS_MAIN_FORM_UUID=
+
+# service-register version probe. The register verifies the running version via a
+# signed request to /__version. Put the register's PUBLIC ed25519 key here (base64).
+# It is not a secret, but it is environment specific: set it per environment and do
+# not commit the value. Leave empty to keep /__version returning 404.
+REGISTER_VERIFY_KEY=

--- a/config/register.php
+++ b/config/register.php
@@ -1,0 +1,33 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | service-register /__version endpoint
+    |--------------------------------------------------------------------------
+    |
+    | The service-register probes this app's running version over a signed
+    | request to /__version. We verify each request with the register's public
+    | ed25519 key. The public key is not a secret; the register holds the private
+    | key. See the /__version route in routes/web.php.
+    |
+    | Read via config() (not env()) so the route keeps working after
+    | `php artisan config:cache`, where env() outside config files returns null.
+    | Set REGISTER_VERIFY_KEY per environment in .env, never commit the value.
+    */
+
+    'verify_key' => env('REGISTER_VERIFY_KEY'),
+
+    // Optional version override, used when no VERSION file is written at deploy time
+    // and before falling back to `git describe`. Read via config so it survives
+    // config:cache (env() would return null there).
+    'app_version' => env('APP_VERSION'),
+
+    'timestamp_header' => 'X-Register-Timestamp',
+    'signature_header' => 'X-Register-Signature',
+
+    // Seconds of tolerance on the request timestamp, to stop replay.
+    'clock_skew' => (int) env('REGISTER_CLOCK_SKEW', 60),
+
+];

--- a/routes/web.php
+++ b/routes/web.php
@@ -24,7 +24,14 @@ Route::get('/__version', function (Request $request) {
     $timestamp = $request->header(config('register.timestamp_header'));
     $signature = base64_decode((string) $request->header(config('register.signature_header')), true);
 
-    if (! $publicKey || ! $timestamp || $signature === false || strlen($publicKey) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+    // Reject anything that is not a well formed key + signature before verifying.
+    // base64_decode('', true) returns '' (not false), so a missing or wrong length
+    // signature must be caught by the length check: sodium_crypto_sign_verify_detached
+    // throws on a signature that is not exactly SODIUM_CRYPTO_SIGN_BYTES, which would
+    // turn an unauthenticated request into a 500 and break the "always 404" guarantee.
+    if (! $publicKey || ! $timestamp || $signature === false
+        || strlen($publicKey) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES
+        || strlen($signature) !== SODIUM_CRYPTO_SIGN_BYTES) {
         abort(404);
     }
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,6 +15,83 @@ use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
+// service-register version probe. The register signs a "timestamp\npath" message
+// with its private ed25519 key; we verify it with the public key in config and
+// reject stale timestamps. Every failure returns 404 so the route is invisible to
+// anyone without a valid signature. The response exposes only version metadata.
+Route::get('/__version', function (Request $request) {
+    $publicKey = base64_decode((string) config('register.verify_key'), true);
+    $timestamp = $request->header(config('register.timestamp_header'));
+    $signature = base64_decode((string) $request->header(config('register.signature_header')), true);
+
+    if (! $publicKey || ! $timestamp || $signature === false || strlen($publicKey) !== SODIUM_CRYPTO_SIGN_PUBLICKEYBYTES) {
+        abort(404);
+    }
+
+    // Reject stale or future timestamps to stop replay.
+    if (abs(time() - (int) $timestamp) > (int) config('register.clock_skew')) {
+        abort(404);
+    }
+
+    $message = $timestamp."\n".$request->getPathInfo();
+    if (! sodium_crypto_sign_verify_detached($signature, $message, $publicKey)) {
+        abort(404);
+    }
+
+    $base = base_path();
+
+    $composerLockHash = is_file($base.'/composer.lock')
+        ? 'sha256:'.hash_file('sha256', $base.'/composer.lock')
+        : null;
+
+    // Version info: prefer a deploy written VERSION file, then env, then git. Git is
+    // read at request time (best effort, guarded by function_exists('exec')).
+    $gitTag = null;
+    $gitSha = null;
+    $branch = null;
+    if (is_file($base.'/VERSION')) {
+        $gitTag = trim((string) file_get_contents($base.'/VERSION')) ?: null;
+    }
+    $gitTag = $gitTag ?: (config('register.app_version') ?: null);
+    if (function_exists('exec')) {
+        $gitTag = $gitTag ?: (@exec('git -C '.escapeshellarg($base).' describe --tags --always 2>/dev/null') ?: null);
+        $gitSha = @exec('git -C '.escapeshellarg($base).' rev-parse HEAD 2>/dev/null') ?: null;
+        // A deploy pinned to a tag is detached ("HEAD"), which reports no branch.
+        $branch = @exec('git -C '.escapeshellarg($base).' rev-parse --abbrev-ref HEAD 2>/dev/null') ?: null;
+        if ($branch === 'HEAD') {
+            $branch = null;
+        }
+    }
+
+    // Extra runtimes for the register's end of life check, keyed by endoflife.date
+    // slug: the Node toolchain (best effort) and the container OS. Omitted if absent.
+    $runtimes = [];
+    if (function_exists('exec')) {
+        $node = @exec('node -v 2>/dev/null');
+        if ($node && preg_match('/(\d+\.\d+\.\d+)/', $node, $m)) {
+            $runtimes['nodejs'] = $m[1];
+        }
+    }
+    if (is_readable('/etc/os-release')) {
+        $osRelease = parse_ini_file('/etc/os-release') ?: [];
+        if (! empty($osRelease['ID']) && ! empty($osRelease['VERSION_ID'])) {
+            $runtimes[$osRelease['ID']] = $osRelease['VERSION_ID'];
+        }
+    }
+
+    return response()->json([
+        'php' => PHP_VERSION,
+        'framework' => app()->version(),
+        'git_tag' => $gitTag,
+        'git_sha' => $gitSha,
+        'composer_lock_hash' => $composerLockHash,
+        'app_env' => app()->environment(),
+        'branch' => $branch,
+        'runtimes' => $runtimes,
+        'checked_at' => now()->toIso8601String(),
+    ]);
+});
+
 Route::middleware('signed')
     ->get('admin/admin-invites/{token}', AcceptAdminInvite::class)
     ->name('admin-invites.accept');

--- a/tests/Unit/VersionEndpointTest.php
+++ b/tests/Unit/VersionEndpointTest.php
@@ -1,0 +1,74 @@
+<?php
+
+// The /__version route reads no database. It lives in the Unit suite so it runs
+// without RefreshDatabase (which the Feature suite applies globally): no migrations
+// and no database connection are needed to verify the signature gate and payload.
+
+/** Set the register public key in config and return the matching secret key. */
+function registerKeypair(): string
+{
+    $pair = sodium_crypto_sign_keypair();
+    config(['register.verify_key' => base64_encode(sodium_crypto_sign_publickey($pair))]);
+
+    return sodium_crypto_sign_secretkey($pair);
+}
+
+/** Build the signed request headers the register would send for /__version. */
+function signedHeaders(string $secret, ?int $timestamp = null): array
+{
+    $timestamp ??= time();
+    $signature = sodium_crypto_sign_detached($timestamp."\n".'/__version', $secret);
+
+    return [
+        'X-Register-Timestamp' => (string) $timestamp,
+        'X-Register-Signature' => base64_encode($signature),
+    ];
+}
+
+it('returns the version metadata for a valid signed request', function () {
+    $secret = registerKeypair();
+
+    $response = $this->get('/__version', signedHeaders($secret));
+
+    $response->assertOk()
+        ->assertJson([
+            'php' => PHP_VERSION,
+            'app_env' => 'testing',
+        ])
+        ->assertJsonStructure([
+            'php', 'framework', 'git_tag', 'git_sha', 'composer_lock_hash',
+            'app_env', 'branch', 'runtimes', 'checked_at',
+        ]);
+});
+
+it('404s without a signature so the route is invisible', function () {
+    registerKeypair();
+
+    $this->get('/__version')->assertNotFound();
+});
+
+it('404s on an invalid signature', function () {
+    registerKeypair();
+
+    $headers = [
+        'X-Register-Timestamp' => (string) time(),
+        'X-Register-Signature' => base64_encode(str_repeat("\0", SODIUM_CRYPTO_SIGN_BYTES)),
+    ];
+
+    $this->get('/__version', $headers)->assertNotFound();
+});
+
+it('404s on a stale timestamp even with an otherwise valid signature', function () {
+    $secret = registerKeypair();
+
+    $stale = time() - 3600;
+
+    $this->get('/__version', signedHeaders($secret, $stale))->assertNotFound();
+});
+
+it('404s when no verify key is configured', function () {
+    $secret = registerKeypair();
+    config(['register.verify_key' => null]);
+
+    $this->get('/__version', signedHeaders($secret))->assertNotFound();
+});

--- a/tests/Unit/VersionEndpointTest.php
+++ b/tests/Unit/VersionEndpointTest.php
@@ -58,6 +58,27 @@ it('404s on an invalid signature', function () {
     $this->get('/__version', $headers)->assertNotFound();
 });
 
+it('404s on a malformed signature with a valid timestamp, without throwing', function () {
+    registerKeypair();
+    $timestamp = (string) time();
+
+    // Empty signature header: base64_decode('') is '' (not false), so the length
+    // guard must catch it before sodium_crypto_sign_verify_detached throws.
+    $this->get('/__version', ['X-Register-Timestamp' => $timestamp])->assertNotFound();
+
+    // Short, non 64-byte signature.
+    $this->get('/__version', [
+        'X-Register-Timestamp' => $timestamp,
+        'X-Register-Signature' => base64_encode('too-short'),
+    ])->assertNotFound();
+
+    // Not valid base64 at all.
+    $this->get('/__version', [
+        'X-Register-Timestamp' => $timestamp,
+        'X-Register-Signature' => '!!!not-base64!!!',
+    ])->assertNotFound();
+});
+
 it('404s on a stale timestamp even with an otherwise valid signature', function () {
     $secret = registerKeypair();
 


### PR DESCRIPTION
I want the service-register to read this app's running version automatically instead of me typing it into the inventory by hand. This adds a `/__version` route the register can probe.

How it works:

- The register signs each request (a timestamp plus the request path) with its private ed25519 key. This route verifies the signature with the register's public key, which is not a secret, and rejects stale timestamps (a 60 second window) to stop replay.
- Every failure returns `404`, so the route is invisible to anyone without a valid signature. The response carries only version metadata: PHP version, framework, git tag and sha, composer.lock hash, app env, branch, and extra runtimes.

