### PR TITLE
Include coordinators in the assignable reviewer list

### DIFF
--- a/app/Models/Users/MunicipalityUser.php
+++ b/app/Models/Users/MunicipalityUser.php
@@ -47,7 +47,7 @@ class MunicipalityUser extends User implements FilamentUser, HasTenants
     #[Scope]
     protected function reviewers(Builder $query): void
     {
-        $query->whereIn('role', [Role::Reviewer, Role::ReviewerMunicipalityAdmin]);
+        $query->whereIn('role', [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator]);
     }
 
     #[Scope]

--- a/tests/Feature/CoordinatorRoleTest.php
+++ b/tests/Feature/CoordinatorRoleTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Pages\ViewZaak;
 use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
@@ -12,7 +13,12 @@ use App\Notifications\NewZaak;
 use App\Policies\CoordinatorUserPolicy;
 use App\Policies\ZaakPolicy;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Notification;
+use Tests\Fakes\ZgwHttpFake;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->municipality = Municipality::factory()->create(['name' => 'Test Municipality']);
@@ -331,5 +337,95 @@ describe('CoordinatorUser model', function () {
         User::factory()->create(['role' => Role::Reviewer]);
 
         expect(CoordinatorUser::count())->toBe(1);
+    });
+});
+
+// --- Coordinator assignable as reviewer ---
+
+describe('coordinator assignable as reviewer', function () {
+    it('includes coordinators in the municipality reviewer users', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+        $reviewer->municipalities()->attach($this->municipality);
+
+        $reviewerAdmin = User::factory()->create(['role' => Role::ReviewerMunicipalityAdmin]);
+        $reviewerAdmin->municipalities()->attach($this->municipality);
+
+        $municipalityAdmin = User::factory()->create(['role' => Role::MunicipalityAdmin]);
+        $municipalityAdmin->municipalities()->attach($this->municipality);
+
+        $ids = $this->municipality->allReviewerUsers()->get()->pluck('id');
+
+        expect($ids)->toContain($coordinator->id)
+            ->toContain($reviewer->id)
+            ->toContain($reviewerAdmin->id)
+            ->not->toContain($municipalityAdmin->id);
+    });
+
+    it('lets a coordinator assign themselves as reviewer on a zaak', function () {
+        Notification::fake();
+        Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+        Filament::setCurrentPanel(Filament::getPanel('municipality'));
+
+        $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+        ZgwHttpFake::wildcardFake();
+
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        $zaak = Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'organisation_id' => $this->organisation->id,
+            'zgw_zaak_url' => $zgwZaakUrl,
+        ]);
+
+        $this->actingAs($coordinator);
+        Filament::setTenant($this->municipality);
+
+        livewire(ViewZaak::class, ['record' => $zaak->id])
+            ->assertOk()
+            ->callAction('assign_reviewer', data: [
+                'reviewer_user_id' => $coordinator->id,
+            ])
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        expect($zaak->refresh()->reviewer_user_id)->toBe($coordinator->id);
+        Notification::assertSentTo([$coordinator], AssignedToZaak::class);
+    });
+
+    it('does not offer a municipality admin as assignable reviewer', function () {
+        Notification::fake();
+        Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+        Filament::setCurrentPanel(Filament::getPanel('municipality'));
+
+        $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+        ZgwHttpFake::wildcardFake();
+
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        $municipalityAdmin = User::factory()->create(['role' => Role::MunicipalityAdmin]);
+        $municipalityAdmin->municipalities()->attach($this->municipality);
+
+        $zaak = Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'organisation_id' => $this->organisation->id,
+            'zgw_zaak_url' => $zgwZaakUrl,
+        ]);
+
+        $this->actingAs($coordinator);
+        Filament::setTenant($this->municipality);
+
+        livewire(ViewZaak::class, ['record' => $zaak->id])
+            ->assertOk()
+            ->callAction('assign_reviewer', data: [
+                'reviewer_user_id' => $municipalityAdmin->id,
+            ])
+            ->assertHasActionErrors(['reviewer_user_id']);
+
+        expect($zaak->refresh()->reviewer_user_id)->toBeNull();
     });
 });


### PR DESCRIPTION
## Problem

Feedback from municipalities: when a coordinator opens the "assign reviewer" action on a zaak, the select does not list any coordinators, including their own account. Since the coordinator role is meant to be a handling manager (behandelaar-beheerder) who can also handle cases themselves, they should be assignable as reviewer.

## Cause

The `reviewers()` scope on `MunicipalityUser` only matched `Role::Reviewer` and `Role::ReviewerMunicipalityAdmin`. The assign reviewer select builds its options from `Municipality::allReviewerUsers()`, which uses that scope, so coordinators were excluded. Filament also validates the submitted value against the options, so a coordinator could not be assigned at all.

## Fix

Add `Role::Coordinator` to the `reviewers()` scope. This fixes all consumers of the scope in one place:

- The assign reviewer select on the zaak view now lists coordinators.
- Coordinators who participate in a thread are no longer filtered out of the notification recipients in `Thread` (latent bug).
- Coordinators are included in the organiser-side fallback `Result` notifications, consistent with the role also being a handler.

The coordinator-priority logic in `Zaak::getMunicipalityHandlers()` is unaffected: its reviewer fallback only runs when the municipality has no coordinators, so adding coordinators to the scope changes nothing there. `MunicipalityAdmin` (pure administrator role) intentionally remains non-assignable.

## Tests

- `Municipality::allReviewerUsers()` includes coordinators and still excludes pure municipality admins.
- A coordinator can assign themselves as reviewer via the `assign_reviewer` action and receives the `AssignedToZaak` notification.
- Assigning a pure municipality admin is rejected by validation.