### PR TITLE
Make optional besluit fields nullable in the Besluit value object

### DIFF
--- a/app/ValueObjects/ZGW/Besluit.php
+++ b/app/ValueObjects/ZGW/Besluit.php
@@ -18,9 +18,13 @@ final readonly class Besluit implements Arrayable
         public string $besluittype,
         public string $zaak,
         public string $datum,
-        public string $toelichting,
         public string $ingangsdatum,
-        public string $verzenddatum,
+        // toelichting and verzenddatum are optional in the ZGW Besluiten API; a
+        // OneGround (RX Mission) besluit omits them from the response, so they
+        // must be nullable to avoid a TypeError when the value object is built
+        // (e.g. while rendering the besluiten on the zaak page).
+        public ?string $toelichting = null,
+        public ?string $verzenddatum = null,
         public ?string $vervaldatum = null,
         public ?BesluitTypeData $besluittypeObject = null,
         public ?Collection $besluitDocumenten = null,

--- a/tests/Unit/ValueObjects/ZGW/BesluitTest.php
+++ b/tests/Unit/ValueObjects/ZGW/BesluitTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ValueObjects\ZGW\Besluit;
+
+test('builds from a besluit response that omits the optional toelichting and verzenddatum', function () {
+    // A OneGround (RX Mission) besluit omits the optional toelichting,
+    // verzenddatum and vervaldatum fields from its response. Building the value
+    // object from such a response must not throw (regression: a missing
+    // toelichting previously produced a TypeError while rendering the besluiten
+    // on the zaak page).
+    $response = [
+        'url' => 'https://besluiten.example/api/v1/besluiten/abc',
+        'identificatie' => 'B0001',
+        'besluittype' => 'https://catalogi.example/api/v1/besluittypen/1',
+        'zaak' => 'https://zaken.example/api/v1/zaken/xyz',
+        'datum' => '2026-07-07',
+        'ingangsdatum' => '2026-07-07',
+    ];
+
+    $besluit = new Besluit(...$response);
+
+    expect($besluit->toelichting)->toBeNull()
+        ->and($besluit->verzenddatum)->toBeNull()
+        ->and($besluit->vervaldatum)->toBeNull()
+        ->and($besluit->identificatie)->toBe('B0001')
+        ->and($besluit->ingangsdatum)->toBe('2026-07-07');
+});
+
+test('accepts an explicit null toelichting and verzenddatum', function () {
+    // The zaak-page render path passes the fields through by name, as null.
+    $besluit = new Besluit(
+        url: 'https://besluiten.example/api/v1/besluiten/abc',
+        identificatie: 'B1',
+        besluittype: 'https://catalogi.example/api/v1/besluittypen/1',
+        zaak: 'https://zaken.example/api/v1/zaken/xyz',
+        datum: '2026-07-07',
+        ingangsdatum: '2026-07-07',
+        toelichting: null,
+        verzenddatum: null,
+    );
+
+    expect($besluit->toelichting)->toBeNull()
+        ->and($besluit->verzenddatum)->toBeNull();
+});
+
+test('still accepts a besluit with all fields populated', function () {
+    $besluit = new Besluit(
+        url: 'https://besluiten.example/api/v1/besluiten/abc',
+        identificatie: 'B1',
+        besluittype: 'https://catalogi.example/api/v1/besluittypen/1',
+        zaak: 'https://zaken.example/api/v1/zaken/xyz',
+        datum: '2026-07-07',
+        ingangsdatum: '2026-07-08',
+        toelichting: 'Vergunning verleend',
+        verzenddatum: '2026-07-09',
+        vervaldatum: '2026-12-31',
+    );
+
+    expect($besluit->toelichting)->toBe('Vergunning verleend')
+        ->and($besluit->verzenddatum)->toBe('2026-07-09')
+        ->and($besluit->vervaldatum)->toBe('2026-12-31')
+        ->and($besluit->toArray()['toelichting'])->toBe('Vergunning verleend');
+});


### PR DESCRIPTION
## What

Makes the optional besluit fields nullable in the `Besluit` value object, fixing a TypeError that crashed the municipality zaak page for zaken with a OneGround (Rx.Mission) besluit.

## Why

The `Besluit` value object typed `toelichting`, `ingangsdatum` and `verzenddatum` as non-nullable strings. A OneGround besluit omits `toelichting` and `verzenddatum` from its response (both are optional in the ZGW Besluiten API), so building the value object while rendering the besluiten on `/municipality/{tenant}/zaken/{record}` threw:

```
App\ValueObjects\ZGW\Besluit::__construct(): Argument #6 ($toelichting) must be of type string, null given
```

Confirmed against a real OneGround besluit response: it carries `datum`, `ingangsdatum`, `identificatie` and `url`, but not `toelichting`, `verzenddatum` or `vervaldatum`.

## How

`toelichting` and `verzenddatum` become `?string` with a null default and move after the required `ingangsdatum` to avoid an optional-before-required parameter. `ingangsdatum` stays required per the ZGW standard. All three construction sites build the value object from an associative array via named-argument unpacking, so the reorder is safe. Existing consumers already guard on an empty `verzenddatum`.

Added unit tests: building from a response that omits the optional fields, an explicit null, and a fully populated besluit. The existing besluit-visibility tests still pass.
