### PR TITLE
Send identifying attributes for a natuurlijk persoon initiator

### DIFF
--- a/app/EventForm/Submit/ZaakeigenschappenMap.php
+++ b/app/EventForm/Submit/ZaakeigenschappenMap.php
@@ -118,6 +118,10 @@ final class ZaakeigenschappenMap
     }
 
     /**
+     * The natuurlijk_persoon_adres entry is assembled from the flat fields of
+     * the "Adresgegevens" fieldset (only shown to aanvragers without a KvK
+     * number), so a private aanvrager's verblijfsadres reaches the ZGW rol.
+     *
      * @return array<string, mixed>
      */
     public function buildInitiator(FormState $state): array
@@ -129,7 +133,15 @@ final class ZaakeigenschappenMap
         return array_filter([
             'kvk' => $this->stringOrNull($state->get('watIsHetKamerVanKoophandelNummerVanUwOrganisatie')),
             'organisatie_naam' => $this->stringOrNull($state->get('watIsDeNaamVanUwOrganisatie')),
-            'organisatie_adres' => $state->get('watIsHetAdresVanUwOrganisatie'),
+            'natuurlijk_persoon_adres' => array_filter([
+                'postcode' => $this->stringOrNull($state->get('postcode')),
+                'huisnummer' => $this->stringOrNull($state->get('huisnummer')),
+                'huisletter' => $this->stringOrNull($state->get('huisletter')),
+                'huisnummertoevoeging' => $this->stringOrNull($state->get('huisnummertoevoeging')),
+                'straatnaam' => $this->stringOrNull($state->get('straatnaam')),
+                'plaatsnaam' => $this->stringOrNull($state->get('plaatsnaam')),
+                'land' => $this->stringOrNull($state->get('land')),
+            ]),
             'contactpersoon' => array_filter([
                 'naam' => $naam !== '' ? $naam : null,
                 'emailadres' => $this->stringOrNull($state->get('watIsUwEMailadres')),

--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -310,7 +310,13 @@ class CreateDoorkomstZaken implements ShouldQueue
             return;
         }
 
-        $rolData = InitiatorRolBuilder::build($newZaakUrl, $roltype['url'], $state, $initiator);
+        $rolData = InitiatorRolBuilder::build(
+            $newZaakUrl,
+            $roltype['url'],
+            $state,
+            $initiator,
+            InitiatorRolBuilder::anpIdentificatieForUser($this->zaak->organiser_user_id),
+        );
         if ($rolData === null) {
             return;
         }

--- a/app/Jobs/Zaak/UpdateInitiatorZGW.php
+++ b/app/Jobs/Zaak/UpdateInitiatorZGW.php
@@ -18,17 +18,18 @@ use Woweb\Zgw\Connection\ZgwConnection;
 use Woweb\Zgw\Facades\Zgw;
 
 /**
- * Zet de initiator-rol op de ZGW-zaak op basis van het initiator-blok
- * in de FormState-snapshot. Twee varianten — matcht OF:
+ * Sets the initiator rol on the ZGW zaak from the initiator block in the
+ * FormState snapshot. Two variants, matching the aanvrager:
  *
- * - Heeft de aanvrager een KvK-nummer? → `niet_natuurlijk_persoon`
+ * - has a KvK number → `niet_natuurlijk_persoon`
  *   (statutaireNaam, kvkNummer, contactpersoon)
- * - Anders → `natuurlijk_persoon` (voornamen, geslachtsnaam, adres)
+ * - otherwise → `natuurlijk_persoon` (voornamen, geslachtsnaam,
+ *   anpIdentificatie, verblijfsadres)
  *
- * In de oude flow bestond er al een initiator-rol (door OF aangemaakt)
- * en deed deze job een PUT. In de nieuwe flow maken wij de zaak zelf
- * aan zonder initiator, dus moet hier een POST (nieuw rol) gebeuren.
- * Het initiator-roltype wordt opgezocht in de catalogi.
+ * In the legacy flow an initiator rol already existed (created by Open Forms)
+ * and this job did a PUT. In the native flow we create the zaak ourselves
+ * without an initiator, so a POST (new rol) happens here. The initiator
+ * roltype is looked up in the catalogi.
  */
 class UpdateInitiatorZGW implements ShouldQueue
 {
@@ -57,7 +58,13 @@ class UpdateInitiatorZGW implements ShouldQueue
             return;
         }
 
-        $rolData = InitiatorRolBuilder::build($ozZaak->url, $roltype, $state, $initiator);
+        $rolData = InitiatorRolBuilder::build(
+            $ozZaak->url,
+            $roltype,
+            $state,
+            $initiator,
+            InitiatorRolBuilder::anpIdentificatieForUser($this->zaak->organiser_user_id),
+        );
         if ($rolData === null) {
             return;
         }

--- a/app/Services/Zgw/InitiatorRolBuilder.php
+++ b/app/Services/Zgw/InitiatorRolBuilder.php
@@ -19,7 +19,14 @@ use Illuminate\Support\Str;
  *
  * Two variants, matching the aanvrager:
  * - has a KvK number → niet_natuurlijk_persoon (statutaireNaam, kvkNummer)
- * - otherwise        → natuurlijk_persoon (voornamen, geslachtsnaam, adres)
+ * - otherwise        → natuurlijk_persoon (voornamen, geslachtsnaam,
+ *   anpIdentificatie, verblijfsadres)
+ *
+ * A natuurlijk_persoon rol needs an identifying attribute for a ZGW backend to
+ * materialise a betrokkene (OneGround/RX Mission shows nothing for a rol whose
+ * betrokkeneIdentificatie only carries name parts). We have no BSN, so a stable
+ * application-issued anpIdentificatie derived from the organiser user id is
+ * sent, mirroring kvkNummer on the organisation variant.
  */
 final class InitiatorRolBuilder
 {
@@ -27,7 +34,7 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
      * @return array<string, mixed>|null rol payload, or null when there is no initiator data
      */
-    public static function build(string $zaakUrl, string $roltype, FormState $state, array $initiator): ?array
+    public static function build(string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie = null): ?array
     {
         if ($initiator === []) {
             return null;
@@ -35,7 +42,18 @@ final class InitiatorRolBuilder
 
         return isset($initiator['kvk']) && $initiator['kvk']
             ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator)
-            : self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator);
+            : self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie);
+    }
+
+    /**
+     * Stable identifier for a private aanvrager, derived from the organiser
+     * user id so the same person maps to the same betrokkene across zaken. The
+     * ZGW schema caps anpIdentificatie at 17 characters, which the EVL prefix
+     * plus a bigint id stays well within.
+     */
+    public static function anpIdentificatieForUser(?int $userId): ?string
+    {
+        return $userId === null ? null : sprintf('EVL%d', $userId);
     }
 
     /**
@@ -65,11 +83,12 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function natuurlijkPersoon(string $zaakUrl, string $roltype, FormState $state, array $initiator): array
+    private static function natuurlijkPersoon(string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie): array
     {
         $voornaam = (string) $state->get('watIsUwVoornaam');
         $achternaam = (string) $state->get('watIsUwAchternaam');
-        $adres = $state->get('natuurlijkPersoonAdres');
+        $naam = trim($voornaam.' '.$achternaam);
+        $adres = $initiator['natuurlijk_persoon_adres'] ?? null;
 
         $rolData = [
             'zaak' => $zaakUrl,
@@ -78,24 +97,60 @@ final class InitiatorRolBuilder
             'roltoelichting' => 'inzender formulier',
             'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
             'betrokkeneIdentificatie' => array_filter([
+                'anpIdentificatie' => $anpIdentificatie,
                 'geslachtsnaam' => $achternaam !== '' ? $achternaam : null,
                 'voornamen' => $voornaam !== '' ? $voornaam : null,
             ]),
         ];
 
-        if (is_array($adres) && Arr::has($adres, ['postcode', 'plaatsnaam', 'huisnummer'])
-            && (empty($adres['land']) || strtolower((string) $adres['land']) === 'nederland')) {
-            $rolData['betrokkeneIdentificatie']['verblijfsadres'] = [
-                'aoaIdentificatie' => config('app.name').'-persoonsadres-'.Str::uuid(),
-                'wplWoonplaatsNaam' => $adres['plaatsnaam'] ?? null,
-                'gorOpenbareRuimteNaam' => 'adres',
-                'aoaPostcode' => $adres['postcode'] ?? null,
-                'aoaHuisnummer' => $adres['huisnummer'] ?? null,
-                'aoaHuisletter' => $adres['huisletter'] ?? null,
-                'aoaHuisnummertoevoeging' => $adres['huisnummertoevoeging'] ?? null,
-            ];
+        if ($naam !== '') {
+            $rolData['afwijkendeNaamBetrokkene'] = $naam;
+        }
+
+        $verblijfsadres = self::verblijfsadres($adres);
+        if ($verblijfsadres !== null) {
+            $rolData['betrokkeneIdentificatie']['verblijfsadres'] = $verblijfsadres;
         }
 
         return $rolData;
+    }
+
+    /**
+     * A verblijfsadres is only sent for a Dutch address with a plain numeric
+     * huisnummer: the ZGW schema types aoaHuisnummer as an integer, caps
+     * aoaHuisletter at one character and aoaHuisnummertoevoeging at four, so
+     * values outside those bounds are dropped rather than risking a 400 that
+     * would abort the submit chain.
+     *
+     * @param  array<string, mixed>|mixed  $adres
+     * @return array<string, mixed>|null
+     */
+    private static function verblijfsadres(mixed $adres): ?array
+    {
+        if (! is_array($adres) || ! Arr::has($adres, ['postcode', 'plaatsnaam', 'huisnummer'])) {
+            return null;
+        }
+        if (! empty($adres['land']) && strtolower((string) $adres['land']) !== 'nederland') {
+            return null;
+        }
+
+        $huisnummer = trim((string) $adres['huisnummer']);
+        if (! ctype_digit($huisnummer)) {
+            return null;
+        }
+
+        $huisletter = trim((string) ($adres['huisletter'] ?? ''));
+        $toevoeging = trim((string) ($adres['huisnummertoevoeging'] ?? ''));
+        $straatnaam = trim((string) ($adres['straatnaam'] ?? ''));
+
+        return array_filter([
+            'aoaIdentificatie' => config('app.name').'-persoonsadres-'.Str::uuid(),
+            'wplWoonplaatsNaam' => $adres['plaatsnaam'],
+            'gorOpenbareRuimteNaam' => $straatnaam !== '' ? $straatnaam : 'adres',
+            'aoaPostcode' => str_replace(' ', '', (string) $adres['postcode']),
+            'aoaHuisnummer' => (int) $huisnummer,
+            'aoaHuisletter' => strlen($huisletter) === 1 ? $huisletter : null,
+            'aoaHuisnummertoevoeging' => ($toevoeging !== '' && strlen($toevoeging) <= 4) ? $toevoeging : null,
+        ], fn ($v) => $v !== null);
     }
 }

--- a/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
@@ -1,18 +1,22 @@
 <?php
 
 /**
- * UpdateInitiatorZGW zet de initiator-rol op de ZGW-zaak op basis van het
- * initiator-blok in de FormState-snapshot.
+ * UpdateInitiatorZGW sets the initiator rol on the ZGW zaak from the initiator
+ * block in the FormState snapshot.
  *
- * Belangrijkste gedrag dat hier wordt afgedekt: voor een organisatie met een
- * KvK-nummer sturen we als bedrijfsidentificatie uitsluitend `kvkNummer`, voor
- * elke connectie (OpenZaak inbegrepen). `annIdentificatie` wordt bewust
- * weggelaten omdat niet elke ZGW-instantie dat veld accepteert.
+ * Main behaviour covered here: for an organisation with a KvK number we send
+ * only `kvkNummer` as the company identifier, for every connection (OpenZaak
+ * included); `annIdentificatie` is deliberately omitted because not every ZGW
+ * instance accepts it. For a private aanvrager (no KvK) the rol carries a
+ * stable `anpIdentificatie` and the verblijfsadres from the form's address
+ * fieldset, so backends such as OneGround materialise a visible betrokkene.
  */
 
+use App\Enums\Role;
 use App\EventForm\Submit\ZaakeigenschappenMap;
 use App\Jobs\Zaak\UpdateInitiatorZGW;
 use App\Models\Municipality;
+use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -21,7 +25,7 @@ use Tests\Fakes\ZgwHttpFake;
 
 uses(RefreshDatabase::class);
 
-function zaakMetInitiator(array $values): Zaak
+function zaakMetInitiator(array $values, ?int $organiserUserId = null): Zaak
 {
     $muni = Municipality::factory()->create();
     $zaaktype = Zaaktype::factory()->create([
@@ -33,6 +37,7 @@ function zaakMetInitiator(array $values): Zaak
         'zaaktype_id' => $zaaktype->id,
         'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/abc-123',
         'form_state_snapshot' => ['values' => $values],
+        'organiser_user_id' => $organiserUserId,
     ]);
 }
 
@@ -83,6 +88,42 @@ test('stuurt voor een organisatie alleen kvkNummer als bedrijfsidentificatie', f
             && ($identificatie['kvkNummer'] ?? null) === '12345678'
             && ! array_key_exists('annIdentificatie', $identificatie)
             && ($identificatie['statutaireNaam'] ?? null) === 'Acme BV';
+    });
+});
+
+test('stuurt voor een particulier anpIdentificatie, naam en verblijfsadres mee', function () {
+    $user = User::factory()->state(['role' => Role::Organiser])->create();
+    $zaak = zaakMetInitiator([
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Jansen',
+        'watIsUwEMailadres' => 'jan@example.com',
+        'postcode' => '6411CD',
+        'huisnummer' => '32',
+        'straatnaam' => 'Coriovallumstraat',
+        'plaatsnaam' => 'Heerlen',
+    ], $user->id);
+
+    fakeZaakRoltypenEnRollen();
+
+    (new UpdateInitiatorZGW($zaak))->handle(app(ZaakeigenschappenMap::class));
+
+    Http::assertSent(function ($request) use ($user) {
+        if (! str_contains($request->url(), '/zaken/api/v1/rollen') || $request->method() !== 'POST') {
+            return false;
+        }
+
+        $identificatie = $request->data()['betrokkeneIdentificatie'] ?? [];
+        $adres = $identificatie['verblijfsadres'] ?? [];
+
+        return $request->data()['betrokkeneType'] === 'natuurlijk_persoon'
+            && ($request->data()['afwijkendeNaamBetrokkene'] ?? null) === 'Jan Jansen'
+            && ($identificatie['anpIdentificatie'] ?? null) === "EVL{$user->id}"
+            && ($identificatie['geslachtsnaam'] ?? null) === 'Jansen'
+            && ($identificatie['voornamen'] ?? null) === 'Jan'
+            && ($adres['aoaPostcode'] ?? null) === '6411CD'
+            && ($adres['aoaHuisnummer'] ?? null) === 32
+            && ($adres['gorOpenbareRuimteNaam'] ?? null) === 'Coriovallumstraat'
+            && ($adres['wplWoonplaatsNaam'] ?? null) === 'Heerlen';
     });
 });
 

--- a/tests/Unit/Zgw/InitiatorRolBuilderTest.php
+++ b/tests/Unit/Zgw/InitiatorRolBuilderTest.php
@@ -21,7 +21,40 @@ test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
         ->and($rol['contactpersoonRol'])->toBe(['naam' => 'Organisator Test']);
 });
 
-test('builds a natuurlijk_persoon rol from name when there is no KvK', function () {
+test('builds a natuurlijk_persoon rol with anpIdentificatie, display name and verblijfsadres', function () {
+    $state = FormState::fromSnapshot(['values' => [
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Jansen',
+    ]]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'natuurlijk_persoon_adres' => [
+            'postcode' => '6411 CD',
+            'huisnummer' => '32',
+            'huisletter' => 'a',
+            'huisnummertoevoeging' => 'bis',
+            'straatnaam' => 'Coriovallumstraat',
+            'plaatsnaam' => 'Heerlen',
+        ],
+        'contactpersoon' => ['naam' => 'Jan Jansen'],
+    ], 'EVL42');
+
+    expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
+        ->and($rol['afwijkendeNaamBetrokkene'])->toBe('Jan Jansen')
+        ->and($rol['betrokkeneIdentificatie']['anpIdentificatie'])->toBe('EVL42')
+        ->and($rol['betrokkeneIdentificatie']['geslachtsnaam'])->toBe('Jansen')
+        ->and($rol['betrokkeneIdentificatie']['voornamen'])->toBe('Jan');
+
+    $adres = $rol['betrokkeneIdentificatie']['verblijfsadres'];
+    expect($adres['wplWoonplaatsNaam'])->toBe('Heerlen')
+        ->and($adres['gorOpenbareRuimteNaam'])->toBe('Coriovallumstraat')
+        ->and($adres['aoaPostcode'])->toBe('6411CD')
+        ->and($adres['aoaHuisnummer'])->toBe(32)
+        ->and($adres['aoaHuisletter'])->toBe('a')
+        ->and($adres['aoaHuisnummertoevoeging'])->toBe('bis');
+});
+
+test('builds a natuurlijk_persoon rol without verblijfsadres when no address is present', function () {
     $state = FormState::fromSnapshot(['values' => [
         'watIsUwVoornaam' => 'Jan',
         'watIsUwAchternaam' => 'Jansen',
@@ -32,12 +65,65 @@ test('builds a natuurlijk_persoon rol from name when there is no KvK', function 
     ]);
 
     expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
-        ->and($rol['betrokkeneIdentificatie']['geslachtsnaam'])->toBe('Jansen')
-        ->and($rol['betrokkeneIdentificatie']['voornamen'])->toBe('Jan');
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('verblijfsadres')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('anpIdentificatie');
+});
+
+test('skips the verblijfsadres for a foreign address', function () {
+    $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'natuurlijk_persoon_adres' => [
+            'postcode' => '4000',
+            'huisnummer' => '7',
+            'plaatsnaam' => 'Luik',
+            'land' => 'België',
+        ],
+    ]);
+
+    expect($rol['betrokkeneIdentificatie'])->not->toHaveKey('verblijfsadres');
+});
+
+test('skips the verblijfsadres when the huisnummer is not numeric', function () {
+    $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'natuurlijk_persoon_adres' => [
+            'postcode' => '6411CD',
+            'huisnummer' => '32a',
+            'plaatsnaam' => 'Heerlen',
+        ],
+    ]);
+
+    expect($rol['betrokkeneIdentificatie'])->not->toHaveKey('verblijfsadres');
+});
+
+test('drops huisletter and toevoeging values that exceed the ZGW schema bounds', function () {
+    $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
+
+    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'natuurlijk_persoon_adres' => [
+            'postcode' => '6411CD',
+            'huisnummer' => '32',
+            'huisletter' => 'abc',
+            'huisnummertoevoeging' => 'achterzijde',
+            'plaatsnaam' => 'Heerlen',
+        ],
+    ]);
+
+    $adres = $rol['betrokkeneIdentificatie']['verblijfsadres'];
+    expect($adres)->not->toHaveKey('aoaHuisletter')
+        ->and($adres)->not->toHaveKey('aoaHuisnummertoevoeging')
+        ->and($adres['aoaHuisnummer'])->toBe(32);
 });
 
 test('returns null when there is no initiator data', function () {
     $state = FormState::fromSnapshot(['values' => []]);
 
     expect(InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, []))->toBeNull();
+});
+
+test('derives a stable anpIdentificatie from the user id', function () {
+    expect(InitiatorRolBuilder::anpIdentificatieForUser(42))->toBe('EVL42')
+        ->and(InitiatorRolBuilder::anpIdentificatieForUser(null))->toBeNull();
 });


### PR DESCRIPTION
## Problem

Retesting the Rx.Mission integration surfaced that the data of a natural person is not transferred to Rx.Mission unless organisation data is linked.

The initiator rol for a private aanvrager (no KvK number) was sent with only `voornamen` and `geslachtsnaam` in its `betrokkeneIdentificatie`:

- The verblijfsadres was read from the FormState key `natuurlijkPersoonAdres`, which has not been produced anywhere since the migration to the native submit pipeline. The address the aanvrager fills in (the Adresgegevens fieldset) never reached ZGW, on any connection.
- No identifying attribute (`inpBsn` / `anpIdentificatie`) was included at all. The organisation variant does send `kvkNummer`, which is why data only appeared in Rx.Mission when organisation data was linked: OneGround accepts a rol without an identifying attribute (no failed jobs) but does not materialise a visible betrokkene from it.

## Changes

- `ZaakeigenschappenMap::buildInitiator()` now assembles `natuurlijk_persoon_adres` from the flat address fields (`postcode`, `huisnummer`, `huisletter`, `huisnummertoevoeging`, `straatnaam`, `plaatsnaam`, `land`), and `InitiatorRolBuilder` reads that entry instead of the dead key.
- A stable, application-issued `anpIdentificatie` (`EVL{user id}`, well within the 17-character schema cap) is sent for the natural person, mirroring `kvkNummer` on the organisation variant, so the same aanvrager maps to the same betrokkene across zaken.
- `afwijkendeNaamBetrokkene` is filled with the full name as a display fallback.
- The verblijfsadres now uses the actual `straatnaam` as `gorOpenbareRuimteNaam` (previously the hardcoded string `'adres'`) and is guarded against ZGW schema bounds (integer `aoaHuisnummer`, one-character `aoaHuisletter`, four-character `aoaHuisnummertoevoeging`, Dutch addresses only) so the async submit chain cannot break on a validation error.
- The dead `organisatie_adres` mapping is removed: its source key `watIsHetAdresVanUwOrganisatie` never existed in the native form and nothing consumed the entry.

Both call sites (`UpdateInitiatorZGW` for the hoofdzaak and `CreateDoorkomstZaken` for doorkomst deelzaken) pass the identifier, so deelzaken get the same initiator identification.

## Tests

- Unit tests for the builder now cover the natural person variant: identifying attribute, display name, verblijfsadres mapping, foreign address and non-numeric huisnummer skips, and schema-bound guards. The previous natural person test asserted the buggy behaviour (no address, no identification) and has been replaced.
- Feature test for `UpdateInitiatorZGW` asserting the full POST payload for a private aanvrager.