### PR TITLE
Restrict aanvraagformulier and ownerless document versions to platform admin

### DIFF
--- a/app/Support/Documents/DocumentVersionAuthorizer.php
+++ b/app/Support/Documents/DocumentVersionAuthorizer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Support\Documents;
 
 use App\Enums\Role;
+use App\Jobs\Submit\UploadSubmissionPdfToZGW;
 use App\Models\User;
 use App\Models\Users\AdvisorUser;
 use App\Models\Users\MunicipalityUser;
@@ -24,26 +25,57 @@ use Spatie\Activitylog\Models\Activity;
  * elders bepaald (ZaakPolicy::uploadDocument); deze checker voegt daar de
  * per-document groepsregel aan toe.
  *
- * Wanneer de maker niet te bepalen is, wordt het toevoegen conservatief
- * geblokkeerd om cross-group bewerkingen te voorkomen. Gemeentegebruikers
- * vormen hierop een uitzondering: zij mogen dan wél een nieuwe versie
- * toevoegen.
+ * Twee documenten hebben geen groeps-eigenaar en mogen daarom alleen door de
+ * platform-admin worden vervangen: de systeem-aanvraagformulier-PDF, en elk
+ * document waarvan de maker niet uit de activity log te bepalen is.
  */
 class DocumentVersionAuthorizer
 {
+    /**
+     * The fixed filename of the system-generated aanvraagformulier PDF, set by
+     * {@see UploadSubmissionPdfToZGW}.
+     */
+    private const AANVRAAGFORMULIER_FILENAME = 'aanvraagformulier.pdf';
+
     public static function canAddVersion(User $user, Zaak $zaak, string $documentUuid): bool
     {
+        // The platform admin may always add a version, including for the system
+        // aanvraagformulier and documents without a resolvable owner.
         if ($user->role === Role::Admin) {
             return true;
         }
 
+        // The aanvraagformulier PDF is a system document without a user-owner;
+        // only the platform admin (handled above) may replace it.
+        if (self::isSystemAanvraagformulier($documentUuid)) {
+            return false;
+        }
+
         $creator = self::resolveCreator($documentUuid);
 
+        // Without a resolvable creator there is no owner, so only the platform
+        // admin (handled above) may add a version.
         if ($creator === null) {
-            return $user instanceof MunicipalityUser;
+            return false;
         }
 
         return self::inSameGroup($user, $creator);
+    }
+
+    /**
+     * Whether the document is the system-generated aanvraagformulier PDF.
+     * Identified via the immutable 'created' activity-log entry (its filename is
+     * the fixed aanvraagformulier filename) rather than the current, mutable
+     * bestandsnaam or titel, which change once a new version is uploaded.
+     */
+    private static function isSystemAanvraagformulier(string $documentUuid): bool
+    {
+        return Activity::query()
+            ->where('log_name', 'document')
+            ->where('event', 'created')
+            ->where('properties->document_uuid', $documentUuid)
+            ->where('properties->filename', self::AANVRAAGFORMULIER_FILENAME)
+            ->exists();
     }
 
     private static function resolveCreator(string $documentUuid): ?User

--- a/tests/Feature/Support/DocumentVersionAuthorizerTest.php
+++ b/tests/Feature/Support/DocumentVersionAuthorizerTest.php
@@ -56,10 +56,38 @@ test('advisor is blocked when the original creator is unknown', function () {
     expect(DocumentVersionAuthorizer::canAddVersion($advisor, $this->zaak, 'doc-uuid'))->toBeFalse();
 });
 
-test('municipality user can add a new version when the original creator is unknown', function () {
+test('a document with an unknown creator can only be versioned by a platform admin', function () {
+    // Previously a municipality user could version an ownerless document. The
+    // ownership rule now restricts this to the platform admin: without a
+    // resolvable creator there is no owner.
     $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $admin = User::factory()->create(['role' => Role::Admin]);
 
-    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'doc-uuid'))->toBeTrue();
+    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'doc-uuid'))->toBeFalse()
+        ->and(DocumentVersionAuthorizer::canAddVersion($admin, $this->zaak, 'doc-uuid'))->toBeTrue();
+});
+
+test('only a platform admin can add a version of the system aanvraagformulier', function () {
+    // The aanvraagformulier PDF is logged as created by the organiser, but it is
+    // a system document: no role except the platform admin may replace it.
+    $organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($organiser, ['role' => OrganisationRole::Admin->value]);
+
+    activity('document')
+        ->event('created')
+        ->causedBy($organiser)
+        ->performedOn($this->zaak)
+        ->withProperties(['document_uuid' => 'aanvraag-uuid', 'filename' => 'aanvraagformulier.pdf'])
+        ->log('created');
+
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $advisor = User::factory()->create(['role' => Role::Advisor]);
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    expect(DocumentVersionAuthorizer::canAddVersion($organiser, $this->zaak, 'aanvraag-uuid'))->toBeFalse()
+        ->and(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'aanvraag-uuid'))->toBeFalse()
+        ->and(DocumentVersionAuthorizer::canAddVersion($advisor, $this->zaak, 'aanvraag-uuid'))->toBeFalse()
+        ->and(DocumentVersionAuthorizer::canAddVersion($admin, $this->zaak, 'aanvraag-uuid'))->toBeTrue();
 });
 
 test('organiser can add a new version of a document created by an organiser', function () {


### PR DESCRIPTION
## What

Tightens the document-version ownership rule so the two documents without a real owner can only be replaced by a platform admin.

## Why

The "Nieuwe versie" button was shown to roles that should not be able to replace a document:

1. The system-generated aanvraagformulier PDF is logged as created by the organiser, so the ownership rule treated the organiser as its owner and let them upload a new version. It is a system document with no user-owner.
2. A document without a resolvable creator (no logged author) fell back to allowing municipality users, so they saw the button on documents they did not create.

## How

`DocumentVersionAuthorizer::canAddVersion` now:

- returns true for a platform admin (unchanged);
- blocks the aanvraagformulier for every other role, identified via the immutable created activity-log entry (its filename is the fixed aanvraagformulier filename) rather than the mutable current bestandsnaam or titel, which change once a new version is uploaded;
- blocks documents with an unresolvable creator for every non-admin role (previously municipality users were allowed);
- otherwise keeps the same-group ownership rule.

The "Nieuwe versie" action already hides itself via `visible(canAddVersion)`, so no change to the action or table is needed.

Tests cover each role for the aanvraagformulier and the unknown-creator case, alongside the existing same-group tests.
