### PR TITLE
Cache the gemeente check on the effective location input

### DIFF
--- a/app/EventForm/Services/ServiceFetcher.php
+++ b/app/EventForm/Services/ServiceFetcher.php
@@ -74,10 +74,18 @@ class ServiceFetcher
                 (string) $state->get('EvenementEind'),
                 (string) $state->get('evenementInGemeente.brk_identification'),
             ])),
+            // Hash op de effectieve input van de location-check (de
+            // gefilterde geometrieën en complete adressen), niet op de ruwe
+            // editgrids. Zo bust een half getypt adres (alleen een postcode,
+            // of een gewijzigde locatienaam) de cache niet: dat blijft een
+            // cache-hit en scheelt een overbodige PDOK-lookup en berekening.
+            // Polygonen en lijnen zitten via hun gefilterde geometrieën nog
+            // steeds in de hash, dus de gemeentebepaling voor kaart-items
+            // triggert ongewijzigd.
             'inGemeentenResponse' => sha1((string) json_encode([
-                'p' => $state->get('locatieSOpKaart'),
-                'l' => $state->get('routesOpKaart'),
-                'a' => $state->get('adresVanDeGebouwEn'),
+                'p' => $this->collectPolygonsFromEditgrid($state->get('locatieSOpKaart')),
+                'l' => $this->collectLinesFromEditgrid($state->get('routesOpKaart')),
+                'a' => $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn')),
             ])),
             default => null,
         };

--- a/tests/Feature/EventForm/Services/ServiceFetcherTest.php
+++ b/tests/Feature/EventForm/Services/ServiceFetcherTest.php
@@ -142,6 +142,43 @@ describe('ServiceFetcher inGemeentenResponse', function () {
         expect($result)->toBeArray()
             ->and($result['all']['items'])->toHaveCount(1);
     });
+
+    test('adding a half-typed address does not re-run the gemeente check', function () {
+        Http::fake([
+            'api.pdok.nl/bzk/locatieserver/search/v3_1/free*' => Http::response([
+                'response' => ['docs' => [['gemeentecode' => '0882', 'gemeentenaam' => 'Maastricht']]],
+            ]),
+        ]);
+
+        $state = FormState::empty();
+        $state->setField('adresVanDeGebouwEn', [
+            'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => ['postcode' => '6211AA', 'huisnummer' => '1']],
+        ]);
+
+        $this->fetcher->fetch('inGemeentenResponse', $state);
+        Http::assertSentCount(1);
+
+        // A second row with only a postcode leaves the set of complete
+        // addresses unchanged, so the cache key stays the same and no new
+        // PDOK lookup is made.
+        $state->setField('adresVanDeGebouwEn', [
+            'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => ['postcode' => '6211AA', 'huisnummer' => '1']],
+            'row-2' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => ['postcode' => '6411CD']],
+        ]);
+
+        $this->fetcher->fetch('inGemeentenResponse', $state);
+        Http::assertSentCount(1);
+
+        // Completing the second address changes the set, so the check re-runs
+        // (one PDOK lookup per complete address).
+        $state->setField('adresVanDeGebouwEn', [
+            'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => ['postcode' => '6211AA', 'huisnummer' => '1']],
+            'row-2' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => ['postcode' => '6411CD', 'huisnummer' => '32']],
+        ]);
+
+        $this->fetcher->fetch('inGemeentenResponse', $state);
+        Http::assertSentCount(3);
+    });
 });
 
 describe('ServiceFetcher unknown variable', function () {


### PR DESCRIPTION
Small, standalone efficiency improvement. This is explicitly **not** a fix for the address-autofill race with multiple locations (that turned out to be a deeper Livewire re-render issue; see the separate analysis).

## What

The `inGemeentenResponse` cache key in `ServiceFetcher` hashed the raw location editgrids (`locatieSOpKaart`, `routesOpKaart`, `adresVanDeGebouwEn`). Any change to those, including a half-typed postcode or an edited location name, changed the hash and triggered a fresh PDOK lookup plus PostGIS calculation, even when the set of complete addresses and geometries had not changed.

The key now hashes the collected, effective input (the filtered geometries and complete addresses) that the location check actually consumes. Partial or cosmetic edits stay a cache hit, avoiding a redundant PDOK call and re-computation.

## Line and polygon detection preserved

Polygons and lines remain part of the key via their filtered geometries, so a drawn or edited map shape still busts the cache and re-runs the gemeente detection. The existing intersect and location-check tests pass unchanged.

## Tests

Adds a test asserting that adding a half-typed second address does not re-run the check (no extra PDOK call), while completing it does. Full `EventForm/Services` and `EventForm/Pages` suites pass; Pint and PHPStan clean.