### PR TITLE
Add OneGround connection flag for RX Mission-specific behaviour

### DIFF
--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZaaktypeMappings/MunicipalityZaaktypeMappingResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZaaktypeMappings/MunicipalityZaaktypeMappingResource.php
@@ -306,14 +306,16 @@ class MunicipalityZaaktypeMappingResource extends Resource
     /**
      * Whether an organiser may withdraw a zaak on this municipality's connection.
      * When disabled the eind-statustype and ingetrokken-resultaattype do not need
-     * to be configured, so those two flow selects are hidden. The global "main"
-     * connection (no row) always allows withdrawal.
+     * to be configured, so those two flow selects are hidden. Always disabled for
+     * a OneGround connection; otherwise it follows the connection's own toggle.
+     * The global "main" connection (no row) always allows withdrawal.
      */
     private static function organiserWithdrawalAllowed(): bool
     {
         $tenant = Filament::getTenant();
         $connection = $tenant instanceof Municipality ? $tenant->zgwConnection : null;
 
-        return $connection === null || $connection->allow_organiser_withdrawal;
+        return $connection === null
+            || (! $connection->is_oneground && $connection->allow_organiser_withdrawal);
     }
 }

--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -21,6 +21,7 @@ use Filament\Resources\Resource;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
@@ -145,10 +146,23 @@ class MunicipalityZgwConnectionResource extends Resource
                         Toggle::make('suppress_notifications')
                             ->label(__('municipality/resources/zgw_connection.fields.suppress_notifications.label'))
                             ->helperText(__('municipality/resources/zgw_connection.fields.suppress_notifications.helper')),
+                        Toggle::make('is_oneground')
+                            ->label(__('municipality/resources/zgw_connection.fields.is_oneground.label'))
+                            ->helperText(__('municipality/resources/zgw_connection.fields.is_oneground.helper'))
+                            ->live()
+                            // A OneGround backend cannot complete the withdrawal
+                            // flow, so turning this on forces withdrawal off.
+                            ->afterStateUpdated(function (Set $set, ?bool $state): void {
+                                if ($state) {
+                                    $set('allow_organiser_withdrawal', false);
+                                }
+                            }),
                         Toggle::make('allow_organiser_withdrawal')
                             ->label(__('municipality/resources/zgw_connection.fields.allow_organiser_withdrawal.label'))
                             ->helperText(__('municipality/resources/zgw_connection.fields.allow_organiser_withdrawal.helper'))
-                            ->default(true),
+                            ->default(true)
+                            // Withdrawal is never possible on a OneGround backend.
+                            ->disabled(fn (Get $get): bool => (bool) $get('is_oneground')),
                     ]),
 
                 Section::make(__('municipality/resources/zgw_connection.sections.vertrouwelijkheid.heading'))

--- a/app/Jobs/Zaak/AddGlobaleLocatieZGW.php
+++ b/app/Jobs/Zaak/AddGlobaleLocatieZGW.php
@@ -6,6 +6,7 @@ namespace App\Jobs\Zaak;
 
 use App\Models\Zaak;
 use App\Services\Zgw\ZaakReadModel;
+use App\Services\Zgw\ZgwConnectionConfig;
 use App\Services\Zgw\ZgwResource;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -45,14 +46,15 @@ class AddGlobaleLocatieZGW implements ShouldQueue
             'objectType' => 'overige',
             'objectTypeOverige' => 'GlobaleLocatie',
             'relatieomschrijving' => 'Globale locatie van het evenement',
-            // For objectType "overige" the ZGW ObjectOverige identification lives
-            // under objectIdentificatie.overigeData (a free-form object); a bare
-            // `naam` is rejected with a 400 (objectIdentificatie.overigeData is
-            // required).
+            // For objectType "overige" the identification lives under
+            // objectIdentificatie.overigeData, which is required. The ZGW
+            // standard types it as a free-form object, so OpenZaak wants
+            // `{naam: ...}`; OneGround (RX Mission) deviates and stores/expects
+            // overigeData as a bare string, so send just the names there.
             'objectIdentificatie' => [
-                'overigeData' => [
-                    'naam' => $locaties,
-                ],
+                'overigeData' => ZgwConnectionConfig::isOneGround($connectionName)
+                    ? $locaties
+                    : ['naam' => $locaties],
             ],
         ]);
     }

--- a/app/Models/MunicipalityZgwConnection.php
+++ b/app/Models/MunicipalityZgwConnection.php
@@ -49,6 +49,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property bool $show_organisatievragen_tab
  * @property bool $suppress_notifications
  * @property bool $allow_organiser_withdrawal
+ * @property bool $is_oneground
  * @property Carbon|null $last_verified_at
  * @property Carbon|null $activated_at
  */
@@ -84,6 +85,7 @@ class MunicipalityZgwConnection extends Model
         'show_organisatievragen_tab',
         'suppress_notifications',
         'allow_organiser_withdrawal',
+        'is_oneground',
         'last_verified_at',
         'activated_at',
     ];
@@ -129,6 +131,7 @@ class MunicipalityZgwConnection extends Model
             'show_organisatievragen_tab' => 'boolean',
             'suppress_notifications' => 'boolean',
             'allow_organiser_withdrawal' => 'boolean',
+            'is_oneground' => 'boolean',
             'last_verified_at' => 'datetime',
             'activated_at' => 'datetime',
         ];
@@ -244,6 +247,7 @@ class MunicipalityZgwConnection extends Model
             'bronorganisatie_rsin' => $this->bronorganisatie_rsin,
             'vertrouwelijkheid_map' => $this->vertrouwelijkheid_map,
             'allow_organiser_withdrawal' => $this->allow_organiser_withdrawal,
+            'is_oneground' => $this->is_oneground,
         ];
 
         foreach ($overrides as $key => $value) {

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -139,16 +139,18 @@ class Zaak extends Model implements Eventable
 
     /**
      * Whether an organiser may withdraw ("intrekken") this zaak from inside
-     * Eventloket. Disabled per connection for a OneGround (RX Mission) backend,
-     * where setting the eind-status archives the zaak immediately and is
-     * rejected unless all related documents are already 'gearchiveerd'. The
-     * global "main" connection (no row) always allows withdrawal.
+     * Eventloket. Always disabled for a OneGround (RX Mission) connection, where
+     * setting the eind-status archives the zaak immediately and is rejected
+     * unless all related documents are already 'gearchiveerd'; otherwise it
+     * follows the connection's own toggle. The global "main" connection (no row)
+     * always allows withdrawal.
      */
     public function organiserCanWithdraw(): bool
     {
         $connection = $this->zgwConnectionModel();
 
-        return $connection === null || $connection->allow_organiser_withdrawal;
+        return $connection === null
+            || (! $connection->is_oneground && $connection->allow_organiser_withdrawal);
     }
 
     /**

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -118,13 +118,29 @@ class ZgwConnectionConfig
     /**
      * Whether an organiser may withdraw a zaak on this connection. Defaults to
      * true, so the global "main" connection (and any connection without the key)
-     * keeps withdrawal enabled. Disabled per connection for a OneGround (RX
-     * Mission) backend, where the eind-status archives the zaak immediately.
+     * keeps withdrawal enabled. Always disabled for a OneGround (RX Mission)
+     * backend, where setting the eind-status archives the zaak immediately (and
+     * OneGround rejects that unless all documents are already 'gearchiveerd').
      */
     public static function allowsOrganiserWithdrawal(string $connectionName): bool
     {
+        if (self::isOneGround($connectionName)) {
+            return false;
+        }
+
         $value = config("zgw.connections.{$connectionName}.allow_organiser_withdrawal");
 
         return $value === null ? true : (bool) $value;
+    }
+
+    /**
+     * Whether this connection talks to a OneGround (RX Mission) backend, which
+     * deviates from the ZGW standard on a few points (bare-string overigeData,
+     * eager archiving on eind-status). Defaults to false so the global "main"
+     * connection and any OpenZaak connection keep standard behaviour.
+     */
+    public static function isOneGround(string $connectionName): bool
+    {
+        return (bool) config("zgw.connections.{$connectionName}.is_oneground");
     }
 }

--- a/database/factories/MunicipalityZgwConnectionFactory.php
+++ b/database/factories/MunicipalityZgwConnectionFactory.php
@@ -46,6 +46,7 @@ class MunicipalityZgwConnectionFactory extends Factory
             'show_organisatievragen_tab' => true,
             'suppress_notifications' => false,
             'allow_organiser_withdrawal' => true,
+            'is_oneground' => false,
         ];
     }
 

--- a/database/migrations/2026_07_09_110410_add_is_oneground_to_municipality_zgw_connections.php
+++ b/database/migrations/2026_07_09_110410_add_is_oneground_to_municipality_zgw_connections.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Marks a connection as a OneGround (RX Mission) backend. OneGround deviates
+     * from the ZGW standard on a few points, so this flag drives OneGround-
+     * specific behaviour:
+     *  - the GlobaleLocatie zaakobject is sent with `overigeData` as a bare
+     *    string instead of the standard free-form object, and
+     *  - organiser withdrawal ("intrekken") is blocked, because setting the
+     *    eind-status archives the zaak immediately and OneGround rejects that
+     *    unless all related documents are already 'gearchiveerd'.
+     *
+     * Defaults to false so existing (OpenZaak) connections keep standard
+     * behaviour.
+     */
+    public function up(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table) {
+            $table->boolean('is_oneground')->default(false)->after('allow_organiser_withdrawal');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('municipality_zgw_connections', function (Blueprint $table) {
+            $table->dropColumn('is_oneground');
+        });
+    }
+};

--- a/docs/functionaliteiten/oneground-aandachtspunten.md
+++ b/docs/functionaliteiten/oneground-aandachtspunten.md
@@ -18,7 +18,7 @@ Dit wijkt af van de standaard Open Zaak, waar de eindstatus de archiefstatus nie
 
 ### Wat je moet instellen
 
-Zet op de ZGW-koppeling de instelling **Intrekken door organisator toestaan** uit. De intrekken-actie verdwijnt dan uit Eventloket, zodat een organisator niet in de mislukkende flow terechtkomt. In de bijbehorende zaaktype-koppeling zijn het eind-statustype en het ingetrokken-resultaattype dan ook niet meer nodig en die velden verdwijnen.
+Zet op de ZGW-koppeling de instelling **Dit is een OneGround koppeling** aan. Daarmee wordt het intrekken door een organisator automatisch geblokkeerd: de instelling "Intrekken door organisator toestaan" wordt uitgezet en vergrendeld, en de intrekken-actie verdwijnt uit Eventloket, zodat een organisator niet in de mislukkende flow terechtkomt. In de bijbehorende zaaktype-koppeling zijn het eind-statustype en het ingetrokken-resultaattype dan ook niet meer nodig en die velden verdwijnen.
 
 ### De fundamentele oplossing
 
@@ -67,7 +67,7 @@ OneGround geeft in de relatie tussen zaaktype en informatieobjecttype de omschri
 Deze twee punten raken elke koppeling, maar kwamen naar boven bij de OneGround-integratie.
 
 - **Adres.** Een BAG-adres wordt als zaakobject van type "adres" geregistreerd. Het veld `objectIdentificatie.identificatie` (de BAG nummeraanduiding-id) is verplicht. Zonder dat veld volgt een 400. Eventloket haalt die id op bij de Locatieserver en stuurt de straatnaam mee als openbare-ruimtenaam.
-- **GlobaleLocatie.** De evenementlocaties worden als zaakobject van type "overige" (objectTypeOverige "GlobaleLocatie") meegestuurd. Voor dat type moet de identificatie onder `objectIdentificatie.overigeData` staan (een vrij-vorm object). Een kale `objectIdentificatie.naam` wordt door zowel Open Zaak als OneGround geweigerd met een 400.
+- **GlobaleLocatie.** De evenementlocaties worden als zaakobject van type "overige" (objectTypeOverige "GlobaleLocatie") meegestuurd. Voor dat type moet de identificatie onder `objectIdentificatie.overigeData` staan; een kale `objectIdentificatie.naam` wordt door zowel Open Zaak als OneGround geweigerd met een 400. Hier speelt wel een verschil in vorm. De ZGW-standaard typeert `overigeData` als een vrij-vorm object, dus voor Open Zaak stuurt Eventloket `{"naam": "..."}`. OneGround wijkt af en verwacht (en toont) `overigeData` als een kale tekst. Staat het vinkje **Dit is een OneGround koppeling** aan, dan stuurt Eventloket de locatienamen daarom als kale tekst in plaats van als object.
 
 ---
 
@@ -93,7 +93,7 @@ De volledige uitleg staat in de sectie over doorkomsten in [ZGW-koppelingbeheer]
 
 ## Samenvatting van in te stellen punten voor OneGround
 
-- Zet **Intrekken door organisator toestaan** uit (punt 1).
+- Zet **Dit is een OneGround koppeling** aan. Dat blokkeert meteen het intrekken door de organisator (punt 1) en zorgt dat de globale locatie in het OneGround-formaat wordt meegestuurd (punt 6).
 - Overweeg **Status niet wijzigbaar door behandelaar** als de gemeente de status volledig in OneGround beheert (punt 8).
 - Controleer bij het inrichten van de zaaktype-koppeling dat de eigenschappen en documenttypen goed laden (punt 5). Dat is meteen de bevestiging dat de juiste zaaktype-versie is gekozen.
 - Voer altijd een proefaanvraag uit en controleer dat de zaak, de eigenschappen, de aanvrager, de documenten en de beginstatus correct in OneGround terechtkomen (zie de eindcontrole in [ZGW-koppelingbeheer](zgw-koppelingbeheer.md)).

--- a/docs/functionaliteiten/zgw-koppelingbeheer.md
+++ b/docs/functionaliteiten/zgw-koppelingbeheer.md
@@ -219,13 +219,14 @@ Datums in zaakeigenschappen hebben geen instelling nodig. Eventloket leest per e
 
 In deze sectie bepaal je hoe Eventloket zaken van deze koppeling toont en notificeert. De standaardwaarden houden het volledige gedrag aan; pas ze alleen aan als de werkwijze van de gemeente daarom vraagt.
 
+- **Dit is een OneGround koppeling.** Standaard uit. Zet dit aan wanneer de koppeling naar een OneGround (Rx.Mission) zaaksysteem wijst. OneGround wijkt op een paar punten af van de ZGW-standaard en dit vinkje schakelt het bijbehorende gedrag in. De globale locatie van een evenement wordt dan als kale tekst meegestuurd in plaats van als object, en het intrekken door een organisator wordt geblokkeerd (zie de instelling hieronder). Zet dit vinkje aan als eerste stap bij het inrichten van een OneGround-koppeling. De volledige lijst van OneGround-bijzonderheden staat in [OneGround aandachtspunten](oneground-aandachtspunten.md).
 - **Status niet wijzigbaar door behandelaar.** Als dit aan staat, kan de behandelaar de status van een zaak niet vanuit Eventloket wijzigen en de zaak niet afronden. De status wordt dan volledig in het zaaksysteem beheerd. Of de organisator een aanvraag kan intrekken regel je apart met de instelling "Intrekken door organisator toestaan".
 - **Tabblad besluiten tonen.** Toont het tabblad Besluiten bij een zaak.
 - **Tabblad bestanden tonen.** Toont het tabblad Bestanden. Bij uitschakelen ziet de organisator nog wel de eigen aanvraag-bestanden, maar kunnen er geen nieuwe bestanden bijkomen.
 - **Tabblad adviesvragen tonen.** Toont het tabblad Adviesvragen bij een zaak.
 - **Tabblad organisatievragen tonen.** Toont het tabblad Organisatievragen bij een zaak.
 - **Geen notificaties versturen.** Onderdrukt alle notificaties voor zaken van deze koppeling. Alleen de ontvangstbevestiging bij het indienen wordt dan nog verstuurd.
-- **Intrekken door organisator toestaan.** Standaard aan. Als dit aan staat, kan een organisator een ingediende aanvraag intrekken via Eventloket. Zet dit uit voor een OneGround (Rx.Mission) koppeling: daar mislukt het intrekken, omdat het zetten van de eindstatus de zaak direct archiveert en dat pas is toegestaan als alle documenten gearchiveerd zijn. Staat deze instelling uit, dan hoef je in de zaaktype-koppeling ook geen eind-statustype en ingetrokken-resultaattype in te stellen; die velden verdwijnen daar dan (zie [sectie 7](#7-zaaktype-koppelingen-instellen)).
+- **Intrekken door organisator toestaan.** Standaard aan. Als dit aan staat, kan een organisator een ingediende aanvraag intrekken via Eventloket. Bij een OneGround (Rx.Mission) koppeling mislukt het intrekken, omdat het zetten van de eindstatus de zaak direct archiveert en dat pas is toegestaan als alle documenten gearchiveerd zijn. Zodra het vinkje "Dit is een OneGround koppeling" aan staat, wordt deze instelling daarom automatisch uitgezet en vergrendeld, en is intrekken niet mogelijk. Staat intrekken uit, dan hoef je in de zaaktype-koppeling ook geen eind-statustype en ingetrokken-resultaattype in te stellen; die velden verdwijnen daar dan (zie [sectie 7](#7-zaaktype-koppelingen-instellen)).
 
 ### 5.6 Vertrouwelijkheid
 

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -93,7 +93,11 @@ return [
         ],
         'allow_organiser_withdrawal' => [
             'label' => 'Intrekken door organisator toestaan',
-            'helper' => 'Sta toe dat een organisator een aanvraag intrekt via Eventloket. Zet dit uit voor een OneGround (RX Mission) koppeling: daar mislukt het intrekken omdat het zetten van de eindstatus de zaak meteen archiveert, wat pas mag als alle documenten gearchiveerd zijn.',
+            'helper' => 'Sta toe dat een organisator een aanvraag intrekt via Eventloket. Niet beschikbaar voor een OneGround (RX Mission) koppeling: daar mislukt het intrekken omdat het zetten van de eindstatus de zaak meteen archiveert, wat pas mag als alle documenten gearchiveerd zijn.',
+        ],
+        'is_oneground' => [
+            'label' => 'Dit is een OneGround koppeling',
+            'helper' => 'Zet dit aan voor een OneGround (RX Mission) koppeling. OneGround wijkt op punten af van de ZGW-standaard: de globale locatie wordt als kale tekst meegestuurd in plaats van als object, en intrekken door de organisator wordt geblokkeerd.',
         ],
     ],
 

--- a/tests/Feature/Filament/Municipality/Resources/MunicipalityZaaktypeMappingResourceTest.php
+++ b/tests/Feature/Filament/Municipality/Resources/MunicipalityZaaktypeMappingResourceTest.php
@@ -170,6 +170,43 @@ it('hides the eind-statustype and ingetrokken-resultaattype when withdrawal is d
         ->assertFormFieldIsVisible('initiator_roltype');
 });
 
+it('hides the eind-statustype and ingetrokken-resultaattype on a OneGround connection', function () {
+    $base = 'https://gemeente.example.com';
+
+    // Withdrawal is left enabled; a OneGround connection blocks it regardless.
+    MunicipalityZgwConnection::factory()->active()->create([
+        'municipality_id' => $this->municipality->id,
+        'allow_organiser_withdrawal' => true,
+        'is_oneground' => true,
+    ]);
+
+    Http::fake([
+        "{$base}/catalogi/api/v1/zaaktypen*" => Http::response(ZgwHttpFake::envelope([
+            ['identificatie' => 'EVT-1', 'omschrijving' => 'Evenementenvergunning', 'url' => "{$base}/catalogi/api/v1/zaaktypen/1"],
+        ])),
+        "{$base}/catalogi/api/v1/statustypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Afgehandeld', 'volgnummer' => 1, 'isEindstatus' => true],
+        ])),
+        "{$base}/catalogi/api/v1/roltypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Aanvrager', 'omschrijvingGeneriek' => 'initiator'],
+        ])),
+        "{$base}/catalogi/api/v1/resultaattypen*" => Http::response(ZgwHttpFake::envelope([
+            ['omschrijving' => 'Afgebroken', 'omschrijvingGeneriek' => 'Afgebroken'],
+        ])),
+        "{$base}/catalogi/api/v1/*" => Http::response(ZgwHttpFake::envelope([])),
+    ]);
+
+    livewire(CreateMunicipalityZaaktypeMapping::class)
+        ->fillForm([
+            'role' => ZaaktypeRole::Vergunning->value,
+            'zaaktype_identificatie' => 'EVT-1',
+        ])
+        ->assertFormFieldIsHidden('eind_statustype')
+        ->assertFormFieldIsHidden('ingetrokken_resultaattype')
+        ->assertFormFieldIsVisible('initial_statustype')
+        ->assertFormFieldIsVisible('initiator_roltype');
+});
+
 it('rejects a second mapping for the same role', function () {
     fakeCatalogus();
 

--- a/tests/Feature/Jobs/Zaak/AddGlobaleLocatieZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/AddGlobaleLocatieZGWTest.php
@@ -51,6 +51,24 @@ test('registers a GlobaleLocatie zaakobject with the composed location names', f
     });
 });
 
+test('sends overigeData as a bare string on a OneGround connection', function () {
+    // OneGround (RX Mission) deviates from the ZGW standard: it stores/expects
+    // overigeData as a plain string, not the standard free-form object. The zaak
+    // here resolves to the "main" connection, so we flag main as OneGround.
+    config(['zgw.connections.main.is_oneground' => true]);
+
+    $zaak = zaakWithLocaties('Marktplein, Hoofdstraat');
+
+    dispatch(new AddGlobaleLocatieZGW($zaak));
+
+    Http::assertSent(function ($request) {
+        return str_contains($request->url(), '/zaken/api/v1/zaakobjecten')
+            && $request->method() === 'POST'
+            && data_get($request->data(), 'objectTypeOverige') === 'GlobaleLocatie'
+            && data_get($request->data(), 'objectIdentificatie.overigeData') === 'Marktplein, Hoofdstraat';
+    });
+});
+
 test('does nothing when there are no location names', function () {
     $zaak = zaakWithLocaties(null);
 

--- a/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
+++ b/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
@@ -83,3 +83,13 @@ test('allow_organiser_withdrawal disabled blocks organiser withdrawal', function
 
     expect($zaak->organiserCanWithdraw())->toBeFalse();
 });
+
+test('a OneGround connection always blocks organiser withdrawal', function () {
+    // Even with withdrawal explicitly enabled, OneGround cannot complete it.
+    $zaak = zaakForConnection([
+        'allow_organiser_withdrawal' => true,
+        'is_oneground' => true,
+    ]);
+
+    expect($zaak->organiserCanWithdraw())->toBeFalse();
+});

--- a/tests/Unit/Zgw/ZgwConnectionConfigTest.php
+++ b/tests/Unit/Zgw/ZgwConnectionConfigTest.php
@@ -95,3 +95,28 @@ it('uses the connection system upload default when configured', function () {
 
     expect(ZgwConnectionConfig::systemUploadDefault('gemeente_9'))->toBe('vertrouwelijk');
 });
+
+it('reports a connection as OneGround only when the flag is set', function () {
+    Config::set('zgw.connections.gemeente_9.is_oneground', true);
+    Config::set('zgw.connections.main.is_oneground', false);
+
+    expect(ZgwConnectionConfig::isOneGround('gemeente_9'))->toBeTrue()
+        ->and(ZgwConnectionConfig::isOneGround('main'))->toBeFalse()
+        // An unset flag defaults to false.
+        ->and(ZgwConnectionConfig::isOneGround('gemeente_42'))->toBeFalse();
+});
+
+it('allows organiser withdrawal by default and honours the toggle', function () {
+    Config::set('zgw.connections.gemeente_9.allow_organiser_withdrawal', false);
+
+    expect(ZgwConnectionConfig::allowsOrganiserWithdrawal('main'))->toBeTrue()
+        ->and(ZgwConnectionConfig::allowsOrganiserWithdrawal('gemeente_9'))->toBeFalse();
+});
+
+it('always blocks organiser withdrawal on a OneGround connection', function () {
+    // Even with withdrawal explicitly enabled, OneGround blocks it.
+    Config::set('zgw.connections.gemeente_9.allow_organiser_withdrawal', true);
+    Config::set('zgw.connections.gemeente_9.is_oneground', true);
+
+    expect(ZgwConnectionConfig::allowsOrganiserWithdrawal('gemeente_9'))->toBeFalse();
+});


### PR DESCRIPTION
## What

Adds an **is_oneground** flag to a municipality's ZGW connection and branches the OneGround (RX Mission) specific behaviour on it. OneGround deviates from the ZGW standard on a couple of points, and until now those were handled ad hoc (or not at all).

## Why

Two concrete OneGround deviations were observed against a OneGround (RX Mission) test connection:

1. **GlobaleLocatie zaakobject.** The ZGW standard types `objectIdentificatie.overigeData` as a free-form object, so OpenZaak expects `{"naam": "..."}`. OneGround stores and expects `overigeData` as a bare string. Sending the object works for storage but does not display cleanly on the OneGround side.
2. **Organiser withdrawal (intrekken).** On OneGround, setting the eind-status archives the zaak immediately, which is rejected unless all related documents are already `gearchiveerd`, so the withdrawal flow cannot complete. This was previously worked around by manually turning off "Intrekken door organisator toestaan".

## Changes

- New boolean column `is_oneground` on `municipality_zgw_connections` (migration, model, factory, `buildConfig`).
- Connection form: a "Dit is een OneGround koppeling" toggle. Turning it on disables and clears the withdrawal toggle.
- `AddGlobaleLocatieZGW` sends `overigeData` as a bare string on a OneGround connection, and as the standard `{naam: ...}` object otherwise.
- Organiser withdrawal is always blocked on a OneGround connection, in `Zaak::organiserCanWithdraw()`, `ZgwConnectionConfig::allowsOrganiserWithdrawal()`, and the zaaktype mapping resource (which hides the eind-statustype and ingetrokken-resultaattype selects).
- Documentation updated: `docs/functionaliteiten/zgw-koppelingbeheer.md` (new setting in section 5.5) and `docs/functionaliteiten/oneground-aandachtspunten.md` (withdrawal and GlobaleLocatie sections plus the summary).

## Notes

- The bare-string `overigeData` form was implemented per the OneGround expectation but has not been verified live against a running OneGround backend (that would create a real zaakobject). Worth a check on a test zaak after deploy.
- The relevant OneGround connection needs the new toggle switched on to activate the behaviour.
