### PR TITLE
Fix address BAG lookup exactness and document-version authorization

### DIFF
--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -6,6 +6,7 @@ namespace App\EventForm\Components;
 
 use App\Services\LocatieserverService;
 use Filament\Forms\Components\TextInput;
+use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
@@ -122,25 +123,51 @@ final class AddressNL
                 return;
             }
 
-            $bag = app(LocatieserverService::class)->getBagObjectByPostcodeHuisnummer(
+            $service = app(LocatieserverService::class);
+            $huisletter = is_string($get("{$key}.huisletter")) ? $get("{$key}.huisletter") : null;
+            $huisnummertoevoeging = is_string($get("{$key}.huisnummertoevoeging")) ? $get("{$key}.huisnummertoevoeging") : null;
+
+            $bag = $service->getBagObjectByPostcodeHuisnummer(
                 (string) $postcode,
                 (string) $huisnummer,
-                is_string($get("{$key}.huisletter")) ? $get("{$key}.huisletter") : null,
-                is_string($get("{$key}.huisnummertoevoeging")) ? $get("{$key}.huisnummertoevoeging") : null,
+                $huisletter,
+                $huisnummertoevoeging,
             );
 
-            if ($bag === null) {
+            if ($bag !== null) {
+                $set("{$key}.straatnaam", $bag->straatnaam);
+                $set("{$key}.woonplaatsnaam", $bag->woonplaatsnaam);
+                if ($bag->huisletter !== null && $bag->huisletter !== '') {
+                    $set("{$key}.huisletter", $bag->huisletter);
+                }
+                if ($bag->huisnummertoevoeging !== null && $bag->huisnummertoevoeging !== '') {
+                    $set("{$key}.huisnummertoevoeging", $bag->huisnummertoevoeging);
+                }
+
                 return;
             }
 
-            $set("{$key}.straatnaam", $bag->straatnaam);
-            $set("{$key}.woonplaatsnaam", $bag->woonplaatsnaam);
-            if ($bag->huisletter !== null && $bag->huisletter !== '') {
-                $set("{$key}.huisletter", $bag->huisletter);
+            // No exact match. When only the huisletter/toevoeging refinement
+            // failed but the plain postcode + house number does resolve, the
+            // street/city are still valid, so leave them untouched. Only when
+            // the base combination itself does not exist do we clear the
+            // previously auto-filled street/city (so no stale address lingers)
+            // and tell the organiser they can fill it in manually.
+            if (($huisletter !== null && $huisletter !== '') || ($huisnummertoevoeging !== null && $huisnummertoevoeging !== '')) {
+                $baseBag = $service->getBagObjectByPostcodeHuisnummer((string) $postcode, (string) $huisnummer);
+                if ($baseBag !== null) {
+                    return;
+                }
             }
-            if ($bag->huisnummertoevoeging !== null && $bag->huisnummertoevoeging !== '') {
-                $set("{$key}.huisnummertoevoeging", $bag->huisnummertoevoeging);
-            }
+
+            $set("{$key}.straatnaam", null);
+            $set("{$key}.woonplaatsnaam", null);
+
+            Notification::make()
+                ->title('Geen adres gevonden')
+                ->body('Er is geen adres gevonden voor deze postcode en huisnummer. Controleer de invoer of vul straat en plaats zelf in.')
+                ->warning()
+                ->send();
         };
     }
 }

--- a/app/Livewire/Thread/MessageForm.php
+++ b/app/Livewire/Thread/MessageForm.php
@@ -11,6 +11,7 @@ use App\Filament\Shared\Resources\Zaken\Actions\NewDocumentVersionAction;
 use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Models\Message;
 use App\Models\Thread;
+use App\Support\Documents\DocumentVersionAuthorizer;
 use App\ValueObjects\MessageDocument;
 use App\ValueObjects\ZGW\Informatieobject;
 use Filament\Actions\Action;
@@ -165,7 +166,15 @@ class MessageForm extends Component implements HasActions, HasSchemas
 
                 Select::make('existing_document')
                     ->label('Selecteer bestaand document')
-                    ->options(fn () => $zaak->documenten->pluck('titel', 'uuid')->toArray())
+                    // Only offer documents the current user is allowed to add a
+                    // new version to (own group; the aanvraagformulier and
+                    // ownerless documents are admin-only). This mirrors the
+                    // visibility rule on the document table's "Nieuwe versie"
+                    // action; the action below enforces it server-side too.
+                    ->options(fn () => $zaak->documenten
+                        ->filter(fn (Informatieobject $document): bool => DocumentVersionAuthorizer::canAddVersion(auth()->user(), $zaak, $document->uuid))
+                        ->pluck('titel', 'uuid')
+                        ->toArray())
                     ->required()
                     ->visible(fn (Get $get): bool => $get('type') === 'version')
                     ->live()
@@ -195,6 +204,14 @@ class MessageForm extends Component implements HasActions, HasSchemas
                         ->success()
                         ->send();
                 } elseif ($data['type'] === 'version') {
+                    // Defence in depth: the options list is already filtered, but
+                    // a crafted request could still target a document the user is
+                    // not allowed to version.
+                    abort_unless(
+                        DocumentVersionAuthorizer::canAddVersion(auth()->user(), $this->thread->zaak, $data['existing_document']),
+                        403,
+                    );
+
                     NewDocumentVersionAction::createNewDocumentVersion($data['existing_document'], $data, $this->thread->zaak);
 
                     $this->thread->zaak->refresh(); // Need to refresh to re-initialize documenten

--- a/app/Services/LocatieserverService.php
+++ b/app/Services/LocatieserverService.php
@@ -66,7 +66,15 @@ class LocatieserverService
 
         if ($httpResponse->successful()) {
             $data = $httpResponse->json();
-            $item = Arr::first($data['response']['docs'] ?? [], function ($item) use ($huisletter, $huisnummertoevoeging) {
+            $item = Arr::first($data['response']['docs'] ?? [], function ($item) use ($postcode, $huisnummer, $huisletter, $huisnummertoevoeging) {
+                // PDOK's free-text search is fuzzy: a non-existent house number
+                // still returns the closest matching address. Guard against that
+                // by requiring the returned postcode and house number to match
+                // the input exactly, otherwise a wrong address gets auto-filled.
+                if (! $this->matchesPostcode($item, $postcode) || ! $this->matchesHuisnummer($item, $huisnummer)) {
+                    return false;
+                }
+
                 if ($huisletter && $huisnummertoevoeging) {
                     if (isset($item['huisletter']) && $item['huisletter'] === $huisletter && isset($item['huisnummertoevoeging']) && $item['huisnummertoevoeging'] === $huisnummertoevoeging) {
                         return true;
@@ -100,6 +108,42 @@ class LocatieserverService
         }
 
         return null;
+    }
+
+    /**
+     * Whether the PDOK document's postcode equals the requested postcode,
+     * ignoring casing and internal spacing ("6361 bz" matches "6361BZ").
+     *
+     * @param  array<string, mixed>  $item
+     */
+    private function matchesPostcode(array $item, string $postcode): bool
+    {
+        if (! isset($item['postcode'])) {
+            return false;
+        }
+
+        return $this->normalizePostcode((string) $item['postcode']) === $this->normalizePostcode($postcode);
+    }
+
+    /**
+     * Whether the PDOK document's house number equals the requested one. PDOK
+     * may return the house number as an int, so both sides are compared as
+     * trimmed strings.
+     *
+     * @param  array<string, mixed>  $item
+     */
+    private function matchesHuisnummer(array $item, string $huisnummer): bool
+    {
+        if (! isset($item['huisnummer'])) {
+            return false;
+        }
+
+        return trim((string) $item['huisnummer']) === trim($huisnummer);
+    }
+
+    private function normalizePostcode(string $postcode): string
+    {
+        return strtoupper((string) preg_replace('/\s+/', '', $postcode));
     }
 
     public function getBagObjectById(string $bagId): ?BagObject

--- a/tests/Feature/EventForm/Components/AddressNLLookupTest.php
+++ b/tests/Feature/EventForm/Components/AddressNLLookupTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\EventForm\State\FormState;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Organisation;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Http;
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach($this->organisation->id, ['role' => 'admin']);
+
+    $this->actingAs($this->user);
+    Filament::setCurrentPanel(Filament::getPanel('organiser'));
+    Filament::setTenant($this->organisation);
+
+    $this->draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => FormState::empty()->toSnapshot(),
+        'current_step_key' => null,
+    ]);
+
+    // PDOK's free-text search always returns the same real address (house
+    // number 1). That mimics its fuzzy behaviour: a non-existent house number
+    // still resolves to the nearest real one.
+    Http::fake([
+        'https://api.pdok.nl/*' => Http::response([
+            'response' => [
+                'docs' => [[
+                    'id' => 'adr-1',
+                    'type' => 'adres',
+                    'centroide_ll' => 'POINT(5.88 50.91)',
+                    'weergavenaam' => 'Deweverplein 1, 6361BZ Nuth',
+                    'straatnaam' => 'Deweverplein',
+                    'postcode' => '6361BZ',
+                    'huisnummer' => 1,
+                    'woonplaatsnaam' => 'Nuth',
+                    'gemeentecode' => '1954',
+                    'gemeentenaam' => 'Beekdaelen',
+                ]],
+            ],
+        ]),
+    ]);
+});
+
+function seedGebouwRow(Testable $component): string
+{
+    $component->set('data.waarVindtHetEvenementPlaats', ['gebouw']);
+    $rows = $component->get('data.adresVanDeGebouwEn');
+    $uuid = array_key_first($rows);
+
+    return "data.adresVanDeGebouwEn.$uuid.adresVanHetGebouwWaarUwEvenementPlaatsvindt1";
+}
+
+test('an existing postcode + house number auto-fills street and city', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    $base = seedGebouwRow($component);
+
+    $component
+        ->set("$base.postcode", '6361 BZ')
+        ->set("$base.huisnummer", '1');
+
+    expect($component->get("$base.straatnaam"))->toBe('Deweverplein')
+        ->and($component->get("$base.woonplaatsnaam"))->toBe('Nuth');
+});
+
+test('changing to a non-existent house number clears the stale street/city and notifies', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    $base = seedGebouwRow($component);
+
+    $component
+        ->set("$base.postcode", '6361 BZ')
+        ->set("$base.huisnummer", '1');
+
+    // Sanity: filled first.
+    expect($component->get("$base.straatnaam"))->toBe('Deweverplein');
+
+    // Now change to a house number PDOK does not have (it still returns nr 1).
+    $component->set("$base.huisnummer", '999');
+
+    expect($component->get("$base.straatnaam"))->toBeEmpty()
+        ->and($component->get("$base.woonplaatsnaam"))->toBeEmpty();
+
+    $component->assertNotified('Geen adres gevonden');
+});

--- a/tests/Feature/Services/LocatieserverServiceExactMatchTest.php
+++ b/tests/Feature/Services/LocatieserverServiceExactMatchTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The BAG lookup by postcode + house number must return the address only when
+ * it exactly matches the requested postcode and house number. PDOK's free-text
+ * search is fuzzy and returns a nearby address for a non-existent house number;
+ * without an exact-match guard that wrong address gets auto-filled in the form.
+ */
+
+use App\Services\LocatieserverService;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    Config::set('services.locatieserver.base_url', 'https://locatieserver.test');
+});
+
+function fakePdokDoc(array $overrides = []): array
+{
+    return array_merge([
+        'id' => 'adr-1',
+        'type' => 'adres',
+        'centroide_ll' => 'POINT(5.88 50.91)',
+        'weergavenaam' => 'Deweverplein 1, 6361BZ Nuth',
+        'straatnaam' => 'Deweverplein',
+        'postcode' => '6361BZ',
+        'huisnummer' => 1,
+        'woonplaatsnaam' => 'Nuth',
+        'gemeentecode' => '1954',
+    ], $overrides);
+}
+
+test('returns the address when postcode and house number match exactly', function () {
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [fakePdokDoc()]],
+        ]),
+    ]);
+
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6361BZ', '1');
+
+    expect($bag)->not->toBeNull()
+        ->and($bag->straatnaam)->toBe('Deweverplein')
+        ->and($bag->woonplaatsnaam)->toBe('Nuth');
+});
+
+test('matches despite spacing and casing differences in the postcode', function () {
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [fakePdokDoc()]],
+        ]),
+    ]);
+
+    // User types "6361 bz", PDOK returns "6361BZ".
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6361 bz', '1');
+
+    expect($bag)->not->toBeNull()
+        ->and($bag->straatnaam)->toBe('Deweverplein');
+});
+
+test('returns null when the returned house number differs from the requested one', function () {
+    // PDOK returns house number 1 for the fuzzy query "6361 BZ 999".
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [fakePdokDoc()]],
+        ]),
+    ]);
+
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6361BZ', '999');
+
+    expect($bag)->toBeNull();
+});
+
+test('returns null when the returned postcode differs from the requested one', function () {
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [fakePdokDoc(['postcode' => '6361BZ', 'huisnummer' => 1])]],
+        ]),
+    ]);
+
+    // Different postcode, same house number: must not match.
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6400AA', '1');
+
+    expect($bag)->toBeNull();
+});
+
+test('picks the exact match out of several fuzzy candidates', function () {
+    Http::fake([
+        'https://locatieserver.test/search/v3_1/free*' => Http::response([
+            'response' => ['docs' => [
+                fakePdokDoc(['id' => 'other', 'huisnummer' => 3, 'straatnaam' => 'Andere straat']),
+                fakePdokDoc(['id' => 'wanted', 'huisnummer' => 12, 'straatnaam' => 'Deweverplein']),
+            ]],
+        ]),
+    ]);
+
+    $bag = (new LocatieserverService)->getBagObjectByPostcodeHuisnummer('6361BZ', '12');
+
+    expect($bag)->not->toBeNull()
+        ->and($bag->huisnummer)->toBe('12')
+        ->and($bag->straatnaam)->toBe('Deweverplein');
+});

--- a/tests/Feature/Threads/MessageFormDocumentVersionAuthTest.php
+++ b/tests/Feature/Threads/MessageFormDocumentVersionAuthTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Enums\ThreadType;
+use App\Models\Message;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\Threads\OrganiserThread;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\Support\Documents\DocumentVersionAuthorizer;
+use App\ValueObjects\ZGW\Informatieobject;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Cache;
+use Tests\Fakes\ZgwHttpFake;
+
+/**
+ * The thread attach flow ("Nieuwe versie van bestaand bestand") must honour the
+ * same per-document ownership rule as the document table: only documents the
+ * user is allowed to version may be selected, and the aanvraagformulier /
+ * ownerless documents are off-limits to non-admins.
+ */
+function makeThreadDocument(string $uuid, string $titel): Informatieobject
+{
+    return new Informatieobject(
+        uuid: $uuid,
+        url: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$uuid,
+        creatiedatum: now()->toIso8601String(),
+        titel: $titel,
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        auteur: 'Test',
+        versie: 1,
+        bestandsnaam: $titel.'.pdf',
+        inhoud: 'base64content',
+        beschrijving: 'Test beschrijving',
+        informatieobjecttype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+        formaat: 'application/pdf',
+        locked: false,
+    );
+}
+
+function logCreated(User $creator, Zaak $zaak, string $documentUuid, ?string $filename = null): void
+{
+    $properties = ['document_uuid' => $documentUuid];
+    if ($filename !== null) {
+        $properties['filename'] = $filename;
+    }
+
+    activity('document')
+        ->event('created')
+        ->causedBy($creator)
+        ->performedOn($zaak)
+        ->withProperties($properties)
+        ->log('created');
+}
+
+beforeEach(function () {
+    $this->municipality = Municipality::factory()->create();
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->municipality->id]);
+
+    ZgwHttpFake::wildcardFake();
+
+    $this->zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+
+    // One document owned by the organiser, one system aanvraagformulier.
+    Cache::forever("zaak.{$this->zaak->id}.documenten", collect([
+        makeThreadDocument('own-doc-uuid', 'Eigen document'),
+        makeThreadDocument('aanvraagformulier-uuid', 'Aanvraagformulier'),
+    ]));
+
+    logCreated($this->organiser, $this->zaak, 'own-doc-uuid');
+    logCreated($this->organiser, $this->zaak, 'aanvraagformulier-uuid', 'aanvraagformulier.pdf');
+
+    $this->thread = OrganiserThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Organiser,
+        'created_by' => $this->organiser->id,
+        'title' => 'Test thread',
+    ]);
+
+    Message::forceCreate([
+        'thread_id' => $this->thread->id,
+        'user_id' => $this->organiser->id,
+        'body' => 'Initial message',
+    ]);
+
+    Filament::setCurrentPanel(Filament::getPanel('organiser'));
+    $this->actingAs($this->organiser);
+    Filament::setTenant($this->organisation);
+});
+
+test('the existing-document select only offers documents the user may version', function () {
+    // The Select options and the action's server-side guard both derive from
+    // this exact filter. Exercising it against real cached documenten + their
+    // activity-log creators validates the whole plumbing the fix depends on.
+    $selectable = $this->zaak->documenten
+        ->filter(fn ($document): bool => DocumentVersionAuthorizer::canAddVersion($this->organiser, $this->zaak, $document->uuid))
+        ->pluck('uuid');
+
+    expect($selectable)->toContain('own-doc-uuid')
+        ->and($selectable)->not->toContain('aanvraagformulier-uuid');
+});
+
+test('the organiser may version their own document but not the system aanvraagformulier', function () {
+    expect(DocumentVersionAuthorizer::canAddVersion($this->organiser, $this->zaak, 'own-doc-uuid'))->toBeTrue()
+        ->and(DocumentVersionAuthorizer::canAddVersion($this->organiser, $this->zaak, 'aanvraagformulier-uuid'))->toBeFalse();
+});
+
+test('a reviewer from the municipality may not version the organiser-owned document', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->municipality->users()->attach($reviewer);
+
+    // Cross-group: a municipality user is not in the organiser's group, so the
+    // thread attach flow must not offer or accept the organiser-owned document.
+    expect(DocumentVersionAuthorizer::canAddVersion($reviewer, $this->zaak, 'own-doc-uuid'))->toBeFalse();
+});


### PR DESCRIPTION
Fixes several findings from the next/v1.2 tester report (gemeente Beekdaelen, DEEL 1).

## Address lookup (findings 2 and 3)

**Non-existent house number returned an address.** `LocatieserverService::getBagObjectByPostcodeHuisnummer()` used PDOK's fuzzy free-text search and never verified that the returned document actually matched the requested postcode and house number. A non-existent house number resolved to the nearest real address, which was then auto-filled. The lookup now requires an exact match on postcode (normalised for spacing and casing) and house number, otherwise it returns `null`.

**Stale street/city lingered.** When a lookup failed, `AddressNL` kept the previously auto-filled street and city, so they stayed visible for an address that no longer matched. It now clears street/city and shows a notification, while manual entry stays possible (both fields remain required and editable). A failed huisletter/toevoeging refinement keeps a still-valid street/city untouched.

## Document version authorization (finding 3, thread route)

The thread attach flow ("Nieuwe versie van bestaand bestand") called `createNewDocumentVersion()` without any ownership check and offered every document on the case. Any message author could version any document, including the system aanvraagformulier. The selectable documents are now filtered by `DocumentVersionAuthorizer` and the same check is enforced server-side in the action.

## Not included here

The autofill-fails-on-location-1 finding is a browser-side morph race (the server-side lookup chain is proven correct by the new tests). It matches an already-documented, CI-unreproducible race class in this codebase and needs browser-verified work in the seeded test environment, so it is deliberately left out of this PR. See `onderzoek.md` for the full analysis.

## Merge note

This branch is cut from `main` to become a new beta that is merged back into `next/v1.2`. The document-table visibility regression from that finding lives only on `next/v1.2` and is fixed separately on that branch.

## Tests

New tests: `LocatieserverServiceExactMatchTest`, `AddressNLLookupTest`, `MessageFormDocumentVersionAuthTest`. Full affected suite (74 tests) passes; Pint and PHPStan clean.