### PR TITLE
Fix location address in samenvatting and debounce the PDOK lookup

### DIFF
--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -64,23 +64,23 @@ final class AddressNL
                     ->label('Postcode')
                     ->required()
                     ->maxLength(7)
-                    ->live(onBlur: true)
+                    ->live(debounce: '750ms')
                     ->afterStateUpdated(self::lookupCallback($key)),
                 TextInput::make("{$key}.huisnummer")
                     ->label('Huisnummer')
                     ->required()
                     ->numeric()
-                    ->live(onBlur: true)
+                    ->live(debounce: '750ms')
                     ->afterStateUpdated(self::lookupCallback($key)),
                 TextInput::make("{$key}.huisletter")
                     ->label('Huisletter')
                     ->maxLength(1)
-                    ->live(onBlur: true)
+                    ->live(debounce: '750ms')
                     ->afterStateUpdated(self::lookupCallback($key)),
                 TextInput::make("{$key}.huisnummertoevoeging")
                     ->label('Toevoeging')
                     ->maxLength(10)
-                    ->live(onBlur: true)
+                    ->live(debounce: '750ms')
                     ->afterStateUpdated(self::lookupCallback($key)),
                 // Straatnaam and woonplaatsnaam are auto-filled by the PDOK
                 // lookup, but that call can fail to fire; making them required
@@ -97,8 +97,20 @@ final class AddressNL
     }
 
     /**
-     * Bouwt de after-state-updated closure die op blur van postcode of
-     * huisnummer de straat/plaats uit PDOK haalt en in de form-state zet.
+     * Whether the PDOK lookup has enough input to be worthwhile: it needs both
+     * a postcode and a huisnummer. Huisletter and huisnummertoevoeging only
+     * refine an already-valid postcode + huisnummer combination.
+     */
+    public static function hasLookupInput(mixed $postcode, mixed $huisnummer): bool
+    {
+        return is_string($postcode) && $postcode !== ''
+            && $huisnummer !== null && $huisnummer !== '';
+    }
+
+    /**
+     * Bouwt de after-state-updated closure die, na een debounce op één van de
+     * adresvelden, de straat/plaats uit PDOK haalt en in de form-state zet.
+     * Doet niets zolang postcode en huisnummer niet allebei gevuld zijn.
      */
     private static function lookupCallback(string $key): \Closure
     {
@@ -106,15 +118,12 @@ final class AddressNL
             $postcode = $get("{$key}.postcode");
             $huisnummer = $get("{$key}.huisnummer");
 
-            if (! is_string($postcode) || $postcode === '') {
-                return;
-            }
-            if ($huisnummer === null || $huisnummer === '') {
+            if (! self::hasLookupInput($postcode, $huisnummer)) {
                 return;
             }
 
             $bag = app(LocatieserverService::class)->getBagObjectByPostcodeHuisnummer(
-                $postcode,
+                (string) $postcode,
                 (string) $huisnummer,
                 is_string($get("{$key}.huisletter")) ? $get("{$key}.huisletter") : null,
                 is_string($get("{$key}.huisnummertoevoeging")) ? $get("{$key}.huisnummertoevoeging") : null,

--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -43,6 +43,8 @@ final class AddressNL
     public const REQUIRED_SUBFIELDS = [
         'postcode',
         'huisnummer',
+        'straatnaam',
+        'woonplaatsnaam',
     ];
 
     /** @return list<string> */
@@ -80,11 +82,16 @@ final class AddressNL
                     ->maxLength(10)
                     ->live(onBlur: true)
                     ->afterStateUpdated(self::lookupCallback($key)),
+                // Straatnaam and woonplaatsnaam are auto-filled by the PDOK
+                // lookup, but that call can fail to fire; making them required
+                // forces a fallback where the organiser fills them in manually.
                 TextInput::make("{$key}.straatnaam")
                     ->label('Straatnaam')
+                    ->required()
                     ->maxLength(255),
                 TextInput::make("{$key}.woonplaatsnaam")
                     ->label('Plaats')
+                    ->required()
                     ->maxLength(255),
             ]);
     }

--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -77,6 +77,18 @@ final class SubmissionReport
     ];
 
     /**
+     * Repeaters whose rows are event locations. Their rows are labelled
+     * "<repeater> — locatie N" instead of the generic "— rij N".
+     *
+     * @var list<string>
+     */
+    private const LOCATION_REPEATER_KEYS = [
+        'adresVanDeGebouwEn',
+        'locatieSOpKaart',
+        'routesOpKaart',
+    ];
+
+    /**
      * @return list<array{label: string, value: string, sub?: list<array{label: string, value: string}>, table?: array{header: list<string>, rows: list<list<string>>}}>
      */
     private function extractEntries(Step $step, FormState $state): array
@@ -119,16 +131,26 @@ final class SubmissionReport
                     return;
                 }
                 $repeaterLabel = $this->renderLabel($component, $stubLivewire);
-                foreach (array_values($rows) as $rowIndex => $rowData) {
+                // Location repeaters read as "locatie N", other repeaters as
+                // the generic "rij N".
+                $rowNoun = in_array($key, self::LOCATION_REPEATER_KEYS, true) ? 'locatie' : 'rij';
+                // Iterate rows by their actual key: a UUID in the live wizard
+                // state (samenvatting), a numeric index in the dehydrated submit
+                // snapshot (PDF). Reading by a forced numeric index only resolved
+                // the snapshot, so the live samenvatting showed no repeater rows.
+                // A separate counter drives the displayed row number.
+                $rowNumber = 0;
+                foreach ($rows as $rowKey => $rowData) {
                     if (! is_array($rowData)) {
                         continue;
                     }
-                    $subEntries = $this->extractRowEntries($component, $state, "{$fullKey}.{$rowIndex}", $stubLivewire);
+                    $subEntries = $this->extractRowEntries($component, $state, "{$fullKey}.{$rowKey}", $stubLivewire);
                     if ($subEntries === []) {
                         continue;
                     }
+                    $rowNumber++;
                     $entries[] = [
-                        'label' => sprintf('%s — rij %d', $repeaterLabel, $rowIndex + 1),
+                        'label' => sprintf('%s — %s %d', $repeaterLabel, $rowNoun, $rowNumber),
                         'value' => '',
                         'sub' => $subEntries,
                     ];

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -29,6 +29,8 @@ use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
 use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Wizard\Step;
 
 test('lege state → geen secties (alle stappen worden overgeslagen)', function () {
@@ -255,6 +257,67 @@ test('Repeater-rijen worden uitgeklapt naar sub-entries in plaats van samengevat
     $subValues = collect($repeaterRow['sub'])->pluck('value')->all();
     expect($subValues)->toContain('Buurtcentrum De Hoek')
         ->and($subValues)->toContain('6411CD');
+});
+
+test('repeater rows keyed by uuid (live samenvatting state) resolve their sub-fields', function () {
+    // The samenvatting builds sections from the live FormState, where repeater
+    // rows are keyed by a uuid, not by a numeric index. Reading rows by a forced
+    // numeric index left the samenvatting empty while the PDF (numeric snapshot)
+    // worked. Rows must resolve by their actual key.
+    $state = new FormState(values: [
+        'adresVanDeGebouwEn' => [
+            '3d2b7a1e-5c44-4b8a-9f21-0a1b2c3d4e5f' => [
+                'naamVanDeLocatieGebouw' => 'Buurtcentrum De Hoek',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6411CD',
+                    'huisnummer' => '1',
+                    'straatnaam' => 'Geleenstraat',
+                    'woonplaatsnaam' => 'Heerlen',
+                ],
+            ],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build(
+        $state,
+        [LocatieVanHetEvenement2Step::make()],
+    );
+
+    $row = collect($sections[0]['entries'])->first(fn ($e) => ! empty($e['sub']));
+    expect($row)->not->toBeNull()
+        // A location repeater is labelled "locatie N", not "rij N".
+        ->and($row['label'])->toContain('locatie 1')
+        ->and($row['label'])->not->toContain('rij');
+
+    $subValues = collect($row['sub'])->pluck('value')->all();
+    expect($subValues)->toContain('Buurtcentrum De Hoek')
+        ->and($subValues)->toContain('Geleenstraat')
+        ->and($subValues)->toContain('Heerlen');
+});
+
+test('a non-location repeater keeps the generic "rij" label', function () {
+    // The "locatie N" wording only applies to the event-location repeaters; a
+    // generic repeater (e.g. tents) keeps "rij N".
+    $state = new FormState(values: [
+        'tenten' => [
+            'a-uuid-key' => ['aantalTenten' => '3'],
+        ],
+    ]);
+
+    $step = Step::make('Test')->schema([
+        Repeater::make('tenten')
+            ->label('Tenten')
+            ->schema([
+                TextInput::make('aantalTenten')->label('Aantal tenten'),
+            ]),
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [$step]);
+
+    $row = collect($sections[0]['entries'])->first(fn ($e) => ! empty($e['sub']));
+    expect($row)->not->toBeNull()
+        ->and($row['label'])->toContain('rij 1')
+        ->and($row['label'])->not->toContain('locatie');
 });
 
 test('Map-state met geojson levert een SVG mee in de entry', function () {

--- a/tests/Playwright/doorloop-hele-formulier.spec.mjs
+++ b/tests/Playwright/doorloop-hele-formulier.spec.mjs
@@ -76,12 +76,13 @@ test('walkthrough: doorloop het hele formulier', async ({ page }) => {
         // Heerlen-postcode: gemeente Heerlen (GM0917) heeft zaaktypes in de
         // DB; Maastricht zou ook werken zodra z'n zaaktypes gesynct zijn.
         await vulEindigendOp(page, 'input', '.adresVanHetGebouwWaarUwEvenementPlaatsvindt1.postcode', '6411CD');
-        // Tab weg om blur te triggeren → PDOK-lookup straatnaam/plaats
         await page.keyboard.press('Tab');
         await page.waitForTimeout(500);
         await vulEindigendOp(page, 'input', '.adresVanHetGebouwWaarUwEvenementPlaatsvindt1.huisnummer', '1');
         await page.keyboard.press('Tab');
-        // Wacht op PDOK-lookup én LocationServerCheckService
+        // De adresvelden gebruiken een debounce (750ms); daarna vult de
+        // PDOK-lookup straatnaam/plaats (nu verplichte velden). Ruim wachten
+        // dekt de debounce + PDOK-lookup + LocationServerCheckService.
         await page.waitForTimeout(4000);
 
         await page.screenshot({ path: 'test-results/walkthrough/stap-03.png', fullPage: true });

--- a/tests/Unit/EventForm/Components/AddressNLTest.php
+++ b/tests/Unit/EventForm/Components/AddressNLTest.php
@@ -39,4 +39,14 @@ describe('AddressNL', function () {
         expect(AddressNL::REQUIRED_SUBFIELDS)->not->toContain('huisletter')
             ->and(AddressNL::REQUIRED_SUBFIELDS)->not->toContain('huisnummertoevoeging');
     });
+
+    test('hasLookupInput only allows a lookup when both postcode and huisnummer are filled', function () {
+        expect(AddressNL::hasLookupInput('6411CD', '12'))->toBeTrue()
+            // A numeric huisnummer (from the numeric input) is accepted.
+            ->and(AddressNL::hasLookupInput('6411CD', 12))->toBeTrue()
+            ->and(AddressNL::hasLookupInput('6411CD', ''))->toBeFalse()
+            ->and(AddressNL::hasLookupInput('6411CD', null))->toBeFalse()
+            ->and(AddressNL::hasLookupInput('', '12'))->toBeFalse()
+            ->and(AddressNL::hasLookupInput(null, '12'))->toBeFalse();
+    });
 });

--- a/tests/Unit/EventForm/Components/AddressNLTest.php
+++ b/tests/Unit/EventForm/Components/AddressNLTest.php
@@ -29,8 +29,10 @@ describe('AddressNL', function () {
             ->and($keys)->toContain('adresVanHetGebouw.woonplaatsnaam');
     });
 
-    test('postcode and huisnummer are the required subfields', function () {
-        expect(AddressNL::REQUIRED_SUBFIELDS)->toBe(['postcode', 'huisnummer']);
+    test('postcode, huisnummer, straatnaam and woonplaatsnaam are the required subfields', function () {
+        // straatnaam and woonplaatsnaam are required so a failed PDOK auto-fill
+        // can be recovered by filling them in manually.
+        expect(AddressNL::REQUIRED_SUBFIELDS)->toBe(['postcode', 'huisnummer', 'straatnaam', 'woonplaatsnaam']);
     });
 
     test('huisletter is not in the required subfields list', function () {


### PR DESCRIPTION
## What

Fixes the event-location address handling in the summary and the submission report, and makes the PDOK address lookup more forgiving. Addresses a reported bug where the street name was missing from the generated submission PDF for an address location.

## Why and how

### 1. Address missing from the samenvatting (bug)

`SubmissionReport` iterated repeater rows by a forced numeric index, which only matches the dehydrated submit snapshot used to render the PDF. The live samenvatting builds from the current form state, where repeater rows are keyed by a uuid, so no location row resolved there and the address was missing from the summary while it showed in the PDF. Rows are now iterated by their actual key, so both the live samenvatting and the submitted PDF render the repeater sub-fields.

### 2. Row label wording

Event-location repeaters (address, map locations, routes) are labelled "locatie N" instead of the generic "rij N". All other repeaters (tents, stages, contacts, and so on) keep "rij N".

### 3. Street and city required, with a manual fallback

The PDOK auto-fill sometimes does not fire, leaving straatnaam and woonplaatsnaam empty (the original reported symptom). Both fields are now required, so a failed auto-fill can be recovered by filling them in manually.

### 4. Debounced PDOK lookup

The address fields fired the lookup on blur, so a re-render (the gemeente lookup triggered by the postcode sync) could blur the huisnummer field mid-typing and fire the lookup with an incomplete house number. Postcode, huisnummer, huisletter and huisnummertoevoeging now use a 750ms debounce, so the lookup runs after typing pauses, decoupled from focus changes. The precondition is extracted into `AddressNL::hasLookupInput()` so PDOK is only called when both a postcode and a huisnummer are present.

## Notes

- This addresses the reported missing-street-name bug. As agreed, the related issue is closed after deploy, not from here.
- The Playwright walkthrough fills the address and relies on its existing 4000ms wait, which covers the new debounce and the PDOK lookup. Worth confirming on the next Playwright run.
