### PR TITLE
Add Playwright organiser seeder and address-autofill E2E coverage

### DIFF
--- a/database/seeders/PlaywrightUserSeeder.php
+++ b/database/seeders/PlaywrightUserSeeder.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\OrganisationRole;
+use App\Enums\OrganisationType;
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+
+/**
+ * Deterministic organiser account used by the Playwright walkthrough tests
+ * (auth.setup.mjs logs in as noah.degraaf@example.net / password). The regular
+ * OrganisationSeeder creates organisers with faker e-mails, so this account is
+ * not guaranteed to exist after a normal seed. This seeder is idempotent and
+ * safe to run repeatedly.
+ */
+class PlaywrightUserSeeder extends Seeder
+{
+    public const EMAIL = 'noah.degraaf@example.net';
+
+    public function run(): void
+    {
+        $user = User::updateOrCreate(
+            ['email' => self::EMAIL],
+            [
+                'name' => 'Noah de Graaf',
+                'role' => Role::Organiser,
+                'password' => Hash::make('password'),
+                'email_verified_at' => now(),
+                // No two-factor secret so the Playwright login is a single step.
+                'app_authentication_secret' => null,
+                'app_authentication_recovery_codes' => null,
+            ],
+        );
+
+        $organisation = Organisation::where('type', OrganisationType::Business)->first()
+            ?? Organisation::factory()->create(['type' => OrganisationType::Business]);
+
+        if (! $organisation->users()->whereKey($user->id)->exists()) {
+            $organisation->users()->attach($user->id, ['role' => OrganisationRole::Admin]);
+        }
+    }
+}

--- a/tests/Playwright/helpers/form-invullen.mjs
+++ b/tests/Playwright/helpers/form-invullen.mjs
@@ -9,7 +9,7 @@
 // Filament v5 / Livewire 4 rendert `->live(onBlur: true)` als
 // `wire:model.live.blur` (in v4 was dat `wire:model.blur`). Beide varianten
 // blijven in de lijst zodat de selectors over Filament-versies heen werken.
-const MODIFIERS = ['', '.live', '.defer', '.blur', '.live.blur', '.debounce.500ms', '.live.debounce.500ms'];
+const MODIFIERS = ['', '.live', '.defer', '.blur', '.live.blur', '.debounce.500ms', '.live.debounce.500ms', '.debounce.750ms', '.live.debounce.750ms'];
 
 function selectorVoor(tag, attr) {
     // Bouw een CSS-selector die één van de wire:model-varianten matcht.

--- a/tests/Playwright/scenario-adres-autofill-en-melding.spec.mjs
+++ b/tests/Playwright/scenario-adres-autofill-en-melding.spec.mjs
@@ -1,0 +1,125 @@
+import { test, expect } from '@playwright/test';
+import { loginAlsOrganiser, openFormulier } from './helpers/login.mjs';
+import { leegDraftDb } from './helpers/wizard-flow.mjs';
+import {
+    vulTekst,
+    vulTextarea,
+    vulEindigendOp,
+    kiesSelect,
+    klikVolgende,
+    huidigeStap,
+    endsWithSelector,
+} from './helpers/form-invullen.mjs';
+
+/**
+ * Adres-autofill in de locatie-stap (bevindingen 2, 3 en A uit de tester-ronde).
+ *
+ * - Een bestaand adres vult straat/plaats automatisch aan.
+ * - Een niet-bestaand adres (bv. 5541WG/99: PDOK geeft dan fuzzy een 99 uit een
+ *   andere plaats terug) mag GEEN verkeerd adres invullen; straat/plaats worden
+ *   leeggemaakt en er verschijnt een melding "Geen adres gevonden".
+ * - Bevinding A (nog open): bij meerdere locaties gaat de autofill van één rij
+ *   verloren door de gemeente-detect re-render. Vastgelegd als test.fixme.
+ */
+
+const ADR1 = '.adresVanHetGebouwWaarUwEvenementPlaatsvindt1';
+
+const straatRij = (page, i) => page.locator(endsWithSelector('input', `${ADR1}.straatnaam`)).nth(i);
+const plaatsRij = (page, i) => page.locator(endsWithSelector('input', `${ADR1}.woonplaatsnaam`)).nth(i);
+
+async function vulAdresRij(page, i, postcode, huisnummer) {
+    await page.locator(endsWithSelector('input', `${ADR1}.postcode`)).nth(i).fill(postcode);
+    await page.keyboard.press('Tab');
+    await page.locator(endsWithSelector('input', `${ADR1}.huisnummer`)).nth(i).fill(huisnummer);
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(3500); // debounce (750ms) + PDOK + gemeente-detect
+}
+
+/** Loopt de wizard tot en met "In een gebouw" op de locatie-stap. */
+async function totLocatieGebouw(page) {
+    await leegDraftDb();
+    await loginAlsOrganiser(page);
+    await openFormulier(page);
+
+    // Stap 1: Contactgegevens
+    await vulTekst(page, 'watIsUwVoornaam', 'Noah');
+    await vulTekst(page, 'watIsUwAchternaam', 'de Graaf');
+    await vulTekst(page, 'watIsUwEMailadres', 'noah.degraaf@example.net');
+    await vulTekst(page, 'watIsUwTelefoonnummer', '0612345678');
+    await vulTekst(page, 'watIsHetKamerVanKoophandelNummerVanUwOrganisatie', '12345678').catch(() => {});
+    await vulTekst(page, 'watIsDeNaamVanUwOrganisatie', 'Testorganisatie').catch(() => {});
+    await vulTekst(page, 'postcode1', '6411CD').catch(() => {});
+    await vulTekst(page, 'huisnummer1', '32').catch(() => {});
+    await vulTekst(page, 'straatnaam1', 'Coriovallumstraat').catch(() => {});
+    await vulTekst(page, 'plaatsnaam1', 'Heerlen').catch(() => {});
+    await vulTekst(page, 'emailadresOrganisatie', 'org@example.net').catch(() => {});
+    await vulTekst(page, 'telefoonnummerOrganisatie', '0612345678').catch(() => {});
+    await page.waitForTimeout(500);
+    await klikVolgende(page);
+
+    // Stap 2: Het evenement
+    await vulTekst(page, 'watIsDeNaamVanHetEvenementVergunning', 'Testevenement');
+    await page.waitForTimeout(300);
+    await vulTextarea(page, 'geefEenKorteOmschrijvingVanHetEvenementWatIsDeNaamVanHetEvenementVergunning', 'Test').catch(() => {});
+    await kiesSelect(page, 'soortEvenement', 'Buurt-, barbecue of straatfeest, buitenspeeldagen, (eindejaars-)feesten, garagesales').catch(() => {});
+    await page.waitForTimeout(400);
+    await klikVolgende(page);
+
+    // Stap 3: Locatie
+    expect(await huidigeStap(page)).toMatch(/Locatie/i);
+    await page.getByRole('checkbox', { name: /In een gebouw/i }).check();
+    await page.waitForTimeout(1500);
+    await vulEindigendOp(page, 'input', '.naamVanDeLocatieGebouw', 'Locatie 1');
+}
+
+test('een bestaand adres vult straat en plaats automatisch aan', async ({ page }) => {
+    test.setTimeout(180_000);
+    await totLocatieGebouw(page);
+
+    // 6411CD/32 = Coriovallumstraat, Heerlen.
+    await vulAdresRij(page, 0, '6411CD', '32');
+
+    await expect(straatRij(page, 0)).toHaveValue('Coriovallumstraat');
+    await expect(plaatsRij(page, 0)).toHaveValue('Heerlen');
+});
+
+test('een niet-bestaand adres maakt straat/plaats leeg en toont een melding', async ({ page }) => {
+    test.setTimeout(180_000);
+    await totLocatieGebouw(page);
+
+    // Eerst een geldig adres zodat straat/plaats gevuld zijn.
+    await vulAdresRij(page, 0, '6411CD', '32');
+    await expect(straatRij(page, 0)).toHaveValue('Coriovallumstraat');
+
+    // Nu een huisnummer dat niet bestaat op deze postcode. PDOK geeft fuzzy een
+    // adres uit een andere plaats terug; de exact-match-guard weigert dat.
+    await page.locator(endsWithSelector('input', `${ADR1}.huisnummer`)).nth(0).fill('9999');
+    await page.keyboard.press('Tab');
+    await page.waitForTimeout(4000);
+
+    await expect(straatRij(page, 0)).toHaveValue('');
+    await expect(plaatsRij(page, 0)).toHaveValue('');
+    await expect(page.getByText(/Geen adres gevonden/i).first()).toBeVisible();
+});
+
+// Bevinding A: bij twee locaties gaat de autofill van (in deze run) de tweede
+// rij verloren — straat/plaats blijven leeg terwijl ze server-side wél bepaald
+// worden. Oorzaak is de gemeente-detect re-render die met de autofill-$set
+// botst (zelfde raceklasse als scenario-locatie-route-behoudt-velden). Welke
+// rij het slachtoffer is hangt van timing af. Fixme tot de gemeente-detect
+// re-render geïsoleerd is van de adresvelden.
+test.fixme('bevinding A: beide locatie-rijen vullen straat/plaats automatisch aan', async ({ page }) => {
+    test.setTimeout(180_000);
+    await totLocatieGebouw(page);
+
+    await vulAdresRij(page, 0, '6411CD', '32');
+    await expect(straatRij(page, 0)).toHaveValue('Coriovallumstraat');
+
+    await page.getByRole('button', { name: /Nog een adres toevoegen/i }).click();
+    await page.waitForTimeout(1500);
+    await page.locator(endsWithSelector('input', '.naamVanDeLocatieGebouw')).nth(1).fill('Locatie 2');
+    await vulAdresRij(page, 1, '6411CD', '32');
+
+    await expect(straatRij(page, 1)).toHaveValue('Coriovallumstraat');
+    await expect(plaatsRij(page, 1)).toHaveValue('Heerlen');
+});


### PR DESCRIPTION
Follow-up to #445. That PR merged before this Playwright work was pushed, so it is split off here.

## What

- **PlaywrightUserSeeder** guarantees a deterministic organiser account (`noah.degraaf@example.net` / `password`) attached to an organisation. The regular `OrganisationSeeder` creates organisers with faker e-mails, so the account the Playwright walkthrough logs in as was not guaranteed to exist on a fresh database. The seeder is idempotent.
- **Form helper selector fix**: the `AddressNL` postcode/huisnummer fields render as `wire:model.live.debounce.750ms`, a variant the shared `form-invullen.mjs` selectors did not cover, so those fields were untargetable in Playwright. Added the `.debounce.750ms` / `.live.debounce.750ms` variants.
- **scenario-adres-autofill-en-melding**: end-to-end coverage for the address lookup fixed in #445. Verifies that a valid address auto-fills street/city, and that a non-existent address (where PDOK fuzzily returns a house number from another town) clears the fields and shows the "Geen adres gevonden" notification. Documents finding A (autofill lost on one row during the gemeente-detect re-render) as a `test.fixme`.

## Notes

The E2E specs hit the real PDOK service, matching the existing walkthrough specs. Run with `EF_BASE_URL` pointing at the local app port, e.g. `EF_BASE_URL=http://localhost:8090 npx playwright test tests/Playwright/scenario-adres-autofill-en-melding.spec.mjs`.