### PR TITLE
Let handlers claim and release a zaak themselves

### DIFF
--- a/app/Filament/Shared/Pages/EditProfile.php
+++ b/app/Filament/Shared/Pages/EditProfile.php
@@ -15,6 +15,7 @@ use App\Notifications\NewOrganiserThreadMessage;
 use App\Notifications\NewZaak;
 use App\Notifications\NewZaakDocument;
 use App\Notifications\Result;
+use App\Notifications\ZaakReleased;
 use App\Notifications\ZaakStatusChanged;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\TextInput;
@@ -64,6 +65,7 @@ class EditProfile extends \Filament\Auth\Pages\EditProfile
             Role::MunicipalityAdmin => [],
             Role::Coordinator => [
                 NewZaak::class,
+                ZaakReleased::class,
                 NewOrganiserThread::class,
                 NewOrganiserThreadMessage::class,
                 NewZaakDocument::class,
@@ -72,6 +74,7 @@ class EditProfile extends \Filament\Auth\Pages\EditProfile
             Role::Reviewer => [
                 NewZaak::class,
                 AssignedToZaak::class,
+                ZaakReleased::class,
                 NewAdviceThreadMessage::class,
                 NewOrganiserThread::class,
                 NewOrganiserThreadMessage::class,

--- a/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
@@ -13,6 +13,7 @@ use App\Models\Users\MunicipalityUser;
 use App\Models\Zaak;
 use App\Notifications\AssignedToZaak;
 use App\Notifications\Result;
+use App\Notifications\ZaakReleased;
 use App\ValueObjects\FinishZaakObject;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use App\ValueObjects\ZGW\BesluitType;
@@ -81,6 +82,76 @@ class ViewZaak extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
+            Action::make('claim_zaak')
+                ->label(__('municipality/resources/zaak.header_actions.claim_zaak.label'))
+                ->icon('heroicon-o-hand-raised')
+                ->color('gray')
+                ->requiresConfirmation()
+                ->modalHeading(__('municipality/resources/zaak.header_actions.claim_zaak.confirmation.title'))
+                ->modalDescription(__('municipality/resources/zaak.header_actions.claim_zaak.confirmation.description'))
+                ->visible(fn (Zaak $record) => ! $record->is_imported
+                    && ! $record->reference_data->resultaat
+                    && ! $record->reviewer_user_id
+                    && in_array(auth()->user()->role, [Role::Reviewer, Role::Coordinator, Role::ReviewerMunicipalityAdmin]))
+                ->action(function (Zaak $record) {
+                    // Guard against a colleague claiming between page load and click.
+                    $record->refresh();
+
+                    if ($record->reviewer_user_id) {
+                        Notification::make()
+                            ->warning()
+                            ->title(__('municipality/resources/zaak.header_actions.claim_zaak.notification.already_assigned'))
+                            ->send();
+
+                        $this->dispatch('refreshZaak');
+
+                        return;
+                    }
+
+                    $record->reviewer_user_id = auth()->id();
+                    $record->save();
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('municipality/resources/zaak.header_actions.claim_zaak.notification.claimed'))
+                        ->send();
+
+                    $this->dispatch('refreshZaak');
+                }),
+            Action::make('release_zaak')
+                ->label(__('municipality/resources/zaak.header_actions.release_zaak.label'))
+                ->icon('heroicon-o-user-minus')
+                ->color('gray')
+                ->requiresConfirmation()
+                ->modalHeading(__('municipality/resources/zaak.header_actions.release_zaak.confirmation.title'))
+                ->modalDescription(__('municipality/resources/zaak.header_actions.release_zaak.confirmation.description'))
+                ->visible(fn (Zaak $record) => ! $record->is_imported
+                    && ! $record->reference_data->resultaat
+                    && $record->reviewer_user_id === auth()->id()
+                    && in_array(auth()->user()->role, [Role::Reviewer, Role::Coordinator, Role::ReviewerMunicipalityAdmin]))
+                ->action(function (Zaak $record) {
+                    $releasedBy = auth()->user();
+
+                    $record->reviewer_user_id = null;
+                    $record->save();
+
+                    // With no reviewer assigned this resolves to the coordinators,
+                    // or falls back to all reviewers when the municipality has none.
+                    foreach ($record->getMunicipalityHandlers() as $handler) {
+                        if ($handler->id === $releasedBy->id) {
+                            continue;
+                        }
+
+                        $handler->notify(new ZaakReleased($record, $releasedBy));
+                    }
+
+                    Notification::make()
+                        ->success()
+                        ->title(__('municipality/resources/zaak.header_actions.release_zaak.notification.released'))
+                        ->send();
+
+                    $this->dispatch('refreshZaak');
+                }),
             Action::make('assign_reviewer')
                 ->label(fn (Zaak $record) => $record->reviewer_user_id
                     ? __('municipality/resources/zaak.header_actions.assign_reviewer.label_change')

--- a/app/Notifications/ZaakReleased.php
+++ b/app/Notifications/ZaakReleased.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Models\User;
+use App\Models\Zaak;
+use Filament\Actions\Action;
+use Filament\Notifications\Notification as FilamentNotification;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Notifications\Messages\MailMessage;
+
+class ZaakReleased extends BaseNotification
+{
+    private string $eventName;
+
+    private string $municipalityName;
+
+    private string $releasedByName;
+
+    public function __construct(
+        protected Zaak $zaak,
+        User $releasedBy,
+    ) {
+        $this->eventName = $zaak->reference_data->naam_evenement;
+        $this->municipalityName = $zaak->municipality->name;
+        $this->releasedByName = $releasedBy->name;
+    }
+
+    public static function getLabel(): string|Htmlable|null
+    {
+        return __('notification/zaak-released.label');
+    }
+
+    public function toMail(User $notifiable): MailMessage
+    {
+        return (new MailMessage)
+            ->subject(__('notification/zaak-released.mail.subject', [
+                'event' => $this->eventName,
+                'municipality' => $this->municipalityName,
+            ]))
+            ->markdown('mail.zaak-released', [
+                'event' => $this->eventName,
+                'municipality' => $this->municipalityName,
+                'releasedBy' => $this->releasedByName,
+                'viewUrl' => route('filament.municipality.resources.zaken.view', [
+                    'tenant' => $this->zaak->zaaktype->municipality_id,
+                    'record' => $this->zaak->id,
+                ]),
+            ]);
+    }
+
+    public function toDatabase(User $notifiable): array
+    {
+        return FilamentNotification::make()
+            ->title(__('notification/zaak-released.database.title', [
+                'event' => $this->eventName,
+                'releasedBy' => $this->releasedByName,
+            ]))
+            ->actions([
+                Action::make('view')
+                    ->label(__('View'))
+                    ->url(route('filament.municipality.resources.zaken.view', [
+                        'tenant' => $this->zaak->zaaktype->municipality_id,
+                        'record' => $this->zaak->id,
+                    ]))
+                    ->markAsRead(),
+            ])
+            ->getDatabaseMessage();
+    }
+
+    public function logSubject(): Model
+    {
+        return $this->zaak;
+    }
+}

--- a/lang/nl/municipality/resources/zaak.php
+++ b/lang/nl/municipality/resources/zaak.php
@@ -40,6 +40,27 @@ return [
         ],
     ],
     'header_actions' => [
+        'claim_zaak' => [
+            'label' => 'Zaak oppakken',
+            'confirmation' => [
+                'title' => 'Zaak oppakken',
+                'description' => 'U wordt behandelaar van deze zaak. Weet u het zeker?',
+            ],
+            'notification' => [
+                'claimed' => 'U bent nu behandelaar van deze zaak',
+                'already_assigned' => 'Deze zaak is inmiddels al aan een behandelaar toegewezen',
+            ],
+        ],
+        'release_zaak' => [
+            'label' => 'Zaak vrijgeven',
+            'confirmation' => [
+                'title' => 'Zaak vrijgeven',
+                'description' => 'U wordt verwijderd als behandelaar en de zaak komt terug in de werkvoorraad. De coördinatoren worden geïnformeerd.',
+            ],
+            'notification' => [
+                'released' => 'Zaak vrijgegeven',
+            ],
+        ],
         'assign_reviewer' => [
             'label' => 'Behandelaar toewijzen',
             'label_change' => 'Behandelaar wijzigen',

--- a/lang/nl/notification/zaak-released.php
+++ b/lang/nl/notification/zaak-released.php
@@ -1,0 +1,16 @@
+<?php
+
+return [
+    'label' => 'Zaak vrijgegeven',
+
+    'mail' => [
+        'subject' => 'Zaak ":event" is vrijgegeven',
+        'greeting' => 'Zaak vrijgegeven',
+        'body' => ':releasedBy heeft de behandeling van de zaak voor ":event" bij :municipality vrijgegeven. De zaak heeft momenteel geen behandelaar.',
+        'button' => 'Zaak bekijken',
+    ],
+
+    'database' => [
+        'title' => ':releasedBy heeft zaak ":event" vrijgegeven',
+    ],
+];

--- a/resources/views/mail/zaak-released.blade.php
+++ b/resources/views/mail/zaak-released.blade.php
@@ -1,0 +1,9 @@
+<x-mail::message>
+# {{ __('notification/zaak-released.mail.greeting') }}
+
+{{ __('notification/zaak-released.mail.body', ['event' => $event, 'municipality' => $municipality, 'releasedBy' => $releasedBy]) }}
+
+<x-mail::button :url="$viewUrl">
+    {{ __('notification/zaak-released.mail.button') }}
+</x-mail::button>
+</x-mail::message>

--- a/tests/Feature/ClaimReleaseZaakTest.php
+++ b/tests/Feature/ClaimReleaseZaakTest.php
@@ -1,0 +1,349 @@
+<?php
+
+use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Pages\ViewZaak;
+use App\Models\Municipality;
+use App\Models\NotificationPreference;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\Notifications\ZaakReleased;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Notification;
+use Tests\Fakes\ZgwHttpFake;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->municipality = Municipality::factory()->create(['name' => 'Test Municipality']);
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->municipality->id]);
+    $this->organisation = Organisation::factory()->create();
+
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+
+    $this->zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $this->zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $this->zgwZaakUrl,
+    ]);
+
+    $this->makeUser = function (Role $role): User {
+        $user = User::factory()->create(['role' => $role]);
+        $user->municipalities()->attach($this->municipality);
+
+        return $user;
+    };
+
+    $this->actAs = function (User $user) {
+        $this->actingAs($user);
+        Filament::setTenant($this->municipality);
+    };
+});
+
+describe('claim zaak visibility', function () {
+    it('shows the claim action to handling roles on an unassigned zaak', function (Role $role) {
+        ($this->actAs)(($this->makeUser)($role));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionVisible('claim_zaak');
+    })->with([
+        'reviewer' => Role::Reviewer,
+        'coordinator' => Role::Coordinator,
+        'reviewer municipality admin' => Role::ReviewerMunicipalityAdmin,
+    ]);
+
+    it('hides the claim action from a municipality admin', function () {
+        ($this->actAs)(($this->makeUser)(Role::MunicipalityAdmin));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('claim_zaak');
+    });
+
+    it('hides the claim action when the zaak is assigned to a colleague', function () {
+        $colleague = ($this->makeUser)(Role::Reviewer);
+        $this->zaak->update(['reviewer_user_id' => $colleague->id]);
+
+        ($this->actAs)(($this->makeUser)(Role::Reviewer));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('claim_zaak');
+    });
+
+    it('hides the claim action when the zaak is already assigned to the user themselves', function () {
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $this->zaak->update(['reviewer_user_id' => $reviewer->id]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('claim_zaak');
+    });
+
+    it('hides the claim action when the zaak has a resultaat', function () {
+        $this->zaak->update([
+            'reference_data' => new ZaakReferenceData(
+                start_evenement: now(),
+                eind_evenement: now()->addDay(),
+                registratiedatum: now(),
+                status_name: 'Afgerond',
+                statustype_url: '',
+                resultaat: 'Verleend',
+            ),
+        ]);
+
+        ($this->actAs)(($this->makeUser)(Role::Reviewer));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('claim_zaak');
+    });
+
+    it('hides the claim action on an imported zaak', function () {
+        $importedZaak = Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'organisation_id' => $this->organisation->id,
+            'zgw_zaak_url' => null,
+            'imported_data' => ['bron' => 'import'],
+        ]);
+
+        ($this->actAs)(($this->makeUser)(Role::Reviewer));
+
+        livewire(ViewZaak::class, ['record' => $importedZaak->id])
+            ->assertOk()
+            ->assertActionHidden('claim_zaak');
+    });
+});
+
+describe('claim zaak behaviour', function () {
+    it('assigns the zaak to the acting user without sending notifications', function () {
+        Notification::fake();
+
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->callAction('claim_zaak')
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        expect($this->zaak->refresh()->reviewer_user_id)->toBe($reviewer->id);
+        Notification::assertNothingSent();
+    });
+
+    it('does not overwrite a colleague who claimed the zaak in the meantime', function () {
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $colleague = ($this->makeUser)(Role::Reviewer);
+
+        ($this->actAs)($reviewer);
+
+        $page = livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk();
+
+        // A colleague claims the zaak after the page was loaded but before the click.
+        Zaak::whereKey($this->zaak->id)->update(['reviewer_user_id' => $colleague->id]);
+
+        $page->callAction('claim_zaak');
+
+        expect($this->zaak->refresh()->reviewer_user_id)->toBe($colleague->id);
+    });
+});
+
+describe('release zaak visibility', function () {
+    it('shows the release action only to the assigned handler themselves', function (Role $role) {
+        $user = ($this->makeUser)($role);
+        $this->zaak->update(['reviewer_user_id' => $user->id]);
+
+        ($this->actAs)($user);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionVisible('release_zaak');
+    })->with([
+        'reviewer' => Role::Reviewer,
+        'coordinator' => Role::Coordinator,
+        'reviewer municipality admin' => Role::ReviewerMunicipalityAdmin,
+    ]);
+
+    it('hides the release action when the zaak is unassigned', function () {
+        ($this->actAs)(($this->makeUser)(Role::Reviewer));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('release_zaak');
+    });
+
+    it('hides the release action when the zaak is assigned to a colleague', function () {
+        $colleague = ($this->makeUser)(Role::Reviewer);
+        $this->zaak->update(['reviewer_user_id' => $colleague->id]);
+
+        ($this->actAs)(($this->makeUser)(Role::Reviewer));
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('release_zaak');
+    });
+
+    it('hides the release action when the zaak has a resultaat', function () {
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $this->zaak->update([
+            'reviewer_user_id' => $reviewer->id,
+            'reference_data' => new ZaakReferenceData(
+                start_evenement: now(),
+                eind_evenement: now()->addDay(),
+                registratiedatum: now(),
+                status_name: 'Afgerond',
+                statustype_url: '',
+                resultaat: 'Verleend',
+            ),
+        ]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->assertActionHidden('release_zaak');
+    });
+});
+
+describe('release zaak behaviour', function () {
+    it('unassigns the zaak and notifies the coordinators, not the releasing user', function () {
+        Notification::fake();
+
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $coordinator = ($this->makeUser)(Role::Coordinator);
+        $this->zaak->update(['reviewer_user_id' => $reviewer->id]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->callAction('release_zaak')
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        expect($this->zaak->refresh()->reviewer_user_id)->toBeNull();
+        Notification::assertSentTo([$coordinator], ZaakReleased::class);
+        Notification::assertNotSentTo([$reviewer], ZaakReleased::class);
+    });
+
+    it('falls back to notifying the other reviewers when the municipality has no coordinators', function () {
+        Notification::fake();
+
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $otherReviewer = ($this->makeUser)(Role::ReviewerMunicipalityAdmin);
+        $this->zaak->update(['reviewer_user_id' => $reviewer->id]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->callAction('release_zaak')
+            ->assertHasNoActionErrors();
+
+        expect($this->zaak->refresh()->reviewer_user_id)->toBeNull();
+        Notification::assertSentTo([$otherReviewer], ZaakReleased::class);
+        Notification::assertNotSentTo([$reviewer], ZaakReleased::class);
+    });
+
+    it('succeeds without notifications when the releasing user is the only handler', function () {
+        Notification::fake();
+
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $this->zaak->update(['reviewer_user_id' => $reviewer->id]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->callAction('release_zaak')
+            ->assertHasNoActionErrors()
+            ->assertNotified();
+
+        expect($this->zaak->refresh()->reviewer_user_id)->toBeNull();
+        Notification::assertNothingSent();
+    });
+
+    it('respects a coordinator preference that disables the notification', function () {
+        Notification::fake();
+
+        $reviewer = ($this->makeUser)(Role::Reviewer);
+        $coordinator = ($this->makeUser)(Role::Coordinator);
+        $this->zaak->update(['reviewer_user_id' => $reviewer->id]);
+
+        NotificationPreference::create([
+            'user_id' => $coordinator->id,
+            'notification_class' => ZaakReleased::class,
+            'channels' => [],
+        ]);
+
+        ($this->actAs)($reviewer);
+
+        livewire(ViewZaak::class, ['record' => $this->zaak->id])
+            ->assertOk()
+            ->callAction('release_zaak')
+            ->assertHasNoActionErrors();
+
+        Notification::assertNotSentTo([$coordinator], ZaakReleased::class);
+    });
+});
+
+describe('ZaakReleased notification', function () {
+    beforeEach(function () {
+        $this->zaak->update([
+            'reference_data' => new ZaakReferenceData(
+                start_evenement: now(),
+                eind_evenement: now()->addDay(),
+                registratiedatum: now(),
+                status_name: 'Ontvangen',
+                statustype_url: '',
+                risico_classificatie: 'A',
+                naam_locatie_eveneme: 'Test locatie',
+                naam_evenement: 'Test Event',
+            ),
+        ]);
+
+        $this->releasedBy = User::factory()->create([
+            'role' => Role::Reviewer,
+            'first_name' => 'Test',
+            'last_name' => 'Behandelaar',
+        ]);
+    });
+
+    it('generates correct mail content', function () {
+        $coordinator = ($this->makeUser)(Role::Coordinator);
+        $notification = new ZaakReleased($this->zaak->refresh(), $this->releasedBy);
+        $mail = $notification->toMail($coordinator);
+
+        expect($mail->subject)->toBe('Zaak "Test Event" is vrijgegeven');
+        expect($mail->markdown)->toBe('mail.zaak-released');
+        expect($mail->viewData['event'])->toBe('Test Event');
+        expect($mail->viewData['municipality'])->toBe('Test Municipality');
+        expect($mail->viewData['releasedBy'])->toBe($this->releasedBy->name);
+        expect($mail->viewData['viewUrl'])->toContain(
+            route('filament.municipality.resources.zaken.view', [
+                'tenant' => $this->municipality->id,
+                'record' => $this->zaak->id,
+            ])
+        );
+    });
+
+    it('generates correct database notification content', function () {
+        $coordinator = ($this->makeUser)(Role::Coordinator);
+        $notification = new ZaakReleased($this->zaak->refresh(), $this->releasedBy);
+        $database = $notification->toDatabase($coordinator);
+
+        expect($database['title'])->toBe($this->releasedBy->name.' heeft zaak "Test Event" vrijgegeven');
+    });
+});


### PR DESCRIPTION
## Context

Since the coordinator role was introduced (#389), assignment is done explicitly via `reviewer_user_id` and the `assign_reviewer` action, which is only available to coordinators and admins. A plain reviewer could no longer put a zaak on their own name, something that previously happened as a side effect of changing the status to "in behandeling".

## Changes

Two new header actions on the zaak view page, available to the handling roles (reviewer, coordinator, reviewer municipality admin), both with a confirmation modal:

- **Zaak oppakken**: assigns an unassigned zaak to the acting user. Only possible when no handler is assigned yet (taking over a colleague's zaak remains a coordinator action), with a guard against a colleague claiming it concurrently. No notification is sent, since the claimer is the assignee.
- **Zaak vrijgeven**: available only on a zaak assigned to the acting user themselves. Unassigns it so it returns to the unassigned pool, and notifies the coordinators via a new `ZaakReleased` notification (falling back to all reviewers when the municipality has no coordinators, mirroring `getMunicipalityHandlers()`).

`ZaakReleased` is registered in the profile notification preferences for coordinators and reviewers, so users can disable it per channel like any other notification.

The working stock filters, navigation badges and activity log pick these changes up automatically since they already key off `reviewer_user_id`. Covered by a new `ClaimReleaseZaakTest` suite (visibility per role, claim/release behaviour, notification fallback and preferences).