### PR TITLE
Update woweb/laravel-zgw-client to v1.2.3

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10897,16 +10897,16 @@
         },
         {
             "name": "woweb/laravel-zgw-client",
-            "version": "v1.2.2",
+            "version": "v1.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WowebNL/laravel-zgw-client.git",
-                "reference": "1c67993c8c1895085e3c54014fa300a7243998d8"
+                "reference": "8fb792973ceb88b5d76454d0090409e1b847c697"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/1c67993c8c1895085e3c54014fa300a7243998d8",
-                "reference": "1c67993c8c1895085e3c54014fa300a7243998d8",
+                "url": "https://api.github.com/repos/WowebNL/laravel-zgw-client/zipball/8fb792973ceb88b5d76454d0090409e1b847c697",
+                "reference": "8fb792973ceb88b5d76454d0090409e1b847c697",
                 "shasum": ""
             },
             "require": {
@@ -10964,9 +10964,9 @@
             ],
             "support": {
                 "issues": "https://github.com/WowebNL/laravel-zgw-client/issues",
-                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.2"
+                "source": "https://github.com/WowebNL/laravel-zgw-client/tree/v1.2.3"
             },
-            "time": "2026-07-03T10:46:58+00:00"
+            "time": "2026-07-14T12:53:43+00:00"
         },
         {
             "name": "woweb/openzaak",


### PR DESCRIPTION
Updates `woweb/laravel-zgw-client` from v1.2.2 to [v1.2.3](https://github.com/WowebNL/laravel-zgw-client/releases/tag/v1.2.3).

That release fixes the document lock request (and the catalogi publish actions) sending `[]` as the JSON body where the ZGW spec defines no request body. Open Zaak rejected that with a 400 "Ongeldige data. Verwacht een dictionary, kreeg een list.", which broke every "Nieuwe versie" document upload on staging.

Fixed upstream in WowebNL/laravel-zgw-client#31; the `NewDocumentVersionActionTest` and `NewDocumentVersionUnlockTest` suites pass against the updated package.