### PR TITLE
Fix "Nieuwe versie" button visibility on the document table

### DIFF
--- a/app/Livewire/Zaken/ZaakDocumentsTable.php
+++ b/app/Livewire/Zaken/ZaakDocumentsTable.php
@@ -108,8 +108,13 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
                     ]))
                     ->openUrlInNewTab()
                     ->icon('heroicon-o-eye'),
+                // Use hidden() rather than a second visible(): visible() would
+                // replace the action's own visibility closure and discard the
+                // DocumentVersionAuthorizer ownership check, making "Nieuwe
+                // versie" appear for everyone. hidden() is a separate condition
+                // that is AND-ed with that check.
                 NewDocumentVersionAction::make($this->zaak)
-                    ->visible(fn (): bool => ! $this->submissionOnly),
+                    ->hidden(fn (): bool => $this->submissionOnly),
                 ActionGroup::make([
                     Action::make('downloaden')
                     // ->label(__('municipality/resources/zaak.actions.download.label'))

--- a/tests/Feature/Livewire/ZaakDocumentsTableTest.php
+++ b/tests/Feature/Livewire/ZaakDocumentsTableTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\OrganisationRole;
 use App\Enums\Role;
 use App\Livewire\Zaken\ZaakDocumentsTable;
@@ -10,6 +11,9 @@ use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
+use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Support\Facades\Cache;
+use Tests\Fakes\ZgwHttpFake;
 
 use function Pest\Livewire\livewire;
 
@@ -26,6 +30,41 @@ beforeEach(function () {
         'zgw_zaak_url' => null,
     ]);
 });
+
+function tableDocument(string $uuid, string $titel): Informatieobject
+{
+    return new Informatieobject(
+        uuid: $uuid,
+        url: 'https://zgw.example.com/documenten/api/v1/enkelvoudiginformatieobject/'.$uuid,
+        creatiedatum: now()->toIso8601String(),
+        titel: $titel,
+        // Zaakvertrouwelijk is visible to organiser, reviewer and admin.
+        vertrouwelijkheidaanduiding: DocumentVertrouwelijkheden::Zaakvertrouwelijk->value,
+        auteur: 'Test',
+        versie: 1,
+        bestandsnaam: $titel.'.pdf',
+        inhoud: 'base64content',
+        beschrijving: 'Test beschrijving',
+        informatieobjecttype: 'https://zgw.example.com/catalogi/api/v1/informatieobjecttypen/1',
+        formaat: 'application/pdf',
+        locked: false,
+    );
+}
+
+function logDocCreated(User $creator, Zaak $zaak, string $documentUuid, ?string $filename = null): void
+{
+    $properties = ['document_uuid' => $documentUuid];
+    if ($filename !== null) {
+        $properties['filename'] = $filename;
+    }
+
+    activity('document')
+        ->event('created')
+        ->causedBy($creator)
+        ->performedOn($zaak)
+        ->withProperties($properties)
+        ->log('created');
+}
 
 test('organiser does not see the version column', function () {
     $organiser = User::factory()->create(['role' => Role::Organiser]);
@@ -64,4 +103,67 @@ test('outside submission-only mode the upload action is available', function () 
 
     livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak, 'submissionOnly' => false])
         ->assertTableActionVisible('upload');
+});
+
+/**
+ * Regression: a second visible() on the "Nieuwe versie" action would replace
+ * the action's own visibility closure and discard the DocumentVersionAuthorizer
+ * ownership check, making the button appear for everyone. These tests pin the
+ * per-role, per-document visibility.
+ */
+function seedDocuments(Organisation $organisation, Zaak $zaak): User
+{
+    $owner = User::factory()->create(['role' => Role::Organiser]);
+    $organisation->users()->attach($owner, ['role' => OrganisationRole::Admin->value]);
+
+    // A zgw_zaak_url is required for the documenten accessor to read the cache;
+    // the pre-populated cache below means no document ZGW call is made. The
+    // wildcard fake covers the zaak-expand call the table render triggers.
+    ZgwHttpFake::wildcardFake();
+    $zaak->update(['zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1']);
+
+    Cache::forever("zaak.{$zaak->id}.documenten", collect([
+        tableDocument('own-doc-uuid', 'Eigen document'),
+        tableDocument('aanvraagformulier-uuid', 'Aanvraagformulier'),
+    ]));
+
+    logDocCreated($owner, $zaak, 'own-doc-uuid');
+    logDocCreated($owner, $zaak, 'aanvraagformulier-uuid', 'aanvraagformulier.pdf');
+
+    return $owner;
+}
+
+test('an organiser sees "Nieuwe versie" only on their own document, not the aanvraagformulier', function () {
+    $owner = seedDocuments($this->organisation, $this->zaak);
+
+    $this->actingAs($owner);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertTableActionVisible('new-version', 'own-doc-uuid')
+        ->assertTableActionHidden('new-version', 'aanvraagformulier-uuid');
+});
+
+test('a reviewer does not see "Nieuwe versie" on an organiser-owned document', function () {
+    seedDocuments($this->organisation, $this->zaak);
+
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->municipality->users()->attach($reviewer);
+
+    $this->actingAs($reviewer);
+
+    // Before the fix the override made this button visible to the reviewer too.
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertTableActionHidden('new-version', 'own-doc-uuid');
+});
+
+test('a platform admin sees "Nieuwe versie" on every document including the aanvraagformulier', function () {
+    seedDocuments($this->organisation, $this->zaak);
+
+    $admin = User::factory()->create(['role' => Role::Admin]);
+
+    $this->actingAs($admin);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertTableActionVisible('new-version', 'own-doc-uuid')
+        ->assertTableActionVisible('new-version', 'aanvraagformulier-uuid');
 });


### PR DESCRIPTION
Fixes the finding from the next/v1.2 tester report that the "Nieuwe versie" button was visible to every user (organiser and reviewer) on every document, including the aanvraagformulier.

## Cause

`NewDocumentVersionAction::make()` sets its own `->visible()` closure that runs `DocumentVersionAuthorizer::canAddVersion()`. In `ZaakDocumentsTable` the submission-only guard was added as a second `->visible(fn () => ! $this->submissionOnly)`. A second `visible()` replaces the first closure (it is one property in Filament), so the authorizer ownership check was silently discarded and only the broad `uploadDocument` policy remained, which is true for organiser and reviewer alike.

This override was introduced with the One Ground optimisations (`ea752c64`), after the authorization feature landed, so it exists only on this branch.

## Fix

Use `->hidden(fn () => $this->submissionOnly)` for the submission-only condition. `hidden()` is a separate property that is AND-ed with the action's own `visible()` check, so the authorizer decision is preserved.

## Tests

Adds regression tests to `ZaakDocumentsTableTest` that pin the per-role, per-document visibility of the "new-version" action: an organiser sees it only on their own document (not the aanvraagformulier), a reviewer does not see it on an organiser-owned document, and a platform admin sees it everywhere. Pint and PHPStan clean.

## Related

The address-lookup and thread-route authorization findings from the same test round are fixed on a branch cut from `main` (#445), which becomes the new beta that merges back into `next/v1.2`. This document-table override lives only on `next/v1.2`, hence the separate fix here.