### PR TITLE
Show event locations column instead of event types in zaken table

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
+++ b/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
@@ -104,8 +104,8 @@ class ZakenTable
                     ->searchable()
                     ->forceSearchCaseInsensitive(),
 
-                TextColumn::make('reference_data.types_evenement')
-                    ->label(__('resources/zaak.columns.types_evenement.label'))
+                TextColumn::make('reference_data.locaties_evenement')
+                    ->label(__('resources/zaak.columns.locaties_evenement.label'))
                     ->badge()
                     ->sortable()
                     ->toggleable(isToggledHiddenByDefault: true)


### PR DESCRIPTION
The zaken table listed the event types (`types_evenement`) column. This replaces it with the event locations (`locaties_evenement`) column, using the corresponding translation key that already exists in the language files.

## Changes
- `ZakenTable`: swap the `reference_data.types_evenement` column for `reference_data.locaties_evenement`, with its matching label.