### PR TITLE
Fix fatal error in advisor inbox for advice threads of deleted zaken

### DIFF
--- a/app/Filament/Advisor/Widgets/AdviceThreadInboxWidget.php
+++ b/app/Filament/Advisor/Widgets/AdviceThreadInboxWidget.php
@@ -39,7 +39,7 @@ class AdviceThreadInboxWidget extends TableWidget
     {
         return AdviceThreadsTable::configure($table)
             /** @phpstan-ignore-next-line */
-            ->query(fn (): Builder => AdviceThread::query()->advice()->where('advisory_id', Filament::getTenant()->id)->where('advice_status', '!=', AdviceStatus::Concept))
+            ->query(fn (): Builder => AdviceThread::query()->advice()->whereHas('zaak')->where('advisory_id', Filament::getTenant()->id)->where('advice_status', '!=', AdviceStatus::Concept))
             ->columns([
                 TextColumn::make('zaak.reference_data.naam_evenement')
                     ->label(__('resources/advice_thread.columns.event.label'))

--- a/tests/Feature/Advisor/AdviceThreadVisibilityTest.php
+++ b/tests/Feature/Advisor/AdviceThreadVisibilityTest.php
@@ -383,6 +383,43 @@ test('assign action is visible for advisory admin', function () {
         ->assertTableActionVisible('assign', $thread);
 });
 
+test('AdviceThreadInboxWidget hides threads whose zaak was soft deleted and renders without error', function () {
+    Filament::setCurrentPanel(Filament::getPanel('advisor'));
+    $this->actingAs($this->advisor);
+    Filament::setTenant($this->advisory);
+
+    $liveThread = AdviceThread::forceCreate([
+        'zaak_id' => $this->zaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => AdviceStatus::Asked,
+        'advice_due_at' => now()->addDays(7),
+        'created_by' => null,
+        'title' => 'Live Zaak Thread',
+    ]);
+
+    $deletedZaak = Zaak::factory()->create(['zaaktype_id' => $this->zaaktype->id]);
+    $orphanThread = AdviceThread::forceCreate([
+        'zaak_id' => $deletedZaak->id,
+        'type' => ThreadType::Advice,
+        'advisory_id' => $this->advisory->id,
+        'advice_status' => AdviceStatus::Asked,
+        'advice_due_at' => now()->addDays(7),
+        'created_by' => null,
+        'title' => 'Orphaned Thread',
+    ]);
+
+    // Soft delete the zaak: building the row URL requires the zaak, so an
+    // orphaned thread would otherwise crash the widget (Sentry EVENTLOKET-20).
+    $deletedZaak->delete();
+
+    livewire(AdviceThreadInboxWidget::class)
+        ->assertSuccessful()
+        ->filterTable('unread', 'all')
+        ->assertCanSeeTableRecords([$liveThread])
+        ->assertCanNotSeeTableRecords([$orphanThread]);
+});
+
 test('assign action is hidden for advisory member', function () {
     Filament::setCurrentPanel(Filament::getPanel('advisor'));
     $this->actingAs($this->advisor); // $this->advisor is a Member in beforeEach


### PR DESCRIPTION
## Problem

The advisor dashboard crashes with a fatal error: `Missing required parameter for [Route: filament.advisor.resources.zaken.advice-threads.view] ... [Missing parameter: zaak]`.

`Zaak` uses `SoftDeletes`. The `zaak()` relation excludes soft-deleted zaken, so for an advice thread whose zaak was soft-deleted, `$record->zaak` is `null` (the `zaak_id` column stays set).

The `AdviceThreadInboxWidget` query only filtered on `advisory_id` and `advice_status` (columns on the `threads` table) and did not require the zaak to still exist. Such orphaned threads stayed in the inbox, and building their row URL with `'zaak' => $record->zaak` (null) leaves the required `{zaak}` route parameter empty, crashing the whole widget.

The municipality and organiser inbox widgets do not have this problem, because they scope their query through the zaak relation (`whereHas('zaak...')`) and filter orphaned threads out implicitly.

## Solution

Add `whereHas('zaak')` to the widget query so threads whose zaak was soft-deleted (or is otherwise missing) are excluded from the advisor inbox. This matches the other two panels. It is semantically correct: when a zaak is deleted, its view is unreachable anyway.

## Tests

New test in `AdviceThreadVisibilityTest`: a thread with a soft-deleted zaak is hidden and the widget renders without an exception, while a thread with a live zaak stays visible. Verified that the test fails without the fix on the crashing line.