### PR TITLE
Always release the document lock when a new version patch fails

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/NewDocumentVersionAction.php
@@ -10,7 +10,9 @@ use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Throwable;
 use Woweb\Zgw\Facades\Zgw;
 
 class NewDocumentVersionAction
@@ -64,19 +66,36 @@ class NewDocumentVersionAction
         $formaat = DocumentUploadType::determineFormaat($data['file'], $data['file_name'] ?? null);
         $bestandsnaam = DocumentUploadType::ensureFileNameHasExtension($data['file_name'] ?? '', $formaat);
         $lockString = $connection->documenten()->enkelvoudiginformatieobjecten()->lock($documentUuid);
-        $connection->documenten()->enkelvoudiginformatieobjecten()->patch($documentUuid,
-            [
-                'inhoud' => base64_encode(Storage::get($data['file'])),
-                'titel' => $data['titel'],
-                'auteur' => auth()->user()->name,
-                'bestandsnaam' => $bestandsnaam,
-                'bestandsomvang' => Storage::size($data['file']),
-                'formaat' => $formaat,
-                'lock' => $lockString,
-                'indicatieGebruiksrecht' => false,
-            ]
-        );
-        $connection->documenten()->enkelvoudiginformatieobjecten()->unlock($documentUuid, $lockString);
+
+        // Always release the lock, even when the patch fails. Without this a
+        // failed patch left the document locked, and every subsequent "Nieuwe
+        // versie" attempt then failed on the lock with a 400 "document is al
+        // gelocked" — surfacing as an error for every user on that document.
+        try {
+            $connection->documenten()->enkelvoudiginformatieobjecten()->patch($documentUuid,
+                [
+                    'inhoud' => base64_encode(Storage::get($data['file'])),
+                    'titel' => $data['titel'],
+                    'auteur' => auth()->user()->name,
+                    'bestandsnaam' => $bestandsnaam,
+                    'bestandsomvang' => Storage::size($data['file']),
+                    'formaat' => $formaat,
+                    'lock' => $lockString,
+                    'indicatieGebruiksrecht' => false,
+                ]
+            );
+        } finally {
+            try {
+                $connection->documenten()->enkelvoudiginformatieobjecten()->unlock($documentUuid, $lockString);
+            } catch (Throwable $unlockError) {
+                // Never let a failing unlock mask the original patch error.
+                Log::warning('Releasing the document lock after a new-version patch did not succeed', [
+                    'zaak_id' => $zaak->id,
+                    'document_uuid' => $documentUuid,
+                    'error' => $unlockError->getMessage(),
+                ]);
+            }
+        }
 
         Storage::delete($data['file']);
 

--- a/tests/Feature/NewDocumentVersionUnlockTest.php
+++ b/tests/Feature/NewDocumentVersionUnlockTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Actions\NewDocumentVersionAction;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\Models\Activity;
+use Tests\Fakes\ZgwHttpFake;
+use Woweb\Zgw\Exceptions\ValidationException;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    $this->reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->reviewer, ['role' => OrganisationRole::Admin]);
+    $this->zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+});
+
+test('a failing patch still releases the document lock and rethrows', function () {
+    // Regression (EVENTLOKET-1H): without a guaranteed unlock a failed patch left
+    // the document locked, so every later "Nieuwe versie" attempt failed on the
+    // lock with a 400 "document is al gelocked" — an error for every user on that
+    // document. This test keeps a generic 200 stub out of the setup so the patch
+    // genuinely returns a 400.
+    Storage::fake('local');
+    Storage::put('documents/new-version.pdf', '%PDF-1.4 updated pdf content');
+
+    // Lock succeeds, the patch fails with a ZGW validation error, unlock succeeds.
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/*/lock' => Http::response(['lock' => 'lock-string-123'], 200),
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/*/unlock' => Http::response(null, 204),
+        ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten/*' => Http::response([
+            'invalidParams' => [['name' => 'inhoud', 'code' => 'invalid', 'reason' => 'rejected']],
+        ], 400),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    $this->actingAs($this->reviewer);
+
+    expect(fn () => NewDocumentVersionAction::createNewDocumentVersion('existing-doc-uuid', [
+        'titel' => 'Bijgewerkt document',
+        'file' => 'documents/new-version.pdf',
+        'file_name' => 'new-version.pdf',
+    ], $zaak))->toThrow(ValidationException::class);
+
+    // The lock was released despite the failed patch, so the next attempt can lock again.
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/enkelvoudiginformatieobjecten/existing-doc-uuid/unlock')
+        && $request->method() === 'POST');
+
+    // A failed version does not record an update activity.
+    expect(Activity::where('log_name', 'document')->where('event', 'updated')->count())->toBe(0);
+});


### PR DESCRIPTION
## What

Guarantees that the document lock is always released when adding a new document version, even if the update fails partway through.

## Why

"Nieuwe versie" locks the document, patches the new content, then unlocks it. The unlock was not guaranteed: when the patch failed, the unlock never ran and the document stayed locked. From then on every attempt to add a version to that document failed on the lock step with a `400` validation error ("document is al gelocked"), so the feature appeared broken for every user on that document, not just the one whose patch failed.

This showed up in production as a recurring validation error on the lock call, all on the same stuck document.

## Change

The patch is now wrapped in `try/finally` so the unlock always runs, even when the patch throws. A failure of the unlock itself is caught and logged, so it can never mask the original patch error, which still propagates. On a failed patch the document is therefore left unlocked and the user sees a clear failure, and a retry can proceed.

## Tests

- New regression test: a failing patch still sends the unlock and rethrows, and records no update activity.
- The existing new-version tests (happy path, cache invalidation) stay green.

pint and phpstan clean.

## Notes

- This prevents documents from getting stuck locked going forward. A document that is already stuck in a locked state from before this change is not auto-recovered here (the ZGW client has no force-unlock); such a document needs a one-time manual unlock on the ZGW side.
