### PR TITLE
Lighten the form hint info icons so they read as hints, not selections

### DIFF
--- a/resources/css/filament/organiser/theme.css
+++ b/resources/css/filament/organiser/theme.css
@@ -244,3 +244,19 @@
 .leaflet-pm-action.action-finishMode, .leaflet-pm-action.action-finish {
     display: none!important;
 }
+
+/*
+ * Info-icoontjes bij de hint-teksten onder een veld (belowContent) staan
+ * standaard op primary-500 — vrijwel dezelfde blauwtint als een aangevinkt
+ * keuzebolletje (primary-600). Op tabbladen met veel keuzevragen (bijv. de
+ * risico-scan) leest dat verwarrend. Een tint lichter maakt duidelijk dat
+ * het icoon een hint is, geen selectie. Gescoped op de belowContent-
+ * container zodat andere schema-icoontjes hun kleur houden.
+ */
+.fi-sc.fi-inline .fi-sc-icon.fi-color {
+    color: var(--color-400);
+}
+
+:is(.dark .fi-sc.fi-inline .fi-sc-icon.fi-color) {
+    color: var(--color-300);
+}


### PR DESCRIPTION
## What

Lightens the information icons next to the hint texts under form fields, so they no longer read as a selected option.

## Why

The `belowContent` hint icons (the small information circles under many questions) defaulted to `primary-500`, almost the same blue as a selected radio option (`primary-600`). On tabs with many choice questions, such as the risico-scan, the hint icon looked like a checked answer, which is confusing.

## Change

A single scoped rule in the organiser theme lowers the hint icon to one shade lighter: `primary-400` in light mode, `primary-300` in dark mode. It is scoped to the `belowContent` inline container (`.fi-sc.fi-inline .fi-sc-icon.fi-color`), so other schema icons keep their colour, and it is done in the theme rather than hardcoded per field.

## Visual

Before, the hint icon (primary-500) sits right next to the selected radio (primary-600) at nearly the same blue. After, the hint icon (primary-400) is clearly lighter and reads as a hint. A before/after comparison image is attached to the internal handover for Niels.

## Note

Pure CSS/theme change, no PHP touched. The theme is rebuilt at deploy (`npm run build`); the built asset is not committed.
