### PR TITLE
Serve /__version from a deploy-time version.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,13 +140,13 @@ Next to running migrations, seeders and npm build you need to run additional com
 php artisan passport:keys 
 ```
 
-Write the version file that the `/__version` endpoint serves to the service-register. Run it on every deploy, passing the released tag (the sha and branch are read from git):
+Write the version file that the `/__version` endpoint reads. Run it on deploy, passing the released tag (the sha and branch are read from git):
 
 ```bash
 php artisan register:build-version --tag="$DEPLOY_VERSION"
 ```
 
-This writes `storage/app/version.json`. The endpoint reads it instead of shelling out to git per request. In the staging deploy this is done automatically by the workflow in the `sla-vrzl` repo.
+This writes `storage/app/version.json`, which is served by `/__version`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,14 @@ Next to running migrations, seeders and npm build you need to run additional com
 php artisan passport:keys 
 ```
 
+Write the version file that the `/__version` endpoint serves to the service-register. Run it on every deploy, passing the released tag (the sha and branch are read from git):
+
+```bash
+php artisan register:build-version --tag="$DEPLOY_VERSION"
+```
+
+This writes `storage/app/version.json`. The endpoint reads it instead of shelling out to git per request. In the staging deploy this is done automatically by the workflow in the `sla-vrzl` repo.
+
 ## Contributing
 
 1. Create a feature branch from the `main` branch

--- a/app/Console/Commands/Register/BuildVersionFile.php
+++ b/app/Console/Commands/Register/BuildVersionFile.php
@@ -32,8 +32,8 @@ class BuildVersionFile extends Command
 
     public function handle(): int
     {
-        $tag = $this->stringOption('tag') ?? $this->git(['describe', '--tags', '--always']);
-        $sha = $this->stringOption('sha') ?? $this->git(['rev-parse', 'HEAD']);
+        $tag = $this->stringOption('tag') ?? $this->git('describe --tags --always');
+        $sha = $this->stringOption('sha') ?? $this->git('rev-parse HEAD');
         $branch = $this->stringOption('branch') ?? $this->currentBranch();
         $node = $this->stringOption('node') ?? $this->nodeVersion();
 
@@ -68,10 +68,13 @@ class BuildVersionFile extends Command
         return is_string($value) && trim($value) !== '' ? trim($value) : null;
     }
 
-    /** Run a git subcommand in the app root; null on any failure or empty output. */
-    private function git(array $args): ?string
+    /**
+     * Run a git subcommand in the app root; null on any failure or empty output.
+     * The arguments are static (no user input), so a string command is safe here.
+     */
+    private function git(string $args): ?string
     {
-        $result = Process::path(base_path())->run(array_merge(['git'], $args));
+        $result = Process::path(base_path())->run('git '.$args);
 
         if (! $result->successful()) {
             return null;
@@ -85,7 +88,7 @@ class BuildVersionFile extends Command
     /** The checked out branch, or null when detached (a tag deploy reports HEAD). */
     private function currentBranch(): ?string
     {
-        $branch = $this->git(['rev-parse', '--abbrev-ref', 'HEAD']);
+        $branch = $this->git('rev-parse --abbrev-ref HEAD');
 
         return ($branch === null || $branch === 'HEAD') ? null : $branch;
     }
@@ -93,7 +96,7 @@ class BuildVersionFile extends Command
     /** The Node.js version (major.minor.patch), or null if node is not available. */
     private function nodeVersion(): ?string
     {
-        $result = Process::run(['node', '-v']);
+        $result = Process::run('node -v');
 
         if ($result->successful() && preg_match('/(\d+\.\d+\.\d+)/', $result->output(), $m) === 1) {
             return $m[1];

--- a/app/Console/Commands/Register/BuildVersionFile.php
+++ b/app/Console/Commands/Register/BuildVersionFile.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands\Register;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
+
+/**
+ * Writes the deploy-time version file that the /__version route reads.
+ *
+ * Run this during deployment (see deploy-to-staging.yml in the sla-vrzl repo).
+ * The deploy knows the tag it is releasing, so pass it with --tag; the sha and
+ * branch are read from git when not given. Only deploy-time facts live here; the
+ * route computes php, framework, app_env, composer.lock hash and OS at request
+ * time. Keeping git out of the request path means no exec() on a web request.
+ *
+ * The file is written to config('register.version_file'), which sits outside
+ * public/ so it is never web-served.
+ */
+class BuildVersionFile extends Command
+{
+    protected $signature = 'register:build-version
+        {--tag= : The release tag (defaults to `git describe`)}
+        {--sha= : The commit sha (defaults to `git rev-parse HEAD`)}
+        {--branch= : The branch (defaults to git; a tag deploy is detached, so null)}
+        {--node= : The Node.js version (defaults to `node -v`; omitted if unknown)}';
+
+    protected $description = 'Write the deploy-time version.json for the /__version endpoint';
+
+    public function handle(): int
+    {
+        $tag = $this->stringOption('tag') ?? $this->git(['describe', '--tags', '--always']);
+        $sha = $this->stringOption('sha') ?? $this->git(['rev-parse', 'HEAD']);
+        $branch = $this->stringOption('branch') ?? $this->currentBranch();
+        $node = $this->stringOption('node') ?? $this->nodeVersion();
+
+        $data = [
+            'git_tag' => $tag,
+            'git_sha' => $sha,
+            'branch' => $branch,
+            'deployed_at' => now()->toIso8601String(),
+        ];
+
+        // Only include nodejs when we actually know it (see decision: omitted by
+        // default on the server, but honoured when passed or detectable).
+        if ($node !== null) {
+            $data['nodejs'] = $node;
+        }
+
+        $path = (string) config('register.version_file');
+        File::ensureDirectoryExists(dirname($path));
+        File::put($path, json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES).PHP_EOL);
+
+        $this->info("Wrote {$path}");
+        $this->line('  '.json_encode($data, JSON_UNESCAPED_SLASHES));
+
+        return self::SUCCESS;
+    }
+
+    /** A non-empty trimmed option value, or null. */
+    private function stringOption(string $name): ?string
+    {
+        $value = $this->option($name);
+
+        return is_string($value) && trim($value) !== '' ? trim($value) : null;
+    }
+
+    /** Run a git subcommand in the app root; null on any failure or empty output. */
+    private function git(array $args): ?string
+    {
+        $result = Process::path(base_path())->run(array_merge(['git'], $args));
+
+        if (! $result->successful()) {
+            return null;
+        }
+
+        $output = trim($result->output());
+
+        return $output !== '' ? $output : null;
+    }
+
+    /** The checked out branch, or null when detached (a tag deploy reports HEAD). */
+    private function currentBranch(): ?string
+    {
+        $branch = $this->git(['rev-parse', '--abbrev-ref', 'HEAD']);
+
+        return ($branch === null || $branch === 'HEAD') ? null : $branch;
+    }
+
+    /** The Node.js version (major.minor.patch), or null if node is not available. */
+    private function nodeVersion(): ?string
+    {
+        $result = Process::run(['node', '-v']);
+
+        if ($result->successful() && preg_match('/(\d+\.\d+\.\d+)/', $result->output(), $m) === 1) {
+            return $m[1];
+        }
+
+        return null;
+    }
+}

--- a/config/register.php
+++ b/config/register.php
@@ -23,6 +23,10 @@ return [
     // The /__version route reads the deploy-time facts (git tag/sha/branch) from
     // here instead of shelling out to git per request. It lives outside public/ so
     // it is never web-served, and is regenerated on every deploy.
+    //
+    // There is deliberately no env/APP_VERSION fallback: if a deploy does not run
+    // `register:build-version`, the endpoint simply reports null git fields. So the
+    // deploy step that writes this file must actually run on every deploy.
     'version_file' => storage_path('app/version.json'),
 
     'timestamp_header' => 'X-Register-Timestamp',

--- a/config/register.php
+++ b/config/register.php
@@ -19,10 +19,11 @@ return [
 
     'verify_key' => env('REGISTER_VERIFY_KEY'),
 
-    // Optional version override, used when no VERSION file is written at deploy time
-    // and before falling back to `git describe`. Read via config so it survives
-    // config:cache (env() would return null there).
-    'app_version' => env('APP_VERSION'),
+    // Path to the version file written at deploy time by `register:build-version`.
+    // The /__version route reads the deploy-time facts (git tag/sha/branch) from
+    // here instead of shelling out to git per request. It lives outside public/ so
+    // it is never web-served, and is regenerated on every deploy.
+    'version_file' => storage_path('app/version.json'),
 
     'timestamp_header' => 'X-Register-Timestamp',
     'signature_header' => 'X-Register-Signature',

--- a/routes/web.php
+++ b/routes/web.php
@@ -45,39 +45,30 @@ Route::get('/__version', function (Request $request) {
         abort(404);
     }
 
-    $base = base_path();
+    // Deploy-time facts come from the version file written by
+    // `php artisan register:build-version` on deploy (config('register.version_file')).
+    // No git and no exec on a web request. A missing file (local dev, or before the
+    // first deploy with the command) simply leaves the git fields null.
+    $version = [];
+    $versionFile = (string) config('register.version_file');
+    if (is_file($versionFile)) {
+        $decoded = json_decode((string) file_get_contents($versionFile), true);
+        if (is_array($decoded)) {
+            $version = $decoded;
+        }
+    }
 
+    $base = base_path();
     $composerLockHash = is_file($base.'/composer.lock')
         ? 'sha256:'.hash_file('sha256', $base.'/composer.lock')
         : null;
 
-    // Version info: prefer a deploy written VERSION file, then env, then git. Git is
-    // read at request time (best effort, guarded by function_exists('exec')).
-    $gitTag = null;
-    $gitSha = null;
-    $branch = null;
-    if (is_file($base.'/VERSION')) {
-        $gitTag = trim((string) file_get_contents($base.'/VERSION')) ?: null;
-    }
-    $gitTag = $gitTag ?: (config('register.app_version') ?: null);
-    if (function_exists('exec')) {
-        $gitTag = $gitTag ?: (@exec('git -C '.escapeshellarg($base).' describe --tags --always 2>/dev/null') ?: null);
-        $gitSha = @exec('git -C '.escapeshellarg($base).' rev-parse HEAD 2>/dev/null') ?: null;
-        // A deploy pinned to a tag is detached ("HEAD"), which reports no branch.
-        $branch = @exec('git -C '.escapeshellarg($base).' rev-parse --abbrev-ref HEAD 2>/dev/null') ?: null;
-        if ($branch === 'HEAD') {
-            $branch = null;
-        }
-    }
-
     // Extra runtimes for the register's end of life check, keyed by endoflife.date
-    // slug: the Node toolchain (best effort) and the container OS. Omitted if absent.
+    // slug: the container OS (read without exec) plus the Node toolchain if the
+    // deploy recorded it in the version file.
     $runtimes = [];
-    if (function_exists('exec')) {
-        $node = @exec('node -v 2>/dev/null');
-        if ($node && preg_match('/(\d+\.\d+\.\d+)/', $node, $m)) {
-            $runtimes['nodejs'] = $m[1];
-        }
+    if (! empty($version['nodejs'])) {
+        $runtimes['nodejs'] = $version['nodejs'];
     }
     if (is_readable('/etc/os-release')) {
         $osRelease = parse_ini_file('/etc/os-release') ?: [];
@@ -89,11 +80,11 @@ Route::get('/__version', function (Request $request) {
     return response()->json([
         'php' => PHP_VERSION,
         'framework' => app()->version(),
-        'git_tag' => $gitTag,
-        'git_sha' => $gitSha,
+        'git_tag' => $version['git_tag'] ?? null,
+        'git_sha' => $version['git_sha'] ?? null,
         'composer_lock_hash' => $composerLockHash,
         'app_env' => app()->environment(),
-        'branch' => $branch,
+        'branch' => $version['branch'] ?? null,
         'runtimes' => $runtimes,
         'checked_at' => now()->toIso8601String(),
     ]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -86,6 +86,9 @@ Route::get('/__version', function (Request $request) {
         'app_env' => app()->environment(),
         'branch' => $version['branch'] ?? null,
         'runtimes' => $runtimes,
+        // When the deploy happened (from the version file) versus when this response
+        // was built. For the register, deployed_at is usually the more useful clock.
+        'deployed_at' => $version['deployed_at'] ?? null,
         'checked_at' => now()->toIso8601String(),
     ]);
 });

--- a/tests/Unit/VersionEndpointTest.php
+++ b/tests/Unit/VersionEndpointTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use Illuminate\Support\Facades\File;
+
 // The /__version route reads no database. It lives in the Unit suite so it runs
 // without RefreshDatabase (which the Feature suite applies globally): no migrations
 // and no database connection are needed to verify the signature gate and payload.
@@ -11,6 +13,16 @@ function registerKeypair(): string
     config(['register.verify_key' => base64_encode(sodium_crypto_sign_publickey($pair))]);
 
     return sodium_crypto_sign_secretkey($pair);
+}
+
+/** Point the route at a temp version file with the given contents. */
+function useVersionFile(array $data): string
+{
+    $path = tempnam(sys_get_temp_dir(), 'ver').'.json';
+    File::put($path, json_encode($data));
+    config(['register.version_file' => $path]);
+
+    return $path;
 }
 
 /** Build the signed request headers the register would send for /__version. */
@@ -39,6 +51,57 @@ it('returns the version metadata for a valid signed request', function () {
             'php', 'framework', 'git_tag', 'git_sha', 'composer_lock_hash',
             'app_env', 'branch', 'runtimes', 'checked_at',
         ]);
+});
+
+it('exposes the deploy-time version from the version file', function () {
+    $secret = registerKeypair();
+    useVersionFile([
+        'git_tag' => 'v1.2.3',
+        'git_sha' => 'abc123def456',
+        'branch' => null,
+        'nodejs' => '22.1.0',
+        'deployed_at' => '2026-07-08T10:00:00+00:00',
+    ]);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJson([
+            'git_tag' => 'v1.2.3',
+            'git_sha' => 'abc123def456',
+            'branch' => null,
+        ])
+        ->assertJsonPath('runtimes.nodejs', '22.1.0');
+});
+
+it('returns null git fields when the version file is missing', function () {
+    $secret = registerKeypair();
+    config(['register.version_file' => sys_get_temp_dir().'/no-such-version-'.uniqid().'.json']);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJson(['git_tag' => null, 'git_sha' => null, 'branch' => null]);
+});
+
+it('register:build-version writes the version file from the given options', function () {
+    $path = tempnam(sys_get_temp_dir(), 'ver').'.json';
+    config(['register.version_file' => $path]);
+
+    $this->artisan('register:build-version', [
+        '--tag' => 'v9.9.9',
+        '--sha' => 'deadbeef',
+        '--branch' => 'main',
+        '--node' => '20.11.0',
+    ])->assertSuccessful();
+
+    $data = json_decode(File::get($path), true);
+
+    expect($data['git_tag'])->toBe('v9.9.9')
+        ->and($data['git_sha'])->toBe('deadbeef')
+        ->and($data['branch'])->toBe('main')
+        ->and($data['nodejs'])->toBe('20.11.0')
+        ->and($data)->toHaveKey('deployed_at');
+
+    @unlink($path);
 });
 
 it('404s without a signature so the route is invisible', function () {

--- a/tests/Unit/VersionEndpointTest.php
+++ b/tests/Unit/VersionEndpointTest.php
@@ -1,10 +1,23 @@
 <?php
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Process;
 
 // The /__version route reads no database. It lives in the Unit suite so it runs
 // without RefreshDatabase (which the Feature suite applies globally): no migrations
 // and no database connection are needed to verify the signature gate and payload.
+
+afterEach(function () {
+    foreach (glob(sys_get_temp_dir().'/register-version-test-*.json') ?: [] as $file) {
+        @unlink($file);
+    }
+});
+
+/** A unique temp path for a version file, cleaned up in afterEach(). */
+function tempVersionPath(): string
+{
+    return sys_get_temp_dir().'/register-version-test-'.uniqid().'.json';
+}
 
 /** Set the register public key in config and return the matching secret key. */
 function registerKeypair(): string
@@ -18,7 +31,7 @@ function registerKeypair(): string
 /** Point the route at a temp version file with the given contents. */
 function useVersionFile(array $data): string
 {
-    $path = tempnam(sys_get_temp_dir(), 'ver').'.json';
+    $path = tempVersionPath();
     File::put($path, json_encode($data));
     config(['register.version_file' => $path]);
 
@@ -69,6 +82,7 @@ it('exposes the deploy-time version from the version file', function () {
             'git_tag' => 'v1.2.3',
             'git_sha' => 'abc123def456',
             'branch' => null,
+            'deployed_at' => '2026-07-08T10:00:00+00:00',
         ])
         ->assertJsonPath('runtimes.nodejs', '22.1.0');
 });
@@ -83,7 +97,7 @@ it('returns null git fields when the version file is missing', function () {
 });
 
 it('register:build-version writes the version file from the given options', function () {
-    $path = tempnam(sys_get_temp_dir(), 'ver').'.json';
+    $path = tempVersionPath();
     config(['register.version_file' => $path]);
 
     $this->artisan('register:build-version', [
@@ -100,8 +114,41 @@ it('register:build-version writes the version file from the given options', func
         ->and($data['branch'])->toBe('main')
         ->and($data['nodejs'])->toBe('20.11.0')
         ->and($data)->toHaveKey('deployed_at');
+});
 
-    @unlink($path);
+it('omits nodejs from the version file when node is unavailable', function () {
+    // No --node option, and `node -v` fails, so the field is left out entirely.
+    Process::fake(['node*' => Process::result(errorOutput: 'not found', exitCode: 127)]);
+
+    $path = tempVersionPath();
+    config(['register.version_file' => $path]);
+
+    $this->artisan('register:build-version', [
+        '--tag' => 'v9.9.9',
+        '--sha' => 'deadbeef',
+        '--branch' => 'main',
+    ])->assertSuccessful();
+
+    expect(json_decode(File::get($path), true))->not->toHaveKey('nodejs');
+});
+
+it('falls back to git for the sha when the option is omitted', function () {
+    // --sha omitted, so the command reads it from git; --branch/--node given so
+    // only the sha lookup runs.
+    Process::fake([
+        'git rev-parse HEAD' => Process::result(output: "cafebabe1234\n"),
+        'node*' => Process::result(exitCode: 127),
+    ]);
+
+    $path = tempVersionPath();
+    config(['register.version_file' => $path]);
+
+    $this->artisan('register:build-version', [
+        '--tag' => 'v9.9.9',
+        '--branch' => 'main',
+    ])->assertSuccessful();
+
+    expect(json_decode(File::get($path), true)['git_sha'])->toBe('cafebabe1234');
 });
 
 it('404s without a signature so the route is invisible', function () {


### PR DESCRIPTION
Follow-up to #435. That PR read the running version by shelling out to git on every request. This switches to a `version.json` written once at deploy, which removes `exec()` from the request path entirely.

Why:

- `exec()` may be disabled by `disable_functions` on a hardened PHP-FPM.
- It runs on every probe and is slow.
- It is empty when the deployed artifact has no `.git`.

How:

- Only the deploy-time facts (`git_tag`, `git_sha`, `branch`) go in the file. The route computes `php`, `framework`, `app_env`, the composer.lock hash, the OS (via `/etc/os-release`, no exec) and `checked_at` live. The JSON keys are unchanged, so nothing changes on the register side.
- A new `register:build-version` command writes `storage/app/version.json` (outside `public/`, so never web-served, and already gitignored). It takes `--tag`/`--sha`/`--branch`/`--node` and falls back to git and node via the `Process` facade (deploy is a CLI context, so exec there is fine).
- The route reads the file. A missing file leaves the git fields `null` (local dev, or before the first deploy that runs the command).

The staging deploy in the `sla-vrzl` repo will call `php artisan register:build-version --tag="$DEPLOY_VERSION"` (separate PR there). For a tag deploy `branch` is `null` because it is a detached checkout, which is correct.

Tests cover the version file being read, the missing-file fallback, and the command writing the file. The signature-gate tests stay. pest, pint and phpstan are green.
