### PR TITLE
Keep the "Mijn omgeving" placeholder out of the submission PDF

### DIFF
--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -270,6 +270,17 @@ class EventFormPage extends Page implements HasForms
             $this->state->setVariable($field, $value);
         };
 
+        // Een persoonlijke organisatie draagt de placeholder-naam "Mijn
+        // omgeving". Die wordt niet meer voorgevuld, maar concepten van
+        // vóór die wijziging hebben 'm nog in hun opgeslagen state staan.
+        // De hele fieldset "Organisatie informatie" is verborgen zolang er
+        // geen KvK-nummer is, dus de organisator kan hier zelf nooit iets
+        // hebben ingevuld: wat er staat is altijd oude prefill.
+        $organisation = $this->state->get('authOrganisation');
+        if ($organisation instanceof Organisation && $organisation->isPersonal()) {
+            $this->state->setVariable('watIsDeNaamVanUwOrganisatie', '');
+        }
+
         // OF-rule RuleF56a54dd — user-velden uit session.
         $copy('eventloketSession.user_first_name', 'watIsUwVoornaam');
         $copy('eventloketSession.user_last_name', 'watIsUwAchternaam');

--- a/app/Jobs/Submit/GenerateSubmissionPdf.php
+++ b/app/Jobs/Submit/GenerateSubmissionPdf.php
@@ -54,14 +54,13 @@ final class GenerateSubmissionPdf implements ShouldQueue
         $this->zaak->loadMissing(['zaaktype', 'organisation', 'organiserUser']);
 
         // Een aanvraag op persoonlijke titel hangt aan een organisatie met
-        // de placeholder-naam "Mijn omgeving". Die naam hoort niet in het
-        // inzendingsbewijs; de organisator is dan de persoon zelf, net als
-        // in MapFormStateToReferenceData.
+        // de placeholder-naam "Mijn omgeving". Er is dan geen organisator
+        // om te tonen — de aanvrager staat al op de regel eronder — dus
+        // blijft de regel helemaal weg uit de header.
         $organisation = $this->zaak->organisation;
-        $aanvragerNaam = $this->zaak->organiserUser?->name;
         $organisatorNaam = ($organisation !== null && ! $organisation->isPersonal())
             ? $organisation->name
-            : ($aanvragerNaam !== null && $aanvragerNaam !== '' ? $aanvragerNaam : '—');
+            : null;
 
         $pdf = Pdf::loadView('pdf.submission-report', [
             'zaak' => $this->zaak,

--- a/app/Jobs/Submit/GenerateSubmissionPdf.php
+++ b/app/Jobs/Submit/GenerateSubmissionPdf.php
@@ -51,8 +51,21 @@ final class GenerateSubmissionPdf implements ShouldQueue
         // is gegeven en wanneer.
         $akkoordGegeven = $state->get('akkoordVerwerkingGegevens') === true;
 
+        $this->zaak->loadMissing(['zaaktype', 'organisation', 'organiserUser']);
+
+        // Een aanvraag op persoonlijke titel hangt aan een organisatie met
+        // de placeholder-naam "Mijn omgeving". Die naam hoort niet in het
+        // inzendingsbewijs; de organisator is dan de persoon zelf, net als
+        // in MapFormStateToReferenceData.
+        $organisation = $this->zaak->organisation;
+        $aanvragerNaam = $this->zaak->organiserUser?->name;
+        $organisatorNaam = ($organisation !== null && ! $organisation->isPersonal())
+            ? $organisation->name
+            : ($aanvragerNaam !== null && $aanvragerNaam !== '' ? $aanvragerNaam : '—');
+
         $pdf = Pdf::loadView('pdf.submission-report', [
-            'zaak' => $this->zaak->loadMissing(['zaaktype', 'organisation']),
+            'zaak' => $this->zaak,
+            'organisatorNaam' => $organisatorNaam,
             'state' => $state,
             'sections' => $sections,
             'gemeenteNaam' => $gemeenteNaam,

--- a/resources/views/pdf/submission-report.blade.php
+++ b/resources/views/pdf/submission-report.blade.php
@@ -52,7 +52,7 @@
         @if (! empty($gemeenteNaam))
             <div><strong>Gemeente:</strong> {{ $gemeenteNaam }}</div>
         @endif
-        <div><strong>Organisator:</strong> {{ $zaak->organisation?->name ?? '—' }}</div>
+        <div><strong>Organisator:</strong> {{ $organisatorNaam }}</div>
         <div><strong>Aanvrager:</strong> {{ $zaak->organiserUser?->name ?? '—' }}</div>
         <div><strong>Ingediend op:</strong> {{ $zaak->created_at?->timezone('Europe/Amsterdam')->translatedFormat('j F Y H:i') }}</div>
     </div>

--- a/resources/views/pdf/submission-report.blade.php
+++ b/resources/views/pdf/submission-report.blade.php
@@ -52,7 +52,9 @@
         @if (! empty($gemeenteNaam))
             <div><strong>Gemeente:</strong> {{ $gemeenteNaam }}</div>
         @endif
-        <div><strong>Organisator:</strong> {{ $organisatorNaam }}</div>
+        @if (! empty($organisatorNaam))
+            <div><strong>Organisator:</strong> {{ $organisatorNaam }}</div>
+        @endif
         <div><strong>Aanvrager:</strong> {{ $zaak->organiserUser?->name ?? '—' }}</div>
         <div><strong>Ingediend op:</strong> {{ $zaak->created_at?->timezone('Europe/Amsterdam')->translatedFormat('j F Y H:i') }}</div>
     </div>

--- a/tests/Feature/EventForm/Pages/EventFormPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\MunicipalityVariableType;
+use App\Enums\OrganisationType;
 use App\Enums\Role;
 use App\EventForm\Persistence\Draft;
 use App\EventForm\Schema\EventFormSchema;
@@ -456,4 +457,46 @@ test('gate: een getekend vlak bepaalt de gemeente autoritatief (kaart blijft wer
     locatieGateCallback()($page);
 
     expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0999');
+});
+
+test('mount clears the "Mijn omgeving" placeholder left in an old draft of a personal organisation', function () {
+    $this->organisation->update([
+        'type' => OrganisationType::Personal,
+        'name' => 'Mijn omgeving',
+    ]);
+
+    // Concept van vóór de fix: de placeholder staat al in de opgeslagen state.
+    $this->draft->update([
+        'state' => (new FormState(values: [
+            'watIsDeNaamVanUwOrganisatie' => 'Mijn omgeving',
+        ]))->toSnapshot(),
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
+    expect($page->state()->get('watIsDeNaamVanUwOrganisatie'))->toBe('');
+});
+
+test('mount keeps the organisation name for a business organisation', function () {
+    $this->organisation->update([
+        'type' => OrganisationType::Business,
+        'name' => 'Media Tuin',
+        'coc_number' => '12345678',
+    ]);
+
+    $this->draft->update([
+        'state' => (new FormState(values: [
+            'watIsDeNaamVanUwOrganisatie' => 'Media Tuin',
+        ]))->toSnapshot(),
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
+    expect($page->state()->get('watIsDeNaamVanUwOrganisatie'))->toBe('Media Tuin');
 });

--- a/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
+++ b/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
@@ -18,10 +18,10 @@
  */
 
 use App\Enums\OrganisationType;
+use App\Enums\Role;
 use App\EventForm\State\FormState;
 use App\Jobs\Submit\GenerateSubmissionPdf;
 use App\Jobs\Submit\SendSubmissionConfirmationEmail;
-use App\Enums\Role;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;

--- a/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
+++ b/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
@@ -17,9 +17,13 @@
  * kunnen downloaden/in de mail zien.
  */
 
+use App\Enums\OrganisationType;
 use App\EventForm\State\FormState;
 use App\Jobs\Submit\GenerateSubmissionPdf;
 use App\Jobs\Submit\SendSubmissionConfirmationEmail;
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
@@ -139,4 +143,87 @@ test('risicoClassificatie wordt berekend uit de 14 risicoscan-velden en in de PD
     // (na JSON-deserialisatie van '0') eerder als "ontbrekend veld" werd gezien.
     $loadedState = FormState::fromSnapshot($zaak->fresh()->form_state_snapshot ?? []);
     expect($loadedState->get('risicoClassificatie'))->toBe('A');
+});
+
+/**
+ * Haalt de zichtbare tekst uit een dompdf-PDF: alle FlateDecode-streams
+ * decomprimeren en de null-bytes van de 16-bit glyph-IDs strippen, zodat
+ * een gewone str_contains werkt. Zelfde aanpak als in
+ * GenerateSubmissionPdfIntegrationTest.
+ */
+function tekstUitPdf(string $pdfBytes): string
+{
+    $tekst = '';
+    if (preg_match_all('/stream\s*\n(.*?)\nendstream/s', $pdfBytes, $matches)) {
+        foreach ($matches[1] as $stream) {
+            $decompressed = @gzuncompress($stream);
+            if ($decompressed !== false) {
+                $tekst .= str_replace("\x00", '', $decompressed);
+            }
+        }
+    }
+
+    return $tekst;
+}
+
+/**
+ * @param  array<string, mixed>  $organisationAttributes
+ */
+function pdfVoorOrganisatie(array $organisationAttributes, string $voornaam, string $achternaam): string
+{
+    $organisation = Organisation::factory()->create($organisationAttributes);
+    $zaaktype = Zaaktype::factory()->create(['name' => 'Evenementenvergunning']);
+    $organiser = User::factory()->create([
+        'first_name' => $voornaam,
+        'last_name' => $achternaam,
+        'name' => "{$voornaam} {$achternaam}",
+        'role' => Role::Organiser,
+    ]);
+
+    $state = new FormState(values: [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest Testlaan',
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'public_id' => 'ZAAK-ORG-1',
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => $organisation->id,
+        'organiser_user_id' => $organiser->id,
+        'form_state_snapshot' => $state->toSnapshot(),
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '2026-06-14T14:00:00+02:00',
+            eind_evenement: '2026-06-14T18:00:00+02:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ingediend',
+            statustype_url: '',
+            risico_classificatie: 'A',
+            naam_locatie_eveneme: 'Buurtcentrum De Hoek',
+            naam_evenement: 'Buurtfeest Testlaan',
+        ),
+    ]);
+
+    Queue::fake();
+
+    (new GenerateSubmissionPdf($zaak))->handle();
+
+    return tekstUitPdf(Storage::disk('local')->get("zaken/{$zaak->id}/aanvraagformulier.pdf"));
+}
+
+test('toont de persoonsnaam als organisator bij een aanvraag op persoonlijke titel', function () {
+    $tekst = pdfVoorOrganisatie([
+        'type' => OrganisationType::Personal,
+        'name' => 'Mijn omgeving',
+    ], 'Noah', 'Vermeulen');
+
+    expect($tekst)->not->toContain('Mijn omgeving')
+        ->and($tekst)->toContain('Noah Vermeulen');
+});
+
+test('toont de organisatienaam als organisator bij een zakelijke aanvraag', function () {
+    $tekst = pdfVoorOrganisatie([
+        'type' => OrganisationType::Business,
+        'name' => 'Media Tuin',
+    ], 'Noah', 'Vermeulen');
+
+    expect($tekst)->toContain('Media Tuin');
 });

--- a/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
+++ b/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
@@ -209,13 +209,16 @@ function pdfVoorOrganisatie(array $organisationAttributes, string $voornaam, str
     return tekstUitPdf(Storage::disk('local')->get("zaken/{$zaak->id}/aanvraagformulier.pdf"));
 }
 
-test('toont de persoonsnaam als organisator bij een aanvraag op persoonlijke titel', function () {
+test('laat de organisator-regel weg bij een aanvraag op persoonlijke titel', function () {
     $tekst = pdfVoorOrganisatie([
         'type' => OrganisationType::Personal,
         'name' => 'Mijn omgeving',
     ], 'Noah', 'Vermeulen');
 
+    // De organisator-regel verdwijnt volledig; de aanvrager staat er nog wel.
     expect($tekst)->not->toContain('Mijn omgeving')
+        ->and($tekst)->not->toContain('Organisator:')
+        ->and($tekst)->toContain('Aanvrager:')
         ->and($tekst)->toContain('Noah Vermeulen');
 });
 
@@ -225,5 +228,6 @@ test('toont de organisatienaam als organisator bij een zakelijke aanvraag', func
         'name' => 'Media Tuin',
     ], 'Noah', 'Vermeulen');
 
-    expect($tekst)->toContain('Media Tuin');
+    expect($tekst)->toContain('Organisator:')
+        ->and($tekst)->toContain('Media Tuin');
 });


### PR DESCRIPTION
An organiser applying "op persoonlijke titel" is attached to an organisation carrying the placeholder name "Mijn omgeving". PR #422 suppressed that name in the form prefill (`FormSessionService`) and in the zaak reference data (`MapFormStateToReferenceData`), but the PDF template was never part of that change. It read `$zaak->organisation->name` directly, bypassing the reference data, so every personal submission still showed `Organisator: Mijn omgeving` in the header of the submission PDF. That is the behaviour still seen in production, and it is not related to Horizon not being terminated during the rollout: the placeholder is present in the current code path regardless of which worker renders it.

## Changes

- `GenerateSubmissionPdf` resolves the organiser name itself and passes it to the template, which no longer reaches into the relationship. For a business application that is the organisation name. For a personal application there is no organiser to name, so the whole "Organisator" line is left out of the header. The applicant is already on the "Aanvrager" line right below it, so repeating that person as the organiser would only add noise.
- `EventFormPage::applySessionPrefill()` clears `watIsDeNaamVanUwOrganisatie` when the tenant is a personal organisation. Drafts started before #422 still hold the placeholder in their stored state, and the prefill only fills empty fields, so it survived into the answers section of the PDF and into the ZGW zaakeigenschap `organisatie_naam`. The "Organisatie informatie" fieldset is hidden while there is no chamber of commerce number, so an organiser can never have typed a value there themselves, which makes clearing it safe.

## Note for the rollout

The PDF is generated once at submission time and stored at `zaken/{uuid}/aanvraagformulier.pdf`. Already submitted cases keep their existing PDF; correcting those would need a separate one-off action (regenerating the file and replacing the document in OpenZaak).

## Tests

Two tests on `GenerateSubmissionPdf` assert the rendered PDF text: a personal application no longer contains "Mijn omgeving" nor an "Organisator" line, while the applicant is still listed, and a business application still shows the organisation name. Two tests on `EventFormPage` cover the draft cleanup and confirm a business organisation name is left untouched. Verified that the new failure cases fail without the changes. The full `tests/Feature/EventForm` suite passes (394 tests).