### PR TITLE
Allow coordinators to finish a zaak, upload documents and view the activity log

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
@@ -450,7 +450,7 @@ class ViewZaak extends ViewRecord
                 ->closeModalByClickingAway(false)
                 ->modalSubmitAction(false)
                 ->modalCancelAction(false)
-                ->visible(fn (Zaak $record) => ! $record->reference_data->resultaat && ! $record->is_imported && in_array(auth()->user()->role, [Role::Reviewer, Role::ReviewerMunicipalityAdmin])),
+                ->visible(fn (Zaak $record) => ! $record->reference_data->resultaat && ! $record->is_imported && in_array(auth()->user()->role, [Role::Reviewer, Role::Coordinator, Role::ReviewerMunicipalityAdmin])),
         ];
     }
 

--- a/app/Policies/ZaakPolicy.php
+++ b/app/Policies/ZaakPolicy.php
@@ -75,7 +75,7 @@ class ZaakPolicy
 
         return match ($user->role) {
             /** @phpstan-ignore-next-line */
-            Role::Reviewer, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin => $user->canAccessMunicipality($zaak->zaaktype->municipality_id),
+            Role::Reviewer, Role::Coordinator, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin => $user->canAccessMunicipality($zaak->zaaktype->municipality_id),
             /** @phpstan-ignore-next-line */
             Role::Organiser => $user->canAccessOrganisation($zaak->organisation_id),
             Role::Admin => true,

--- a/app/Policies/ZaakPolicy.php
+++ b/app/Policies/ZaakPolicy.php
@@ -56,7 +56,7 @@ class ZaakPolicy
     {
         return match ($user->role) {
             /** @phpstan-ignore-next-line */
-            Role::Reviewer, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin => $user->canAccessMunicipality($zaak->zaaktype->municipality_id),
+            Role::Reviewer, Role::Coordinator, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin => $user->canAccessMunicipality($zaak->zaaktype->municipality_id),
             Role::Admin => true,
             default => false,
         };

--- a/tests/Feature/CoordinatorRoleTest.php
+++ b/tests/Feature/CoordinatorRoleTest.php
@@ -136,6 +136,62 @@ describe('ZaakPolicy for coordinator', function () {
 
         expect($this->policy->view($coordinator, $this->zaak))->toBeFalse();
     });
+
+    it('allows coordinator in same municipality to upload a document', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        expect($this->policy->uploadDocument($coordinator, $this->zaak))->toBeTrue();
+    });
+
+    it('denies coordinator in different municipality from uploading a document', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->otherMunicipality);
+
+        expect($this->policy->uploadDocument($coordinator, $this->zaak))->toBeFalse();
+    });
+});
+
+// --- Coordinator can finish a zaak ---
+
+describe('coordinator can finish a zaak', function () {
+    beforeEach(function () {
+        Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+        Filament::setCurrentPanel(Filament::getPanel('municipality'));
+
+        $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+        ZgwHttpFake::wildcardFake();
+
+        $this->zaak = Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'organisation_id' => $this->organisation->id,
+            'zgw_zaak_url' => $zgwZaakUrl,
+        ]);
+    });
+
+    it('shows the finish zaak action to a coordinator', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        $this->actingAs($coordinator);
+        Filament::setTenant($this->municipality);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionVisible('finish_zaak');
+    });
+
+    it('hides the finish zaak action from a municipality admin', function () {
+        $municipalityAdmin = User::factory()->create(['role' => Role::MunicipalityAdmin]);
+        $municipalityAdmin->municipalities()->attach($this->municipality);
+
+        $this->actingAs($municipalityAdmin);
+        Filament::setTenant($this->municipality);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('finish_zaak');
+    });
 });
 
 // --- getMunicipalityHandlers ---

--- a/tests/Feature/CoordinatorRoleTest.php
+++ b/tests/Feature/CoordinatorRoleTest.php
@@ -150,6 +150,20 @@ describe('ZaakPolicy for coordinator', function () {
 
         expect($this->policy->uploadDocument($coordinator, $this->zaak))->toBeFalse();
     });
+
+    it('allows coordinator in same municipality to view the activity log', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        expect($this->policy->viewActivity($coordinator, $this->zaak))->toBeTrue();
+    });
+
+    it('denies coordinator in different municipality from viewing the activity log', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->otherMunicipality);
+
+        expect($this->policy->viewActivity($coordinator, $this->zaak))->toBeFalse();
+    });
 });
 
 // --- Coordinator can finish a zaak ---


### PR DESCRIPTION
The Coordinator role was missing from three authorization checks, leaving coordinators with fewer rights on a zaak than intended. They could already change a zaak status, which made the gaps inconsistent.

## Changes

- `ZaakPolicy::uploadDocument()` now allows `Role::Coordinator`, scoped to their own municipality. This restores both the upload button and the "Nieuwe versie" action on the documents tab, which were hidden because both actions authorize against this policy method.
- `ZaakPolicy::viewActivity()` now allows `Role::Coordinator`, scoped to their own municipality. This restores the "Bekijk activiteiten" action on the zaak view page.
- The `finish_zaak` action on `ViewZaak` is now visible to coordinators, alongside reviewers and reviewer municipality admins.

`UploadDocumentAction` already accounted for the Coordinator role when building the confidentiality options, but that code was unreachable because the policy blocked the action first.

## Tests

Six tests added to `CoordinatorRoleTest`, covering document upload and activity log access (allowed in the own municipality, denied in another) and the visibility of the finish action (shown to a coordinator, hidden from a municipality admin). Verified that the new tests fail without the changes.