### PR TITLE
Determine the event gemeente authoritatively on the location gate

### DIFF
--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Components;
 
 use App\Services\LocatieserverService;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\TextInput;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
@@ -94,6 +95,12 @@ final class AddressNL
                     ->label('Plaats')
                     ->required()
                     ->maxLength(255),
+                // Internal-only: the BRK gemeente identification ('GM' + code)
+                // resolved by the PDOK auto-fill. Stored so the location gate
+                // can determine the gemeente for this address without a second
+                // PDOK call. Hidden fields are excluded from the summary/PDF and
+                // are ignored by the ZGW submit, so this never leaks outward.
+                Hidden::make("{$key}.brkGemeente"),
             ]);
     }
 
@@ -137,6 +144,7 @@ final class AddressNL
             if ($bag !== null) {
                 $set("{$key}.straatnaam", $bag->straatnaam);
                 $set("{$key}.woonplaatsnaam", $bag->woonplaatsnaam);
+                $set("{$key}.brkGemeente", 'GM'.$bag->gemeentecode);
                 if ($bag->huisletter !== null && $bag->huisletter !== '') {
                     $set("{$key}.huisletter", $bag->huisletter);
                 }
@@ -156,12 +164,15 @@ final class AddressNL
             if (($huisletter !== null && $huisletter !== '') || ($huisnummertoevoeging !== null && $huisnummertoevoeging !== '')) {
                 $baseBag = $service->getBagObjectByPostcodeHuisnummer((string) $postcode, (string) $huisnummer);
                 if ($baseBag !== null) {
+                    $set("{$key}.brkGemeente", 'GM'.$baseBag->gemeentecode);
+
                     return;
                 }
             }
 
             $set("{$key}.straatnaam", null);
             $set("{$key}.woonplaatsnaam", null);
+            $set("{$key}.brkGemeente", null);
 
             Notification::make()
                 ->title('Geen adres gevonden')

--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -14,6 +14,7 @@ use Filament\Forms\Components\DatePicker;
 use Filament\Forms\Components\DateTimePicker;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\FileUpload;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
@@ -267,6 +268,13 @@ final class SubmissionReport
      */
     private function buildEntry(Field $component, FormState $state, string $key, object $stubLivewire): ?array
     {
+        // Hidden fields carry internal state (e.g. the address auto-fill's
+        // resolved BRK gemeente) that is never meant for the human-facing
+        // summary or PDF. Skip them regardless of value.
+        if ($component instanceof Hidden) {
+            return null;
+        }
+
         $rawValue = $state->get($key);
         $value = $this->renderValue($component, $state, $key, $stubLivewire);
 

--- a/app/EventForm/Schema/Steps/LocatieVanHetEvenement2Step.php
+++ b/app/EventForm/Schema/Steps/LocatieVanHetEvenement2Step.php
@@ -40,9 +40,34 @@ final class LocatieVanHetEvenement2Step
         return Step::make('Locatie')
             ->key(self::UUID)
             ->afterValidation(function ($livewire): void {
-                $evenementInGemeente = $livewire->state()->get('evenementInGemeente');
+                // Autoritatieve gemeentebepaling: draai de volledige location-check
+                // over adressen, vlakken en lijnen (met PDOK-fallback voor
+                // handmatige adressen) en werk de afgeleiden bij. Zo rust de harde
+                // eis "er moet een gemeente bepaald zijn" niet op het reactieve,
+                // per-toetsaanslag bijgehouden mechanisme maar op deze gate.
+                $livewire->runLocationGate();
 
-                if (empty($evenementInGemeente)) {
+                $state = $livewire->state();
+                $items = $state->get('inGemeentenResponse.all.items');
+                $aantalGemeenten = is_array($items) ? count($items) : 0;
+                $keuze = $state->get('userSelectGemeente');
+
+                // Meerdere gemeenten en nog geen keuze: toon de keuze-radio (die
+                // wordt zichtbaar doordat de response nu in de state staat) en
+                // blokkeer tot de organisator één gemeente kiest.
+                if ($aantalGemeenten >= 2 && (! is_string($keuze) || $keuze === '')) {
+                    Notification::make()
+                        ->title('Kies een gemeente')
+                        ->body('De ingevoerde locatie(s) of route valt binnen meerdere gemeenten. Kies hieronder de gemeente waarvoor u de aanvraag wilt doen voordat u verder gaat.')
+                        ->warning()
+                        ->send();
+
+                    throw new Halt;
+                }
+
+                // Geen enkele gemeente bepaald (0 gevonden, of buiten de regio):
+                // blokkeren zoals voorheen.
+                if (empty($state->get('evenementInGemeente'))) {
                     Notification::make()
                         ->title('Gemeente niet bepaald')
                         ->body('Vul een adres, locatie of route in zodat de gemeente automatisch bepaald kan worden voordat u verder gaat.')

--- a/app/EventForm/Services/LocationServerCheckInput.php
+++ b/app/EventForm/Services/LocationServerCheckInput.php
@@ -18,8 +18,8 @@ final readonly class LocationServerCheckInput
      * @param  list<array<string, mixed>>|null  $polygons  GeoJSON Polygon/MultiPolygon objecten
      * @param  array<string, mixed>|null  $line  GeoJSON LineString
      * @param  list<array<string, mixed>>|null  $lines  Lijst van GeoJSON LineStrings
-     * @param  list<array{postcode: string, houseNumber: string}>|null  $addresses
-     * @param  array{postcode: string, houseNumber: string}|null  $address
+     * @param  list<array{postcode: string, houseNumber: string, brkIdentification?: ?string}>|null  $addresses
+     * @param  array{postcode: string, houseNumber: string, brkIdentification?: ?string}|null  $address
      */
     public function __construct(
         public ?array $polygons = null,

--- a/app/EventForm/Services/LocationServerCheckService.php
+++ b/app/EventForm/Services/LocationServerCheckService.php
@@ -310,15 +310,22 @@ class LocationServerCheckService
 
     /**
      * @param  array<string, mixed>  $response
-     * @param  array{postcode: string, houseNumber: string}  $address
+     * @param  array{postcode: string, houseNumber: string, brkIdentification?: ?string}  $address
      * @return array<string, mixed>
      */
     private function absorbAddress(array $response, array $address): array
     {
-        $brkId = $this->locatieserver->getBrkIdentificationByPostcodeHuisnummer(
-            $address['postcode'],
-            $address['houseNumber'],
-        );
+        // Reuse the BRK gemeente resolved by the address auto-fill when it is
+        // available, so we skip a second PDOK lookup for the same address. Only
+        // manually entered addresses (whose auto-fill did not resolve) fall back
+        // to the postcode + house number lookup here.
+        $brkId = $address['brkIdentification'] ?? null;
+        if (! is_string($brkId) || $brkId === '') {
+            $brkId = $this->locatieserver->getBrkIdentificationByPostcodeHuisnummer(
+                $address['postcode'],
+                $address['houseNumber'],
+            );
+        }
         $municipality = $brkId
             ? Municipality::where('brk_identification', $brkId)
                 ->select(['brk_identification', 'name'])

--- a/app/EventForm/Services/ServiceFetcher.php
+++ b/app/EventForm/Services/ServiceFetcher.php
@@ -36,12 +36,26 @@ class ServiceFetcher
      */
     private \WeakMap $inputHashByState;
 
-    public function fetch(string $variable, FormState $state): void
+    /**
+     * @param  bool  $authoritativeAddresses  Bepaalt hoe adressen bijdragen aan
+     *                                        `inGemeentenResponse`. `true` (gate en
+     *                                        mount): alle complete adressen tellen
+     *                                        mee, met een PDOK-fallback voor
+     *                                        handmatige adressen zonder bekende
+     *                                        gemeente. `false` (reactief tijdens
+     *                                        typen): alleen adressen waarvan de
+     *                                        gemeente al uit de auto-fill bekend is
+     *                                        (`brkGemeente`) tellen mee, zodat de
+     *                                        reactieve check nooit een trage
+     *                                        PDOK-lookup doet en de invoer-race op
+     *                                        de adres-repeater niet optreedt.
+     */
+    public function fetch(string $variable, FormState $state, bool $authoritativeAddresses = true): void
     {
         $this->inputHashByState ??= new \WeakMap;
         $hashes = $this->inputHashByState[$state] ?? [];
 
-        $newHash = $this->inputHashFor($variable, $state);
+        $newHash = $this->inputHashFor($variable, $state, $authoritativeAddresses);
         if ($newHash !== null && ($hashes[$variable] ?? null) === $newHash) {
             return; // input ongewijzigd → resultaat staat al in state
         }
@@ -50,7 +64,7 @@ class ServiceFetcher
             'eventloketSession' => $this->fetchEventloketSession($state),
             'gemeenteVariabelen' => $this->fetchGemeenteVariabelen($state),
             'evenementenInDeGemeente' => $this->fetchEvenementenInDeGemeente($state),
-            'inGemeentenResponse' => $this->fetchInGemeentenResponse($state),
+            'inGemeentenResponse' => $this->fetchInGemeentenResponse($state, $authoritativeAddresses),
             default => null,
         };
 
@@ -64,7 +78,7 @@ class ServiceFetcher
      * Hash van de inputs die deze fetch-variant beïnvloeden. Twee
      * roundtrips met dezelfde hash hoeven niet opnieuw te fetchen.
      */
-    private function inputHashFor(string $variable, FormState $state): ?string
+    private function inputHashFor(string $variable, FormState $state, bool $authoritativeAddresses): ?string
     {
         return match ($variable) {
             'eventloketSession' => null, // gebeurt 1× bij mount, geen cache nodig
@@ -85,7 +99,7 @@ class ServiceFetcher
             'inGemeentenResponse' => sha1((string) json_encode([
                 'p' => $this->collectPolygonsFromEditgrid($state->get('locatieSOpKaart')),
                 'l' => $this->collectLinesFromEditgrid($state->get('routesOpKaart')),
-                'a' => $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn')),
+                'a' => $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn'), $authoritativeAddresses),
             ])),
             default => null,
         };
@@ -141,13 +155,13 @@ class ServiceFetcher
         $state->setVariable('evenementenInDeGemeente', $result['event_names']);
     }
 
-    private function fetchInGemeentenResponse(FormState $state): void
+    private function fetchInGemeentenResponse(FormState $state, bool $authoritativeAddresses): void
     {
         $input = new LocationServerCheckInput(
             polygons: $this->collectPolygonsFromEditgrid($state->get('locatieSOpKaart')),
             line: null,
             lines: $this->collectLinesFromEditgrid($state->get('routesOpKaart')),
-            addresses: $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn')),
+            addresses: $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn'), $authoritativeAddresses),
             address: null,
         );
 
@@ -159,9 +173,12 @@ class ServiceFetcher
     }
 
     /**
-     * @return list<array{postcode: string, houseNumber: string}>|null
+     * @param  bool  $authoritative  Zie `fetch()`. `false` slaat adressen zonder
+     *                               een via auto-fill bekende gemeente over, zodat
+     *                               de reactieve check geen PDOK-lookup nodig heeft.
+     * @return list<array{postcode: string, houseNumber: string, brkIdentification: ?string}>|null
      */
-    private function collectAddressesFromEditgrid(mixed $rows): ?array
+    private function collectAddressesFromEditgrid(mixed $rows, bool $authoritative): ?array
     {
         if (! is_array($rows) || $rows === []) {
             return null;
@@ -178,12 +195,25 @@ class ServiceFetcher
             }
             $postcode = $addr['postcode'] ?? null;
             $huisnummer = $addr['huisnummer'] ?? null;
-            if (is_string($postcode) && $postcode !== '' && ($huisnummer !== null && $huisnummer !== '')) {
-                $addresses[] = [
-                    'postcode' => $postcode,
-                    'houseNumber' => (string) $huisnummer,
-                ];
+            if (! (is_string($postcode) && $postcode !== '' && $huisnummer !== null && $huisnummer !== '')) {
+                continue;
             }
+
+            $brk = $addr['brkGemeente'] ?? null;
+            $brk = is_string($brk) && $brk !== '' ? $brk : null;
+
+            // Reactieve modus: alleen adressen meenemen waarvan de gemeente al
+            // uit de auto-fill bekend is. Een adres zonder `brkGemeente` zou een
+            // PDOK-lookup vergen; dat stellen we uit tot de gate (authoritative).
+            if (! $authoritative && $brk === null) {
+                continue;
+            }
+
+            $addresses[] = [
+                'postcode' => $postcode,
+                'houseNumber' => (string) $huisnummer,
+                'brkIdentification' => $brk,
+            ];
         }
 
         return $addresses === [] ? null : $addresses;

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -514,7 +514,13 @@ class EventFormPage extends Page implements HasForms
         }
 
         if (in_array($field, ['locatieSOpKaart', 'routesOpKaart', 'adresVanDeGebouwEn'], true)) {
-            $fetcher->fetch('inGemeentenResponse', $this->state);
+            // Reactieve check tijdens het typen/tekenen: adressen tellen alleen
+            // mee als hun gemeente al uit de auto-fill bekend is, zodat deze
+            // synchrone call nooit een trage PDOK-lookup voor een adres doet.
+            // De autoritatieve, volledige check draait op de gate (Volgende) in
+            // `runLocationGate()`. Kaart-items (vlak/lijn) worden hier gewoon
+            // reactief gedetecteerd — die hebben de invoer-race niet.
+            $fetcher->fetch('inGemeentenResponse', $this->state, authoritativeAddresses: false);
             $this->resetStaleGemeenteKeuze();
 
             // Na een succesvolle BAG-lookup kan FormDerivedState een
@@ -528,6 +534,31 @@ class EventFormPage extends Page implements HasForms
             $fetcher->fetch('gemeenteVariabelen', $this->state);
             $fetcher->fetch('evenementenInDeGemeente', $this->state);
         }
+    }
+
+    /**
+     * Autoritatieve gemeentebepaling op de gate (Volgende in de locatiestap).
+     * Draait de volledige location-check over alle huidige inputs (adressen,
+     * vlakken én lijnen), inclusief de PDOK-fallback voor handmatig ingevoerde
+     * adressen zonder bekende gemeente, en werkt de dependent-fetches en de
+     * state-snapshot bij zodat de afgeleide `evenementInGemeente` en de
+     * zichtbaarheidsregels (keuze-radio, bevestigingstekst) direct kloppen.
+     *
+     * De locatiestap (`LocatieVanHetEvenement2Step::afterValidation`) roept dit
+     * aan en beslist daarna op basis van `evenementInGemeente` of de gebruiker
+     * verder mag.
+     */
+    public function runLocationGate(): void
+    {
+        $this->state->absorbFields($this->data ?? []);
+
+        $fetcher = app(ServiceFetcher::class);
+        $fetcher->fetch('inGemeentenResponse', $this->state);
+        $this->resetStaleGemeenteKeuze();
+        $fetcher->fetch('gemeenteVariabelen', $this->state);
+        $fetcher->fetch('evenementenInDeGemeente', $this->state);
+
+        $this->stateSnapshot = $this->serializableSnapshot($this->state);
     }
 
     /**

--- a/tests/Feature/EventForm/Components/AddressNLLookupTest.php
+++ b/tests/Feature/EventForm/Components/AddressNLLookupTest.php
@@ -73,6 +73,33 @@ test('an existing postcode + house number auto-fills street and city', function 
         ->and($component->get("$base.woonplaatsnaam"))->toBe('Nuth');
 });
 
+test('a successful lookup stores the resolved BRK gemeente for the address', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    $base = seedGebouwRow($component);
+
+    $component
+        ->set("$base.postcode", '6361 BZ')
+        ->set("$base.huisnummer", '1');
+
+    // Reused by the location gate so it need not do a second PDOK lookup to
+    // determine this address's gemeente. 'GM' + the PDOK gemeentecode (1954).
+    expect($component->get("$base.brkGemeente"))->toBe('GM1954');
+});
+
+test('a failed lookup clears the stored BRK gemeente', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    $base = seedGebouwRow($component);
+
+    $component
+        ->set("$base.postcode", '6361 BZ')
+        ->set("$base.huisnummer", '1');
+    expect($component->get("$base.brkGemeente"))->toBe('GM1954');
+
+    $component->set("$base.huisnummer", '999');
+
+    expect($component->get("$base.brkGemeente"))->toBeEmpty();
+});
+
 test('changing to a non-existent house number clears the stale street/city and notifies', function () {
     $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
     $base = seedGebouwRow($component);

--- a/tests/Feature/EventForm/Pages/EventFormPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageTest.php
@@ -6,6 +6,7 @@ use App\Enums\MunicipalityVariableType;
 use App\Enums\Role;
 use App\EventForm\Persistence\Draft;
 use App\EventForm\Schema\EventFormSchema;
+use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\State\FormState;
 use App\Filament\Organiser\Pages\EventFormPage;
@@ -14,7 +15,27 @@ use App\Models\MunicipalityVariable;
 use App\Models\Organisation;
 use App\Models\User;
 use Filament\Facades\Filament;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Support\Facades\Http;
 use Livewire\Livewire;
+
+/**
+ * Haal de `afterValidation`-gate-closure van de locatiestap op zodat we 'm
+ * direct met een echte EventFormPage als `$livewire` kunnen aanroepen. Een
+ * volledige wizard-navigatie zou de hele 18-staps wizard renderen en tegen de
+ * memory-limit aanlopen; deze closure bevat de gate-beslislogica geïsoleerd.
+ */
+function locatieGateCallback(): Closure
+{
+    $step = LocatieVanHetEvenement2Step::make();
+    $ref = new ReflectionProperty($step, 'afterValidation');
+    $ref->setAccessible(true);
+
+    /** @var Closure $callback */
+    $callback = $ref->getValue($step);
+
+    return $callback;
+}
 
 beforeEach(function () {
     $this->user = User::factory()->create(['role' => Role::Organiser]);
@@ -346,3 +367,93 @@ test('a draft with a malformed datetime year mounts without crashing', function 
     'five digit year' => '20256-09-20T16:00',
     'six digit year' => '202026-08-22T13:00',
 ]);
+
+test('gate: één gemeente uit een aangevuld adres → doorgelaten zonder tweede PDOK-call', function () {
+    Municipality::firstOrCreate(['brk_identification' => 'GM0917'], ['name' => 'Heerlen']);
+    Http::fake();
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])->instance();
+    $page->data['adresVanDeGebouwEn'] = [
+        'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+            'postcode' => '6411AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0917',
+        ]],
+    ];
+
+    // Mag niet blokkeren: precies één gemeente bepaald.
+    locatieGateCallback()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0917');
+    Http::assertNothingSent();
+});
+
+test('gate: geen locatie-input → blokkeert (Halt) en geen gemeente bepaald', function () {
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])->instance();
+
+    expect(fn () => locatieGateCallback()($page))->toThrow(Halt::class);
+    expect($page->state()->get('evenementInGemeente'))->toBeNull();
+});
+
+test('gate: twee gemeenten zonder keuze blokkeert en toont de keuze-radio; na keuze doorgelaten', function () {
+    Municipality::firstOrCreate(['brk_identification' => 'GM0917'], ['name' => 'Heerlen']);
+    Municipality::firstOrCreate(['brk_identification' => 'GM0935'], ['name' => 'Maastricht']);
+    Http::fake();
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])->instance();
+    $page->data['adresVanDeGebouwEn'] = [
+        'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+            'postcode' => '6411AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0917',
+        ]],
+        'row-2' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+            'postcode' => '6211AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0935',
+        ]],
+    ];
+
+    // Meerdere gemeenten, geen keuze → blokkeren.
+    expect(fn () => locatieGateCallback()($page))->toThrow(Halt::class);
+    // De response staat wél in de state zodat de keuze-radio zichtbaar wordt.
+    expect($page->state()->get('inGemeentenResponse.all.items'))->toHaveCount(2);
+
+    // Nu een gemeente kiezen → doorgelaten.
+    $page->data['userSelectGemeente'] = 'GM0935';
+    locatieGateCallback()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0935');
+    Http::assertNothingSent();
+});
+
+test('gate: een getekend vlak bepaalt de gemeente autoritatief (kaart blijft werken)', function () {
+    Municipality::factory()->create([
+        'brk_identification' => 'GM0999',
+        'name' => 'Testgemeente',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]]}',
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])->instance();
+    $page->data['locatieSOpKaart'] = [
+        'row-1' => [
+            'naamVanDeLocatieKaart' => 'Plein',
+            'buitenLocatieVanHetEvenement' => [
+                'lat' => 0.0, 'lng' => 0.0,
+                'geojson' => [
+                    'type' => 'FeatureCollection',
+                    'features' => [[
+                        'type' => 'Feature',
+                        'properties' => new stdClass,
+                        'geometry' => [
+                            'type' => 'Polygon',
+                            'coordinates' => [[[-0.5, -0.5], [0.5, -0.5], [0.5, 0.5], [-0.5, 0.5], [-0.5, -0.5]]],
+                        ],
+                    ]],
+                ],
+            ],
+        ],
+    ];
+
+    locatieGateCallback()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0999');
+});

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -484,3 +484,34 @@ test('Radio met Closure-options resolveert label uit dynamische bron (#2 Michel:
     expect($waarden)->toContain('Beekdaelen')
         ->and($waarden)->not->toContain('GM1954');
 });
+
+test('the internal brkGemeente of an address does not leak into the report', function () {
+    // The address auto-fill stores the resolved BRK gemeente in a hidden
+    // subfield so the location gate can reuse it. That internal value must
+    // never surface in the human-facing summary/PDF.
+    $state = new FormState(values: [
+        'adresVanDeGebouwEn' => [
+            'row-1' => [
+                'naamVanDeLocatieGebouw' => 'Stadhuis',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6211AA',
+                    'huisnummer' => '1',
+                    'straatnaam' => 'Markt',
+                    'woonplaatsnaam' => 'Maastricht',
+                    'brkGemeente' => 'GM0882',
+                ],
+            ],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [LocatieVanHetEvenement2Step::make()]);
+
+    $flat = (string) json_encode($sections);
+
+    // The address row is genuinely rendered (so the assertion is not vacuous)...
+    expect($flat)->toContain('Stadhuis')
+        ->and($flat)->toContain('Markt')
+        // ...but the internal gemeente value and key stay out of it.
+        ->and($flat)->not->toContain('GM0882')
+        ->and($flat)->not->toContain('brkGemeente');
+});

--- a/tests/Feature/EventForm/Services/LocationServerCheckServiceTest.php
+++ b/tests/Feature/EventForm/Services/LocationServerCheckServiceTest.php
@@ -56,6 +56,25 @@ test('address input resolves to municipality via locatieserver', function () {
         ->and($item['name'])->toBe('Maastricht');
 });
 
+test('a provided brkIdentification is reused without a PDOK lookup', function () {
+    // The address auto-fill already resolved this address's gemeente, so the
+    // location gate passes it through as brkIdentification. The service must
+    // reuse it and skip the (redundant) postcode + house number PDOK lookup.
+    Http::fake();
+
+    $service = new LocationServerCheckService(new LocatieserverService);
+
+    $result = $service->execute(new LocationServerCheckInput(
+        address: ['postcode' => '6211AA', 'houseNumber' => '1', 'brkIdentification' => 'GM0882'],
+    ));
+
+    expect($result['all']['items'])->toHaveCount(1)
+        ->and($result['all']['items'][0]['brk_identification'])->toBe('GM0882')
+        ->and($result['all']['within'])->toBeTrue();
+
+    Http::assertNothingSent();
+});
+
 test('unknown postcode yields within=false and empty items', function () {
     Http::fake([
         'api.pdok.nl/bzk/locatieserver/search/v3_1/free*' => Http::response([

--- a/tests/Feature/EventForm/Services/ServiceFetcherTest.php
+++ b/tests/Feature/EventForm/Services/ServiceFetcherTest.php
@@ -179,6 +179,47 @@ describe('ServiceFetcher inGemeentenResponse', function () {
         $this->fetcher->fetch('inGemeentenResponse', $state);
         Http::assertSentCount(3);
     });
+
+    test('reactive mode reuses the stored brkGemeente without a PDOK lookup', function () {
+        Municipality::factory()->create(['brk_identification' => 'GM0882', 'name' => 'Maastricht']);
+        Http::fake();
+
+        $state = FormState::empty();
+        $state->setField('adresVanDeGebouwEn', [
+            'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                'postcode' => '6211AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0882',
+            ]],
+        ]);
+
+        $this->fetcher->fetch('inGemeentenResponse', $state, authoritativeAddresses: false);
+
+        expect($state->get('inGemeentenResponse.all.items'))->toHaveCount(1)
+            ->and($state->get('inGemeentenResponse.all.items')[0]['brk_identification'])->toBe('GM0882');
+        Http::assertNothingSent();
+    });
+
+    test('reactive mode skips an address whose gemeente is not yet known (no PDOK during typing)', function () {
+        Municipality::factory()->create(['brk_identification' => 'GM0882', 'name' => 'Maastricht']);
+        // A PDOK response is available, but reactive mode must not reach for it:
+        // an address without a stored brkGemeente is left for the gate to resolve.
+        Http::fake([
+            'api.pdok.nl/bzk/locatieserver/search/v3_1/free*' => Http::response([
+                'response' => ['docs' => [['gemeentecode' => '0882', 'gemeentenaam' => 'Maastricht']]],
+            ]),
+        ]);
+
+        $state = FormState::empty();
+        $state->setField('adresVanDeGebouwEn', [
+            'row-1' => ['adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                'postcode' => '6211AA', 'huisnummer' => '1',
+            ]],
+        ]);
+
+        $this->fetcher->fetch('inGemeentenResponse', $state, authoritativeAddresses: false);
+
+        expect($state->get('inGemeentenResponse'))->toBeNull();
+        Http::assertNothingSent();
+    });
 });
 
 describe('ServiceFetcher unknown variable', function () {

--- a/tests/Playwright/scenario-adres-autofill-en-melding.spec.mjs
+++ b/tests/Playwright/scenario-adres-autofill-en-melding.spec.mjs
@@ -103,11 +103,17 @@ test('een niet-bestaand adres maakt straat/plaats leeg en toont een melding', as
 });
 
 // Bevinding A: bij twee locaties gaat de autofill van (in deze run) de tweede
-// rij verloren — straat/plaats blijven leeg terwijl ze server-side wél bepaald
-// worden. Oorzaak is de gemeente-detect re-render die met de autofill-$set
-// botst (zelfde raceklasse als scenario-locatie-route-behoudt-velden). Welke
-// rij het slachtoffer is hangt van timing af. Fixme tot de gemeente-detect
-// re-render geïsoleerd is van de adresvelden.
+// rij verloren. De gemeente-detect voor adressen doet nu géén tweede PDOK-call
+// meer per commit (reactief wordt de al bekende gemeente uit de auto-fill
+// hergebruikt; de autoritatieve bepaling gebeurt op de gate bij Volgende), en
+// een niet-aangevuld adres kan altijd handmatig worden ingevuld want straat en
+// plaats zijn verplichte velden — de gebruiker komt dus nooit vast te zitten.
+// Wat blijft is de onderliggende Livewire-re-render-race: een commit van de ene
+// rij rendert het formulier opnieuw en wist daarbij de nog niet gesynchroniseerde
+// invoer van de andere rij, los van hoe goedkoop de fetch is. Bij Playwright's
+// instant-`fill()` (het strengste geval, strenger dan menselijk typen) treedt dat
+// nog op. Een deterministische fix vraagt het isoleren van de repeater-re-render
+// van de gemeente-updates; fixme tot dat er is.
 test.fixme('bevinding A: beide locatie-rijen vullen straat/plaats automatisch aan', async ({ page }) => {
     test.setTimeout(180_000);
     await totLocatieGebouw(page);


### PR DESCRIPTION
## Why

The gemeente detection on the Locatie step was reactive and ran per keystroke. Each change to an address triggered a full location check with an external PDOK call plus PostGIS, and the hard requirement ("a gemeente must be determined before the organiser can continue") rested on that fragile, reactively maintained value. Addresses also did two PDOK calls for the same address: one in the auto-fill and one in the detection.

## What changed

1. **Authoritative gate.** The Locatie step now computes the gemeente itself when the organiser clicks Volgende, over addresses, polygons and lines together. It blocks on zero gemeenten, passes on one, and on two or more shows the choice radio and blocks until the organiser picks one. The requirement no longer depends on the per-keystroke mechanism.
2. **Address gemeente reuse.** The address auto-fill already resolves the BRK gemeente. It is stored in a hidden `brkGemeente` subfield and reused by the location check, so a second PDOK lookup for the same address is skipped. Manually entered addresses (auto-fill did not resolve) still fall back to the postcode plus house number lookup, once, on the gate.
3. **Cheaper reactive path.** While typing, address gemeente detection no longer does a PDOK lookup: the reactive check only counts addresses whose gemeente is already known from the auto-fill. Maps (polygons and lines) stay reactively detected, so drawing a shape still updates the confirmation live.
4. **No leak.** The internal `brkGemeente` is a hidden field, excluded from the submission summary/PDF and ignored by the ZGW submit, verified by a test.

## Branch strategy

Branched from `main` so a new beta can be cut from it and merged back into `next/v1.2`.

## Verification

- Full `EventForm` Pest suite green (519 tests), including the equivalence and intersect suites (no regression on the OpenForms derived visibility rules or the route flow).
- New tests: gate decisions (0/1/many, and a drawn polygon resolving on the gate), address gemeente reuse without a PDOK call, reactive mode skipping an unknown address, and the report leak check.
- Playwright: the single address auto-fill and the "no address found" notification scenarios pass against the running app.

## Known limitation (bevinding A)

The reported symptom, where the auto-fill of one of two address rows is sometimes lost, is a Livewire re-render race: a commit of one row re-renders the form and wipes the not yet synchronised input of the other row, regardless of how cheap the fetch is. This change removes the redundant PDOK call and guarantees a gemeente is always determined (and street and city are required, so the organiser can always continue), but it does not deterministically eliminate that framework level re-render race at Playwright instant-fill speed. The Playwright scenario stays a `fixme` with an updated comment. A deterministic fix requires isolating the repeater re-render from the gemeente updates, which is a larger change.