### PR TITLE
Fix fatal TypeError when an organiser views a zaak without an organisation

### DIFF
--- a/app/Models/Users/OrganiserUser.php
+++ b/app/Models/Users/OrganiserUser.php
@@ -23,8 +23,12 @@ class OrganiserUser extends User implements FilamentUser, HasTenants
         return $this->belongsToMany(Organisation::class, 'organisation_user')->withPivot('role');
     }
 
-    public function canAccessOrganisation(int $organisationId, ?OrganisationRole $role = null): bool
+    public function canAccessOrganisation(?int $organisationId, ?OrganisationRole $role = null): bool
     {
+        if ($organisationId === null) {
+            return false;
+        }
+
         $query = $this->organisations()
             ->wherePivot('organisation_id', $organisationId);
 

--- a/tests/Feature/Users/OrganiserUserCanAccessOrganisationTest.php
+++ b/tests/Feature/Users/OrganiserUserCanAccessOrganisationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Users\OrganiserUser;
+
+test('canAccessOrganisation returns false when organisation id is null', function () {
+    $user = User::factory()->create(['role' => Role::Organiser]);
+    $organiser = OrganiserUser::findOrFail($user->id);
+
+    // A zaak without a linked organisation must never be accessible, and must
+    // not throw a TypeError (see Sentry EVENTLOKET-T).
+    expect($organiser->canAccessOrganisation(null))->toBeFalse();
+    expect($organiser->canAccessOrganisation(null, OrganisationRole::Admin))->toBeFalse();
+});
+
+test('canAccessOrganisation returns true for an attached organisation', function () {
+    $user = User::factory()->create(['role' => Role::Organiser]);
+    $organiser = OrganiserUser::findOrFail($user->id);
+
+    $organisation = Organisation::factory()->create();
+    $organiser->organisations()->attach($organisation, ['role' => OrganisationRole::Admin->value]);
+
+    expect($organiser->canAccessOrganisation($organisation->id))->toBeTrue();
+    expect($organiser->canAccessOrganisation($organisation->id, OrganisationRole::Admin))->toBeTrue();
+});
+
+test('canAccessOrganisation returns false for an organisation the user is not attached to', function () {
+    $user = User::factory()->create(['role' => Role::Organiser]);
+    $organiser = OrganiserUser::findOrFail($user->id);
+
+    $organisation = Organisation::factory()->create();
+
+    expect($organiser->canAccessOrganisation($organisation->id))->toBeFalse();
+});


### PR DESCRIPTION
## Problem

When an organiser opens the infolist of a zaak that has no linked organisation, the whole view crashes with a fatal error: `OrganiserUser::canAccessOrganisation(): Argument #1 ($organisationId) must be of type int, null given`.

The `zaken.organisation_id` column is nullable. Two `visible()` closures in `ZaakInfolist` call `$user->canAccessOrganisation($record->organisation_id)`, but the method only accepted a non-null int, so a zaak without an organisation throws.

The same latent crash exists in `ZaakPolicy` and `OrganiserThreadPolicy`, which also pass a potentially null `$zaak->organisation_id`.

## Solution

`canAccessOrganisation()` now accepts a nullable id and returns `false` when null. This is semantically correct: an organiser can never access a zaak that has no organisation. Handling it in one place covers every call site at once.

## Tests

New tests for `canAccessOrganisation`: null returns false, an attached organisation returns true, and an organisation the user is not attached to returns false.