### PR TITLE
Determine the municipality from the current location when copying an event

### DIFF
--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -126,6 +126,12 @@ final class AddressNL
             $postcode = $get("{$key}.postcode");
             $huisnummer = $get("{$key}.huisnummer");
 
+            // Invalidate the stored gemeente first: it belongs to the address as
+            // it was before this edit. The location check trusts it verbatim, so
+            // leaving it in place while the lookup below fails (or resolves a
+            // different address) would route the aanvraag to the wrong gemeente.
+            $set("{$key}.brkGemeente", null);
+
             if (! self::hasLookupInput($postcode, $huisnummer)) {
                 return;
             }

--- a/app/EventForm/Persistence/PrefillLoader.php
+++ b/app/EventForm/Persistence/PrefillLoader.php
@@ -125,6 +125,27 @@ class PrefillLoader
     }
 
     /**
+     * Location-dependent state from the source zaak. These are fetch results and
+     * a choice made for the source event's location, not answers the organiser
+     * gave: carrying them over would let the copy be routed to the original
+     * municipality even after the location is changed. They are rebuilt from the
+     * new location by the location gate.
+     *
+     * `evenementInGemeente` is derived, never written by the current form, but is
+     * stripped defensively: a materialised value in the values bag would win
+     * whenever the derivation yields null.
+     *
+     * @var list<string>
+     */
+    private const LOCATION_DEPENDENT_KEYS = [
+        'userSelectGemeente',
+        'inGemeentenResponse',
+        'gemeenteVariabelen',
+        'evenementenInDeGemeente',
+        'evenementInGemeente',
+    ];
+
+    /**
      * Knip afgeleide state eruit zodat de prefill een "leeg-met-invullen"
      * gevoel geeft, niet een "volgende submit"-gevoel.
      */
@@ -136,6 +157,42 @@ class PrefillLoader
         $clean['field_hidden'] = [];
         $clean['step_applicable'] = [];
 
+        if (isset($clean['values']) && is_array($clean['values'])) {
+            foreach (self::LOCATION_DEPENDENT_KEYS as $key) {
+                unset($clean['values'][$key]);
+            }
+
+            $clean['values'] = $this->stripAddressBrkGemeente($clean['values']);
+        }
+
         return FormState::fromSnapshot($clean);
+    }
+
+    /**
+     * Drops the hidden `brkGemeente` the PDOK auto-fill stored on each copied
+     * address row. It identifies the municipality of the *source* address, and
+     * the location check trusts it verbatim, so a copied row whose auto-fill
+     * does not re-fire would keep routing the aanvraag to the old municipality.
+     * Clearing it forces a fresh postcode + house number lookup.
+     *
+     * @param  array<string, mixed>  $values
+     * @return array<string, mixed>
+     */
+    private function stripAddressBrkGemeente(array $values): array
+    {
+        $addresses = $values['adresVanDeGebouwEn'] ?? null;
+        if (! is_array($addresses)) {
+            return $values;
+        }
+
+        foreach ($addresses as $index => $row) {
+            if (is_array($row)) {
+                unset($addresses[$index]['brkGemeente']);
+            }
+        }
+
+        $values['adresVanDeGebouwEn'] = $addresses;
+
+        return $values;
     }
 }

--- a/app/EventForm/State/FormDerivedState.php
+++ b/app/EventForm/State/FormDerivedState.php
@@ -213,8 +213,16 @@ final class FormDerivedState
     {
         $pick = $this->state->get('userSelectGemeente');
         if (is_string($pick) && $pick !== '') {
-            // De `gemeenten`-map is keyed by brk_identification.
-            return $this->state->get("gemeenten.{$pick}");
+            // De `gemeenten`-map is keyed by brk_identification. A pick that is
+            // no longer among the municipalities found for the current location
+            // is stale (a copied aanvraag whose location has changed, or an
+            // edited location) and must not win: falling through to the
+            // auto-pick keeps the aanvraag with the actual location instead of
+            // silently routing it to the previous municipality.
+            $gemeente = $this->state->get("gemeenten.{$pick}");
+            if ($gemeente !== null) {
+                return $gemeente;
+            }
         }
 
         $items = $this->state->get('inGemeentenResponse.all.items');

--- a/app/EventForm/Submit/ResolveZaaktype.php
+++ b/app/EventForm/Submit/ResolveZaaktype.php
@@ -133,6 +133,8 @@ final class ResolveZaaktype
     {
         $brk = $state->get('evenementInGemeente.brk_identification');
         if (is_string($brk) && $brk !== '') {
+            $this->assertMunicipalityMatchesLocation($state, $brk);
+
             $muni = Municipality::where('brk_identification', $brk)->first();
             if ($muni) {
                 return $muni;
@@ -140,5 +142,34 @@ final class ResolveZaaktype
         }
 
         throw new RuntimeException('Geen gemeente herleidbaar uit de FormState (evenementInGemeente.brk_identification ontbreekt of matcht niets).');
+    }
+
+    /**
+     * Guards the invariant that the municipality a zaak is created for is one of
+     * the municipalities the current location actually falls in. The location
+     * check result is authoritative here: it is recomputed on the location gate
+     * from the submitted addresses, areas and routes.
+     *
+     * Without this a stale gemeente in the state (a copied aanvraag, an edited
+     * location) would silently create the zaak for the previous municipality,
+     * and with it on the previous municipality's ZGW instance. Failing the
+     * submit is the lesser harm; the organiser is sent back through the location
+     * step. A state without a location check result (older drafts) is left
+     * alone.
+     */
+    private function assertMunicipalityMatchesLocation(FormState $state, string $brk): void
+    {
+        $gemeenten = $state->get('inGemeentenResponse.all.object');
+        if (! is_array($gemeenten) || $gemeenten === []) {
+            return;
+        }
+
+        if (! array_key_exists($brk, $gemeenten)) {
+            throw new RuntimeException(sprintf(
+                'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
+                $brk,
+                implode(', ', array_keys($gemeenten)),
+            ));
+        }
     }
 }

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -574,38 +574,57 @@ class EventFormPage extends Page implements HasForms
 
     /**
      * Cleart `userSelectGemeente` wanneer de zojuist berekende gemeente-
-     * intersectie de eerdere keuze van de organisator twijfelachtig
-     * maakt: route start+eindigt in dezelfde gemeente, terwijl 'ie wel
-     * door ≥2 gemeenten gaat. In zo'n geval moet de keuze opnieuw
-     * gemaakt worden — anders blijft een stale brk_identification de
-     * `evenementInGemeente`-derivation aansturen.
+     * intersectie de eerdere keuze van de organisator ongeldig of
+     * twijfelachtig maakt. Twee gevallen:
      *
-     * Migreert OF-rule `be547255-4a1b-4f37-96e8-919d5351e7a5`
-     * (AlsIsGelijkAanTrueEnReductieVanEvenemen). OF gebruikte
-     * `userSelectGemeente11` als trigger-marker (interne duplicate-key-
-     * suffix); wij hebben alleen één veld, dus checken we dat direct.
+     *   1. De keuze komt niet meer voor in de gevonden gemeenten. Dat gebeurt
+     *      wanneer de locatie is gewijzigd, en bij "Nieuwe aanvraag met deze
+     *      gegevens" waarbij de keuze van de bron-aanvraag nog in de state
+     *      stond. Zonder wissen blijft de radio zichtbaar op een gemeente die
+     *      niets met de huidige locatie te maken heeft.
+     *   2. Route start+eindigt in dezelfde gemeente, terwijl 'ie wel door ≥2
+     *      gemeenten gaat. Dan moet de keuze opnieuw gemaakt worden.
+     *      (Migreert OF-rule `be547255-4a1b-4f37-96e8-919d5351e7a5`.)
      */
     private function resetStaleGemeenteKeuze(): void
     {
-        $startEndEqual = $this->state->get('inGemeentenResponse.line.start_end_equal');
-        if ($startEndEqual !== true) {
-            return;
-        }
-
-        $namen = $this->state->get('evenementInGemeentenNamen');
-        if (! is_array($namen) || count($namen) < 2) {
-            return;
-        }
-
         $pick = $this->state->get('userSelectGemeente');
         if (! is_string($pick) || $pick === '') {
             return;
         }
 
-        $this->state->setVariable('userSelectGemeente', '');
-        if (is_array($this->data)) {
-            $this->data['userSelectGemeente'] = '';
+        if (! $this->gemeenteKeuzeIsGeldig($pick) || $this->routeStartEnEindigtInDezelfdeGemeente()) {
+            $this->state->setVariable('userSelectGemeente', '');
+            if (is_array($this->data)) {
+                $this->data['userSelectGemeente'] = '';
+            }
         }
+    }
+
+    /**
+     * Of de gekozen brk_identification voorkomt in de gemeenten die voor de
+     * huidige locatie zijn gevonden. Zonder gemeenten-map (nog geen
+     * locatie-check gedraaid) blijft de keuze staan.
+     */
+    private function gemeenteKeuzeIsGeldig(string $pick): bool
+    {
+        $gemeenten = $this->state->get('inGemeentenResponse.all.object');
+        if (! is_array($gemeenten) || $gemeenten === []) {
+            return true;
+        }
+
+        return array_key_exists($pick, $gemeenten);
+    }
+
+    private function routeStartEnEindigtInDezelfdeGemeente(): bool
+    {
+        if ($this->state->get('inGemeentenResponse.line.start_end_equal') !== true) {
+            return false;
+        }
+
+        $namen = $this->state->get('evenementInGemeentenNamen');
+
+        return is_array($namen) && count($namen) >= 2;
     }
 
     /**

--- a/tests/Feature/EventForm/State/FormDerivedStateEquivalenceTest.php
+++ b/tests/Feature/EventForm/State/FormDerivedStateEquivalenceTest.php
@@ -100,6 +100,39 @@ test('evenementInGemeente — userSelectGemeente wint bij ≥2 gevonden', functi
     ]))->toBe(['brk_identification' => 'GM0917', 'name' => 'Heerlen']);
 });
 
+test('evenementInGemeente — stale keuze buiten de gevonden gemeenten valt terug op de auto-pick', function () {
+    // Komt voor bij "Nieuwe aanvraag met deze gegevens" met een gewijzigde
+    // locatie: de keuze van de bron-aanvraag mag de nieuwe gemeente niet
+    // overrulen.
+    expect(derive('evenementInGemeente', [
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+            'object' => [
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+        ]],
+    ]))->toBe(['brk_identification' => 'GM0935', 'name' => 'Maastricht']);
+});
+
+test('evenementInGemeente — stale keuze bij meerdere gevonden gemeenten → null (keuze opnieuw maken)', function () {
+    expect(derive('evenementInGemeente', [
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+                ['brk_identification' => 'GM0882', 'name' => 'Sittard-Geleen'],
+            ],
+            'object' => [
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+                'GM0882' => ['brk_identification' => 'GM0882', 'name' => 'Sittard-Geleen'],
+            ],
+        ]],
+    ]))->toBeNull();
+});
+
 test('evenementInGemeente — niets gevonden, niets gekozen → null', function () {
     expect(derive('evenementInGemeente', [
         'inGemeentenResponse' => ['all' => ['items' => []]],

--- a/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
+++ b/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
@@ -183,6 +183,54 @@ test('gehashte waarden (hash:-prefix) worden gewist zodat applySessionPrefill ze
         ->and($state->get('auth_bsn'))->toBeNull();
 });
 
+test('locatie-afhankelijke state van de bron-zaak komt niet mee', function () {
+    // De gemeentekeuze en de locatieserver-resultaten horen bij de locatie van
+    // de bron-aanvraag. Zouden ze meekomen, dan wordt een kopie met een andere
+    // locatie alsnog in de oorspronkelijke gemeente aangevraagd.
+    $sc = scenarioZaakMetSnapshot([
+        'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest 2027',
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+            'object' => ['GM0917' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+        ]],
+        'gemeenteVariabelen' => ['use_new_report_questions' => true],
+        'evenementenInDeGemeente' => ['items' => []],
+        'evenementInGemeente' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+    ]);
+
+    $state = $this->loader->load($sc['zaak']->id, $sc['user'], $sc['org']);
+
+    expect($state->get('watIsDeNaamVanHetEvenementVergunning'))->toBe('Buurtfeest 2027')
+        ->and($state->get('userSelectGemeente'))->toBeNull()
+        ->and($state->get('inGemeentenResponse'))->toBeNull()
+        ->and($state->get('gemeenteVariabelen'))->toBeNull()
+        ->and($state->get('evenementenInDeGemeente'))->toBeNull()
+        ->and($state->get('evenementInGemeente'))->toBeNull();
+});
+
+test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
+    // Het verborgen brkGemeente-veld wordt door de locatiecheck verbatim
+    // vertrouwd; een gekopieerde waarde zou een gewijzigd adres naar de oude
+    // gemeente routeren.
+    $sc = scenarioZaakMetSnapshot([
+        'adresVanDeGebouwEn' => [
+            ['postcode' => '6411CD', 'huisnummer' => '32', 'straatnaam' => 'Coriovallumstraat', 'brkGemeente' => 'GM0917'],
+            ['postcode' => '6361BZ', 'huisnummer' => '1', 'straatnaam' => 'Deweverplein', 'brkGemeente' => 'GM1954'],
+        ],
+    ]);
+
+    $state = $this->loader->load($sc['zaak']->id, $sc['user'], $sc['org']);
+    $adressen = $state->get('adresVanDeGebouwEn');
+
+    expect($adressen)->toHaveCount(2)
+        ->and($adressen[0])->not->toHaveKey('brkGemeente')
+        ->and($adressen[1])->not->toHaveKey('brkGemeente')
+        // De ingevulde adresgegevens zelf blijven staan.
+        ->and($adressen[0]['postcode'])->toBe('6411CD')
+        ->and($adressen[1]['straatnaam'])->toBe('Deweverplein');
+});
+
 test('velden die niet meer in het schema zitten komen stil mee uit de snapshot', function () {
     // Voorbeeld: een veld dat bij de vorige submit bestond maar inmiddels
     // vervangen is door een andere key. Dat mag niet crashen; de waarde

--- a/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
+++ b/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
@@ -290,3 +290,46 @@ test('eigen-connectie-rij wint ook op de role-route als beide gekoppeld en actie
 
     expect($this->resolve->forState($state)->id)->toBe($eigen->id);
 });
+
+test('gemeente die niet bij de gevonden locatie hoort → harde fout in plaats van een zaak in de verkeerde gemeente', function () {
+    // Vangt de situatie af waarin een verouderde gemeente in de state blijft
+    // staan (gekopieerde aanvraag, gewijzigde locatie). Zonder deze controle
+    // wordt de zaak stilzwijgend in de oude gemeente en op diens ZGW-instantie
+    // aangemaakt.
+    $heerlen = Municipality::factory()->create(['name' => 'Heerlen', 'brk_identification' => 'GM0917']);
+    Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0917'],
+        'inGemeentenResponse' => ['all' => ['object' => [
+            'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]]],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect(fn () => $this->resolve->forState($state))
+        ->toThrow(RuntimeException::class, 'hoort niet bij de gevonden gemeenten');
+});
+
+test('gemeente die wel bij de gevonden locatie hoort wordt gewoon gebruikt', function () {
+    $maastricht = Municipality::factory()->create(['name' => 'Maastricht', 'brk_identification' => 'GM0935']);
+    $verwacht = Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Maastricht',
+        'municipality_id' => $maastricht->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0935'],
+        'inGemeentenResponse' => ['all' => ['object' => [
+            'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]]],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect($this->resolve->forState($state)->id)->toBe($verwacht->id);
+});


### PR DESCRIPTION
## Problem

Retesting surfaced that copying an event and applying in another municipality still creates the aanvraag in the original municipality.

A zaak has no `municipality_id`: its municipality follows entirely from the zaaktype, which follows from `evenementInGemeente.brk_identification`. That value is derived, but the inputs it derives from were copied verbatim by the "Nieuwe aanvraag met deze gegevens" flow and never revalidated against the new location:

- `userSelectGemeente`, the gemeente the organiser picked for the *source* event.
- `inGemeentenResponse`, the full location check result for the source location.
- `gemeenteVariabelen` (which also drives the melding/vergunning decision) and `evenementenInDeGemeente`.
- The hidden `brkGemeente` on each copied address row, which the location check trusts verbatim.

`stripDerivedState()` only cleared `field_hidden` and `step_applicable`, two keys that no longer exist in the current snapshot format. The location gate accepted an existing choice without checking it still belongs to the current location, so as long as the original municipality remained in the intersection it silently won, with the radio already showing it filled in.

Because the ZGW connection follows the zaaktype, this also meant the zaak was created on the original municipality's ZGW instance.

## Changes

- **`PrefillLoader`** strips the location-dependent keys and the per-address `brkGemeente`. These are fetch results and a choice tied to the source location, not answers the organiser gave; the location gate rebuilds them. `evenementInGemeente` itself is stripped defensively: it is derived and never written by the current form, but a materialised value in the values bag would win whenever the derivation yields null.
- **`FormDerivedState::evenementInGemeente()`** treats a `userSelectGemeente` that is not among the municipalities found for the current location as no choice and falls through to the auto-pick. This also fixes the reverse failure mode: with a single new municipality the stale choice previously returned null and the gate blocked with "Gemeente niet bepaald", while the correction radio is hidden below two municipalities.
- **`resetStaleGemeenteKeuze()`** is now generic (choice no longer among the found municipalities is cleared), instead of only handling the route start-equals-end case.
- **`ResolveZaaktype`** asserts at submit time that the gemeente in the state is among the municipalities found for the submitted location, and throws otherwise. Failing the submit is the lesser harm compared to creating a zaak for the wrong municipality on the wrong ZGW instance. States without a location check result (older drafts) are left alone.
- **`AddressNL`** clears `brkGemeente` before the PDOK lookup runs, so a failed lookup (or one that does not fire during fast typing) cannot leave the previous municipality attached to an edited address.

## Tests

- `PrefillFromZaakTest`: location-dependent state and per-address `brkGemeente` are dropped while the organiser's own answers survive. The file previously had no municipality or location assertions at all.
- `FormDerivedStateEquivalenceTest`: stale choice falls through to the auto-pick with one municipality, and yields null (choose again) with several.
- `ResolveZaaktypeTest`: a gemeente outside the found municipalities throws; a matching one resolves normally.

Full `tests/Feature/EventForm` and `tests/Unit/EventForm` suites pass (539 tests).