### PR TITLE
Fix: "Mijn omgeving" prefilled as organisation name on personal submissions

### DIFF
--- a/app/EventForm/Services/FormSessionService.php
+++ b/app/EventForm/Services/FormSessionService.php
@@ -25,7 +25,7 @@ class FormSessionService
             'user_uuid' => $user->uuid,
             'organiser_uuid' => $organisation->uuid,
             'kvk' => $organisation->coc_number ?? '',
-            'organisation_name' => $organisation->name,
+            'organisation_name' => $organisation->isPersonal() ? '' : $organisation->name,
             'organisation_email' => $organisation->email ?? '',
             'organisation_phone' => $organisation->phone ?? '',
             'user_email' => $user->email,

--- a/app/EventForm/Submit/MapFormStateToReferenceData.php
+++ b/app/EventForm/Submit/MapFormStateToReferenceData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Submit;
 
 use App\EventForm\State\FormState;
+use App\Models\Organisation;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Carbon\Carbon;
 
@@ -120,7 +121,8 @@ final class MapFormStateToReferenceData
         $user = $state->get('authUser');
         $org = $state->get('authOrganisation');
 
-        if (is_object($org) && isset($org->name)) {
+        if (is_object($org) && isset($org->name)
+            && ! ($org instanceof Organisation && $org->isPersonal())) {
             return (string) $org->name;
         }
         if (is_object($user) && isset($user->name)) {

--- a/app/Models/Organisation.php
+++ b/app/Models/Organisation.php
@@ -45,6 +45,11 @@ class Organisation extends Model
         return $this->postbus_address !== null;
     }
 
+    public function isPersonal(): bool
+    {
+        return $this->type === OrganisationType::Personal;
+    }
+
     /** @return Attribute<BagObject|null, void> */
     protected function bagAddress(): Attribute
     {

--- a/database/factories/OrganisationFactory.php
+++ b/database/factories/OrganisationFactory.php
@@ -20,13 +20,26 @@ class OrganisationFactory extends Factory
     public function definition(): array
     {
         return [
-            'type' => fake()->randomElement(OrganisationType::cases()),
+            'type' => OrganisationType::Business,
             'name' => fake()->company,
             'coc_number' => (string) fake()->numberBetween(10000000, 99999999),
             'address' => fake()->address,
             'email' => 'test@domain.com',
             'phone' => fake()->phoneNumber,
         ];
+    }
+
+    /**
+     * State for a personal environment ("Mijn omgeving"): no Chamber of
+     * Commerce number, created when a user registers without a company.
+     */
+    public function personal(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'type' => OrganisationType::Personal,
+            'name' => 'Mijn omgeving',
+            'coc_number' => null,
+        ]);
     }
 
     /**

--- a/tests/Feature/EventForm/Services/FormSessionServiceTest.php
+++ b/tests/Feature/EventForm/Services/FormSessionServiceTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\OrganisationType;
 use App\EventForm\Services\FormSessionService;
 use App\Models\Organisation;
 use App\Models\User;
@@ -12,6 +13,7 @@ beforeEach(function () {
 
 test('builds the expected payload shape', function () {
     $organisation = Organisation::factory()->create([
+        'type' => OrganisationType::Business,
         'name' => 'Woweb Events',
         'coc_number' => '12345678',
         'email' => 'events@woweb.nl',
@@ -38,6 +40,18 @@ test('builds the expected payload shape', function () {
     ])
         ->and($result['user_uuid'])->toBe($user->uuid)
         ->and($result['organiser_uuid'])->toBe($organisation->uuid);
+});
+
+test('returns empty organisation_name for a personal organisation', function () {
+    $organisation = Organisation::factory()->create([
+        'type' => OrganisationType::Personal,
+        'name' => 'Mijn omgeving',
+    ]);
+    $user = User::factory()->create();
+
+    $result = $this->service->buildFor($user, $organisation);
+
+    expect($result['organisation_name'])->toBe('');
 });
 
 test('returns empty string for organisation_address when no address on file', function () {

--- a/tests/Unit/EventForm/Submit/MapFormStateToReferenceDataTest.php
+++ b/tests/Unit/EventForm/Submit/MapFormStateToReferenceDataTest.php
@@ -11,8 +11,11 @@
  * vallen terug op "nu" via de VO).
  */
 
+use App\Enums\OrganisationType;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\MapFormStateToReferenceData;
+use App\Models\Organisation;
+use App\Models\User;
 
 beforeEach(function () {
     $this->map = new MapFormStateToReferenceData;
@@ -76,6 +79,40 @@ test('gebouw-tak: naam_locatie_evenement uit adresVanDeGebouwEn-repeater', funct
     $ref = $this->map->build($state, 'Ingediend', '');
 
     expect($ref->naam_locatie_evenement)->toBe('Sporthal De Geusselt');
+});
+
+test('zakelijke organisatie → organisator is de organisatienaam', function () {
+    $org = new Organisation(['type' => OrganisationType::Business, 'name' => 'Woweb Events']);
+    $user = new User(['first_name' => 'Jan', 'last_name' => 'Jansen', 'name' => 'Jan Jansen']);
+
+    $state = new FormState(
+        values: [
+            'EvenementStart' => '2026-06-14T14:00',
+            'EvenementEind' => '2026-06-14T18:00',
+        ],
+        system: ['authOrganisation' => $org, 'authUser' => $user],
+    );
+
+    $ref = $this->map->build($state, 'Ingediend', '');
+
+    expect($ref->organisator)->toBe('Woweb Events');
+});
+
+test('persoonlijke organisatie → organisator valt terug op de persoonsnaam', function () {
+    $org = new Organisation(['type' => OrganisationType::Personal, 'name' => 'Mijn omgeving']);
+    $user = new User(['first_name' => 'Jan', 'last_name' => 'Jansen', 'name' => 'Jan Jansen']);
+
+    $state = new FormState(
+        values: [
+            'EvenementStart' => '2026-06-14T14:00',
+            'EvenementEind' => '2026-06-14T18:00',
+        ],
+        system: ['authOrganisation' => $org, 'authUser' => $user],
+    );
+
+    $ref = $this->map->build($state, 'Ingediend', '');
+
+    expect($ref->organisator)->toBe('Jan Jansen');
 });
 
 test('registratiedatum wordt gezet op "nu" bij elke build', function () {


### PR DESCRIPTION
Backport of #422 to release/1.0 (cherry picked from commit 7bef91e6).

On personal (non-business) submissions the placeholder "Mijn omgeving" was prefilled as the organisation name. This backport carries the fix to the release/1.0 line for the v1.0.3 patch release:

- Do not prefill "Mijn omgeving" as the organisation name for personal organisations (adds `Organisation::isPersonal()` and guards the prefill in `FormSessionService` / `MapFormStateToReferenceData`).
- `OrganisationFactory` defaults to a business organisation so existing tests keep their expected shape.

All touched files were byte-identical between main and release/1.0, so the cherry-pick applied without conflicts. The two covering tests (`MapFormStateToReferenceDataTest`, `FormSessionServiceTest`) pass on this branch.