### PR TITLE
Name the four municipality roles consistently

### DIFF
--- a/app/Enums/Role.php
+++ b/app/Enums/Role.php
@@ -8,8 +8,8 @@ enum Role: string implements HasLabel
 {
     case Admin = 'admin'; // Platformbeheerder
     case MunicipalityAdmin = 'municipality_admin'; // Gemeentelijk beheerder
-    case ReviewerMunicipalityAdmin = 'reviewer_municipality_admin'; // Behandelaar en gemeentelijk beheerder
-    case Coordinator = 'coordinator'; // Coördinator (behandelaar-beheerder)
+    case ReviewerMunicipalityAdmin = 'reviewer_municipality_admin'; // Gemeentelijk beheerder (+behandelaar)
+    case Coordinator = 'coordinator'; // Coördinator (+behandelaar)
     case Reviewer = 'reviewer'; // Behandelaar
     case Advisor = 'advisor'; // Adviesdienst medewerker
     case Organiser = 'organiser'; // Organisator

--- a/lang/nl/enums/role.php
+++ b/lang/nl/enums/role.php
@@ -8,10 +8,10 @@ return [
         'label' => 'Gemeentelijk beheerder',
     ],
     'reviewer_municipality_admin' => [
-        'label' => 'Gemeentelijk beheerder (behandelaar)',
+        'label' => 'Gemeentelijk beheerder (+behandelaar)',
     ],
     'coordinator' => [
-        'label' => 'Coördinator',
+        'label' => 'Coördinator (+behandelaar)',
     ],
     'reviewer' => [
         'label' => 'Behandelaar',

--- a/lang/nl/resources/reviewer_admin_user.php
+++ b/lang/nl/resources/reviewer_admin_user.php
@@ -1,8 +1,8 @@
 <?php
 
 return [
-    'label' => 'Behandelaar met beheerdersrechten',
-    'plural_label' => 'Behandelaren met beheerdersrechten',
+    'label' => 'Gemeentelijk beheerder (+behandelaar)',
+    'plural_label' => 'Gemeentelijk beheerders (+behandelaar)',
 
     'columns' => [
 

--- a/lang/nl/resources/reviewer_user.php
+++ b/lang/nl/resources/reviewer_user.php
@@ -28,7 +28,7 @@ return [
                 ],
                 'is_coordinator' => [
                     'label' => 'Uitnodigen als coördinator',
-                    'helper_text' => 'Vink dit aan als de behandelaar zaken moet kunnen verdelen onder behandelaars. Een coördinator ontvangt meldingen van nieuwe zaken en wijst behandelaars toe, maar behandelt zaken niet zelf.',
+                    'helper_text' => 'Vink dit aan als de behandelaar zaken moet kunnen verdelen onder behandelaars. Een coördinator ontvangt meldingen van nieuwe zaken en wijst behandelaars toe, en behandelt daarnaast zelf ook zaken.',
                 ],
             ],
             'notification' => [

--- a/resources/views/filament/infolists/components/thread-messages-entry.blade.php
+++ b/resources/views/filament/infolists/components/thread-messages-entry.blade.php
@@ -24,32 +24,26 @@
                                             <p class="text-sm font-medium ">
                                                 {{ $message->user->name }}
                                             </p>
+                                            {{-- The role name comes from the Role enum so it stays in
+                                                 step with the labels used elsewhere in the application.
+                                                 The organisation behind it depends on the role. --}}
+                                            @php
+                                                $roleLabel = $message->user->role?->getLabel();
+                                                $roleContext = match ($message->user->role) {
+                                                    \App\Enums\Role::MunicipalityAdmin,
+                                                    \App\Enums\Role::ReviewerMunicipalityAdmin,
+                                                    \App\Enums\Role::Coordinator,
+                                                    \App\Enums\Role::Reviewer => $message->user->municipalities->pluck('name')->join(', '),
+                                                    \App\Enums\Role::Advisor => $message->user->advisories->pluck('name')->join(', '),
+                                                    \App\Enums\Role::Organiser => $message->user->organisations->pluck('name')->join(', '),
+                                                    default => null,
+                                                };
+                                                $roleDescription = filled($roleContext)
+                                                    ? "{$roleLabel} bij {$roleContext}"
+                                                    : $roleLabel;
+                                            @endphp
                                             <p class="text-sm text-gray-500 dark:text-gray-400">
-                                                @switch($message->user->role)
-                                                    @case(\App\Enums\Role::Admin)
-                                                        Platformbeheerder
-                                                        @break
-
-                                                    @case(\App\Enums\Role::MunicipalityAdmin)
-                                                    @case(\App\Enums\Role::ReviewerMunicipalityAdmin)
-                                                        Gemeentelijk beheerder bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
-                                                        @break
-
-                                                    @case(\App\Enums\Role::Reviewer)
-                                                        Behandelaar bij {{ $message->user->municipalities->pluck('name')->join(', ') }}
-                                                        @break
-
-                                                    @case(\App\Enums\Role::Advisor)
-                                                        Adviseur bij {{ $message->user->advisories->pluck('name')->join(', ') }}
-                                                        @break
-
-                                                    @case(\App\Enums\Role::Organiser)
-                                                        Organisator bij {{ $message->user->organisations->pluck('name')->join(', ') }}
-                                                        @break
-
-                                                    @default
-                                                        Default case...
-                                                @endswitch
+                                                {{ $roleDescription }}
                                             </p>
                                         </div>
                                         <div>

--- a/tests/Feature/Threads/AdviceThreadTest.php
+++ b/tests/Feature/Threads/AdviceThreadTest.php
@@ -819,3 +819,30 @@ test('sends new advice thread message notifications to all advisory admins of un
         NewAdviceThreadMessage::class,
     );
 });
+
+// The message header names the author's role via the Role enum, so a
+// coordinator no longer falls through to the placeholder default that the
+// hard-coded switch used to render.
+test('advice thread page names the role of a coordinator who posted a message', function () {
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+
+    $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+    $this->municipality->users()->attach($coordinator);
+
+    Message::create([
+        'thread_id' => $this->adviceThread->id,
+        'user_id' => $coordinator->id,
+        'body' => 'Ik verdeel deze zaak.',
+    ]);
+
+    $this->actingAs($this->reviewer);
+    Filament::setTenant($this->municipality);
+
+    livewire(ViewAdviceThread::class, [
+        'record' => $this->adviceThread->id,
+        'parentRecord' => $this->zaak,
+    ])
+        ->assertSuccessful()
+        ->assertSee('Coördinator (+behandelaar) bij Test Municipality')
+        ->assertDontSee('Default case');
+});

--- a/tests/Feature/Users/RoleLabelTest.php
+++ b/tests/Feature/Users/RoleLabelTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The four municipality roles are named consistently across the whole
+ * application: every screen resolves them through Role::getLabel(), so
+ * pinning the labels here catches a rename in one panel that was not
+ * carried through to the others.
+ */
+
+use App\Enums\Role;
+
+test('the municipality roles carry their agreed labels', function (Role $role, string $label) {
+    expect($role->getLabel())->toBe($label);
+})->with([
+    'behandelaar' => [Role::Reviewer, 'Behandelaar'],
+    'coördinator' => [Role::Coordinator, 'Coördinator (+behandelaar)'],
+    'gemeentelijk beheerder' => [Role::MunicipalityAdmin, 'Gemeentelijk beheerder'],
+    'gemeentelijk beheerder met behandelaarsrol' => [Role::ReviewerMunicipalityAdmin, 'Gemeentelijk beheerder (+behandelaar)'],
+]);
+
+test('every role resolves a label instead of falling back to its translation key', function () {
+    foreach (Role::cases() as $role) {
+        expect($role->getLabel())
+            ->not->toContain('enums/role')
+            ->and($role->getLabel())->not->toBe('');
+    }
+});


### PR DESCRIPTION
The roles a municipality user can hold were labelled inconsistently. The coordinator was named "Coördinator" without hinting that the role handles cases as well, and the combined role read "Gemeentelijk beheerder (behandelaar)". The agreed naming is:

- Behandelaar
- Coördinator (+behandelaar)
- Gemeentelijk beheerder
- Gemeentelijk beheerder (+behandelaar)

## Changes

Every screen resolves these through `Role::getLabel()`, so updating the enum translations covers the selects, filters, tables, the activity log and the document confidentiality options in one go. Two places named a role outside that path and were brought in line:

- The relation manager listing combined users on a municipality read "Behandelaren met beheerdersrechten" and now uses the role name.
- The message header in a thread hard-coded the role names in a switch that had no case for a coordinator, so a coordinator's message was labelled with the literal placeholder "Default case...". It now resolves the label from the enum and appends the municipality, advisory or organisation behind it, which also means future roles no longer need a case of their own.

The helper text on the coordinator invite still claimed a coordinator does not handle cases itself. That contradicts both the new label and the rights the role actually has, so it was rewritten.

## Tests

A dataset test pins the four labels, and a second test asserts every role resolves a label instead of falling back to its translation key, so a missing entry in the language file fails loudly. One test on the advice thread page covers the message header for a coordinator: the role is named and the old placeholder is gone.