### PR TITLE
Show coordinators in admin reviewer list and fix advisory user search

### DIFF
--- a/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReviewerUsersRelationManager.php
+++ b/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReviewerUsersRelationManager.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReviewerUsersRelationManager extends RelationManager
 {
-    protected static string $relationship = 'reviewerUsers';
+    protected static string $relationship = 'allReviewerUsers';
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string
     {

--- a/app/Filament/Shared/Resources/AdvisorUsers/Tables/AdvisorUserTable.php
+++ b/app/Filament/Shared/Resources/AdvisorUsers/Tables/AdvisorUserTable.php
@@ -45,8 +45,7 @@ class AdvisorUserTable
                             ->title(__('resources/advisor_user.columns.role.notification'))
                             ->success()
                             ->send();
-                    })
-                    ->searchable(),
+                    }),
                 TextColumn::make('created_at')
                     ->dateTime()
                     ->sortable()

--- a/tests/Feature/Filament/Admin/Resources/AdvisoryResourceTest.php
+++ b/tests/Feature/Filament/Admin/Resources/AdvisoryResourceTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Enums\AdvisoryRole;
 use App\Enums\Role;
 use App\Filament\Admin\Resources\AdvisoryResource;
 use App\Filament\Admin\Resources\AdvisoryResource\Pages\CreateAdvisory;
@@ -169,6 +170,23 @@ test('admin can access users relation manager', function () {
         'pageClass' => EditAdvisory::class,
     ])
         ->assertOk();
+});
+
+test('admin can search advisor users by name in users relation manager', function () {
+    $advisory = Advisory::factory()->create();
+    $alpha = User::factory()->create(['first_name' => 'Alpha', 'last_name' => 'Advisor', 'role' => Role::Advisor]);
+    $beta = User::factory()->create(['first_name' => 'Beta', 'last_name' => 'Advisor', 'role' => Role::Advisor]);
+    $advisory->users()->attach($alpha, ['role' => AdvisoryRole::Member]);
+    $advisory->users()->attach($beta, ['role' => AdvisoryRole::Member]);
+
+    livewire(UsersRelationManager::class, [
+        'ownerRecord' => $advisory,
+        'pageClass' => EditAdvisory::class,
+    ])
+        ->assertCanSeeTableRecords([$alpha, $beta])
+        ->searchTable('Alpha')
+        ->assertCanSeeTableRecords([$alpha])
+        ->assertCanNotSeeTableRecords([$beta]);
 });
 
 test('admin can attach advisor user to advisory', function () {

--- a/tests/Feature/Filament/Admin/Resources/MunicipalityResourceTest.php
+++ b/tests/Feature/Filament/Admin/Resources/MunicipalityResourceTest.php
@@ -178,6 +178,37 @@ test('admin can access reviewer users relation manager', function () {
         ->assertOk();
 });
 
+test('reviewer users relation manager includes coordinators and reviewer municipality admins', function () {
+    $municipality = Municipality::factory()->create();
+
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+    $reviewerAdmin = User::factory()->create(['role' => Role::ReviewerMunicipalityAdmin]);
+    $municipalityAdmin = User::factory()->create(['role' => Role::MunicipalityAdmin]);
+    $municipality->users()->attach([$reviewer->id, $coordinator->id, $reviewerAdmin->id, $municipalityAdmin->id]);
+
+    livewire(ReviewerUsersRelationManager::class, [
+        'ownerRecord' => $municipality,
+        'pageClass' => EditMunicipality::class,
+    ])
+        ->assertCanSeeTableRecords([$reviewer, $coordinator, $reviewerAdmin])
+        ->assertCanNotSeeTableRecords([$municipalityAdmin]);
+});
+
+test('admin can change a coordinator role in the reviewer users relation manager', function () {
+    $municipality = Municipality::factory()->create();
+    $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+    $municipality->users()->attach($coordinator);
+
+    livewire(ReviewerUsersRelationManager::class, [
+        'ownerRecord' => $municipality,
+        'pageClass' => EditMunicipality::class,
+    ])
+        ->call('updateTableColumnState', 'role', $coordinator->getKey(), Role::Reviewer->value);
+
+    expect($coordinator->fresh()->role)->toBe(Role::Reviewer);
+});
+
 test('admin can access variables relation manager', function () {
     $municipality = Municipality::factory()->create();
 


### PR DESCRIPTION
## Summary

Two small fixes for the admin panel.

### Include coordinators in the reviewer users list
The reviewer users relation manager on the municipality page in the admin panel used the `reviewerUsers` relation, which is globally scoped to the `reviewer` role only. Municipality admins already see coordinators and reviewer municipality admins in their own panel. The relation manager now uses the existing `allReviewerUsers` relation, so platform admins see the same list as municipality admins and can change a coordinator's role from the table.

### Fix search error in the advisory users table
Searching in the advisory users table (admin and municipality panel) threw a `QueryException` on production. The `pivot.role` select column was marked searchable, so any search generated SQL referencing a non-existent `pivot` column (Filament treats the dot notation as a JSON path on PostgreSQL). The column is no longer searchable; searching by name still works.

Both fixes are covered by new tests that fail without the fix and pass with it.