### PR TITLE
Show archived documents and OneGround besluiten on a zaak

### DIFF
--- a/app/Actions/OpenNotification/GetIncommingNotificationType.php
+++ b/app/Actions/OpenNotification/GetIncommingNotificationType.php
@@ -29,6 +29,12 @@ class GetIncommingNotificationType
             return OpenNotificationType::NewZaakDocument;
         } elseif (($data['actie'] === 'update' || $data['actie'] === 'partial_update') && $data['kanaal'] === 'documenten' && $data['resource'] === 'enkelvoudiginformatieobject') {
             return OpenNotificationType::UpdatedZaakDocument;
+        } elseif ($data['kanaal'] === 'besluiten') {
+            // Every resource on this channel (besluit and besluitinformatieobject)
+            // carries the besluit url as hoofdObject. We subscribe to the channel,
+            // so without this branch a besluit taken in the ZGW backend itself was
+            // dropped and the zaak kept serving its cached besluiten.
+            return OpenNotificationType::BesluitChanged;
         } elseif ($data['kanaal'] === 'zaaktypen') {
             // Every resource on this channel (zaaktype and its child resources
             // like statustype or resultaattype) carries the zaaktype version url

--- a/app/Enums/DocumentVertrouwelijkheden.php
+++ b/app/Enums/DocumentVertrouwelijkheden.php
@@ -16,17 +16,28 @@ enum DocumentVertrouwelijkheden: string
     case Geheim = 'geheim';
     case ZeerGegeheim = 'zeer_geheim';
 
+    /**
+     * The vertrouwelijkheid levels a role may see by default, ordered from least
+     * to most confidential.
+     *
+     * `openbaar` is included for every role: it is the least confidential level
+     * there is, so a role that may see zaakvertrouwelijk documents can certainly
+     * see public ones. Leaving it out meant a backend that labels documents
+     * `openbaar` (OneGround/RX Mission does this for system uploads) showed no
+     * documents at all, to nobody, while more confidential documents were
+     * visible.
+     */
     public static function fromUserRole(Role $role): array
     {
         return match ($role) {
-            Role::Organiser => [self::Zaakvertrouwelijk->value],
-            Role::Advisor => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value],
-            Role::MunicipalityAdmin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::ReviewerMunicipalityAdmin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Coordinator => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Reviewer => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Admin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::KoppelingBeheerder => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Organiser => [self::Openbaar->value, self::Zaakvertrouwelijk->value],
+            Role::Advisor => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value],
+            Role::MunicipalityAdmin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::ReviewerMunicipalityAdmin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Coordinator => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Reviewer => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Admin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::KoppelingBeheerder => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
         };
     }
 

--- a/app/Enums/OpenNotificationType.php
+++ b/app/Enums/OpenNotificationType.php
@@ -10,4 +10,5 @@ enum OpenNotificationType: string
     case NewZaakDocument = 'new_zaak_document';
     case UpdatedZaakDocument = 'updated_zaak_document';
     case ZaaktypeChanged = 'zaaktype_changed';
+    case BesluitChanged = 'besluit_changed';
 }

--- a/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
@@ -489,6 +489,12 @@ class ViewZaak extends ViewRecord
                         $finishZaakObject->besluittype ? new AddBesluitZGW($finishZaakObject) : null,
                         new AddResultaatZGW($finishZaakObject),
                         new AddFinalStatusZGW($finishZaakObject),
+                        // The besluit and the final status change what ZGW
+                        // returns for this zaak. Invalidate here rather than
+                        // waiting for a notification: an external connection
+                        // without a working subscription would otherwise keep
+                        // serving the pre-besluit reads.
+                        fn () => $record->clearZgwCache(),
                         function () use ($record, $finishZaakObject) {
                             if ($record->organisation?->users) {
                                 foreach ($record->organisation->users as $recipient) {

--- a/app/Jobs/DocumentNotificationReceived.php
+++ b/app/Jobs/DocumentNotificationReceived.php
@@ -75,7 +75,7 @@ class DocumentNotificationReceived implements ShouldQueue
 
                 // Only notify for finalised documents (no concepts), and for a
                 // besluitdocument only once the besluit's verzenddatum is reached.
-                if (! $informatieobject->isDefinitief() || ! $this->besluitVerzenddatumReached($connection, $informatieobject)) {
+                if (! $informatieobject->isVastgesteld() || ! $this->besluitVerzenddatumReached($connection, $informatieobject)) {
                     $zaak->clearZgwCache();
 
                     return;

--- a/app/Jobs/ProcessOpenNotification.php
+++ b/app/Jobs/ProcessOpenNotification.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Actions\OpenNotification\GetIncommingNotificationType;
 use App\Enums\OpenNotificationType;
+use App\Jobs\Zaak\BesluitNotificationReceived;
 use App\Jobs\Zaak\ClearZaakCache;
 use App\ValueObjects\OpenNotification;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -26,6 +27,9 @@ class ProcessOpenNotification implements ShouldQueue
             // (zaaktype update + child-resource creates, all sharing the same
             // hoofdObject) collapses into the one unique job.
             OpenNotificationType::ZaaktypeChanged => ZaaktypeNotificationReceived::dispatch($this->notification)->delay(now()->addSeconds(30)),
+            // Delayed for the same reason as documents: the besluit and its
+            // informatieobject links are created in quick succession.
+            OpenNotificationType::BesluitChanged => BesluitNotificationReceived::dispatch($this->notification)->delay(now()->addSeconds(10)),
             default => null,
         };
     }

--- a/app/Jobs/Zaak/BesluitNotificationReceived.php
+++ b/app/Jobs/Zaak/BesluitNotificationReceived.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Jobs\Zaak;
+
+use App\Models\Zaak;
+use App\Services\Zgw\ZgwConnectionResolver;
+use App\ValueObjects\OpenNotification;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Woweb\Zgw\Api\Endpoints\DirectEndpoint;
+use Woweb\Zgw\Facades\Zgw;
+
+/**
+ * Clears a zaak's cached besluiten when the besluiten channel reports a change.
+ *
+ * The notification's hoofdObject is the besluit url, not the zaak url, so the
+ * besluit is read to find the zaak it belongs to. Without this a besluit taken
+ * in the ZGW backend itself (rather than through Eventloket) never reached the
+ * zaak page.
+ */
+class BesluitNotificationReceived implements ShouldQueue
+{
+    use Queueable;
+
+    public function __construct(private readonly OpenNotification $notification) {}
+
+    public function handle(): void
+    {
+        $besluitUrl = $this->notification->hoofdObject;
+
+        try {
+            $connectionName = app(ZgwConnectionResolver::class)->forUrl($besluitUrl);
+            $besluit = (new DirectEndpoint(Zgw::connection($connectionName)))->getByUrl($besluitUrl);
+        } catch (\Throwable $e) {
+            Log::warning('Could not read besluit for a besluiten notification: '.$e->getMessage(), [
+                'besluit' => $besluitUrl,
+            ]);
+
+            return;
+        }
+
+        $zaakUrl = $besluit['zaak'] ?? null;
+        if (! is_string($zaakUrl) || $zaakUrl === '') {
+            return;
+        }
+
+        Zaak::where('zgw_zaak_url', $zaakUrl)->first()?->clearZgwCache();
+    }
+}

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -53,6 +53,18 @@ class Zaak extends Model implements Eventable
 {
     use HasFactory, HasUuids, LogsActivity, SoftDeletes;
 
+    /**
+     * How long the documents and besluiten read from ZGW are cached.
+     *
+     * These caches used to be kept forever and relied on ZGW notifications to be
+     * invalidated. That is not a safe assumption for an external connection: a
+     * subscription that is missing, unreachable or on an unhandled channel meant
+     * an empty list read once (before the documents existed) was served
+     * indefinitely. A short TTL bounds that failure to a few minutes; explicit
+     * invalidation via {@see clearZgwCache()} keeps the common path immediate.
+     */
+    private const ZGW_READ_CACHE_TTL = 300;
+
     protected $table = 'zaken';
 
     protected $fillable = [
@@ -372,10 +384,11 @@ class Zaak extends Model implements Eventable
     {
         return Attribute::make(
             get: function ($value, $attributes) {
-                // Only show finalised documents; concepts from an external ZGW
+                // Only show established documents; concepts from an external ZGW
                 // backend are hidden (documents without an explicit status, such
-                // as our own uploads, count as final). See Informatieobject::isDefinitief().
-                $documenten = $this->getDocuments()->filter(fn (Informatieobject $informatieobject) => $informatieobject->isDefinitief());
+                // as our own uploads, count as established, and so do archived
+                // ones). See Informatieobject::isVastgesteld().
+                $documenten = $this->getDocuments()->filter(fn (Informatieobject $informatieobject) => $informatieobject->isVastgesteld());
 
                 if (app()->runningInConsole()) {
                     // queue needs documents for adding to mail, skip role filter because this is allready done before job is queued
@@ -455,43 +468,79 @@ class Zaak extends Model implements Eventable
     {
         return Attribute::make(
             get: function ($value, $attributes) {
-                // Only show a besluit once it has a finalised besluitdocument and
-                // its verzenddatum has been reached. See besluitIsPubliceerbaar().
+                // Only show a besluit once its send date has been reached. See
+                // besluitIsPubliceerbaar(). The besluitdocumenten are filtered to
+                // what the current role may see: map(), not each(), because the
+                // value object is readonly and a rebuilt besluit has to replace
+                // the original one.
+                $allowed = ZgwConnectionConfig::documentVisibilityForRole($this->zgwConnectionName(), auth()->user()->role);
+
                 return $this->getBesluiten()
                     ->filter(fn (Besluit $besluit) => $this->besluitIsPubliceerbaar($besluit))
-                    ->each(function (Besluit $besluit) {
-                        $besluit = new Besluit(...array_merge($besluit->toArrayWithObjects(), [
-                            'besluitDocumenten' => $besluit->besluitDocumenten?->filter(fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, ZgwConnectionConfig::documentVisibilityForRole($this->zgwConnectionName(), auth()->user()->role))),
-                        ]));
-                    })
+                    ->map(fn (Besluit $besluit) => new Besluit(...array_merge($besluit->toArrayWithObjects(), [
+                        'besluitDocumenten' => $besluit->besluitDocumenten
+                            ?->filter(fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, $allowed))
+                            ->values(),
+                    ])))
                     ->values();
             },
         );
     }
 
     /**
-     * Whether a besluit may be shown to and notified about: it must have a
-     * finalised besluitdocument and a verzenddatum that has been reached (on or
-     * before today, Europe/Amsterdam). Besluiten created in Eventloket get a
-     * verzenddatum of today, so their behaviour is unchanged.
+     * Whether a besluit may be shown to and notified about: its send date must
+     * have been reached (on or before today, Europe/Amsterdam) and it must carry
+     * an established besluitdocument. Besluiten created in Eventloket get a
+     * verzenddatum of today and a document, so their behaviour is unchanged.
+     *
+     * A besluit taken in the ZGW backend itself need not have a
+     * besluitinformatieobject linked to it at all: on a OneGround (RX Mission)
+     * connection the decision document is commonly kept as a zaakdocument. The
+     * document requirement is therefore lifted for those connections, where the
+     * send date alone decides. Requiring it there hid every such besluit
+     * indefinitely.
      */
     private function besluitIsPubliceerbaar(Besluit $besluit): bool
     {
-        $heeftDefinitiefDocument = $besluit->besluitDocumenten?->contains(
-            fn (Informatieobject $document) => $document->isDefinitief()
-        ) ?? false;
+        $verzenddatum = $this->besluitVerzenddatum($besluit);
+        if ($verzenddatum === null) {
+            return false;
+        }
 
-        if (! $heeftDefinitiefDocument || empty($besluit->verzenddatum)) {
+        if (! $this->besluitHeeftVastgesteldDocument($besluit) && ! ZgwConnectionConfig::isOneGround($this->zgwConnectionName())) {
             return false;
         }
 
         try {
-            return Carbon::parse($besluit->verzenddatum, 'Europe/Amsterdam')
+            return Carbon::parse($verzenddatum, 'Europe/Amsterdam')
                 ->startOfDay()
                 ->lessThanOrEqualTo(Carbon::now('Europe/Amsterdam')->startOfDay());
         } catch (\Throwable) {
             return false;
         }
+    }
+
+    private function besluitHeeftVastgesteldDocument(Besluit $besluit): bool
+    {
+        return $besluit->besluitDocumenten?->contains(
+            fn (Informatieobject $document) => $document->isVastgesteld()
+        ) ?? false;
+    }
+
+    /**
+     * The date that decides when a besluit becomes visible. `verzenddatum` is
+     * optional in the ZGW Besluiten API; `publicatiedatum` is the fallback for a
+     * besluit that was published without one.
+     */
+    private function besluitVerzenddatum(Besluit $besluit): ?string
+    {
+        if (! empty($besluit->verzenddatum)) {
+            return $besluit->verzenddatum;
+        }
+
+        $publicatiedatum = $besluit->otherParams['publicatiedatum'] ?? null;
+
+        return is_string($publicatiedatum) && $publicatiedatum !== '' ? $publicatiedatum : null;
     }
 
     private function getBesluiten(): Collection
@@ -500,7 +549,7 @@ class Zaak extends Model implements Eventable
             return collect();
         }
 
-        return Cache::rememberForever("zaak.{$this->id}.besluiten", function () {
+        return Cache::remember("zaak.{$this->id}.besluiten", self::ZGW_READ_CACHE_TTL, function () {
             $connection = Zgw::connection($this->zgwConnectionName());
             $direct = new DirectEndpoint($connection);
             $besluiten = $connection->besluiten()->besluiten()->index(['zaak' => $this->zgw_zaak_url]);
@@ -527,7 +576,7 @@ class Zaak extends Model implements Eventable
             return collect();
         }
 
-        return Cache::rememberForever("zaak.{$this->id}.documenten", function () {
+        return Cache::remember("zaak.{$this->id}.documenten", self::ZGW_READ_CACHE_TTL, function () {
             $connection = Zgw::connection($this->zgwConnectionName());
             $direct = new DirectEndpoint($connection);
             $zaakinformatieobjecten = $connection->zaken()->zaakinformatieobjecten()->index(['zaak' => $this->zgw_zaak_url]);

--- a/app/ValueObjects/ZGW/Informatieobject.php
+++ b/app/ValueObjects/ZGW/Informatieobject.php
@@ -14,6 +14,15 @@ class Informatieobject implements Arrayable
      */
     public const STATUS_DEFINITIEF = 'definitief';
 
+    /**
+     * ZGW document status for a document that has been archived: its form and
+     * content are frozen for archival purposes. It is emphatically not a
+     * statement about availability, and the document stays retrievable until it
+     * is actually destroyed or transferred (at which point it disappears from
+     * the API on its own).
+     */
+    public const STATUS_GEARCHIVEERD = 'gearchiveerd';
+
     /** @phpstan-ignore constructor.unusedParameter */
     public function __construct(
         public readonly string $uuid,
@@ -58,19 +67,30 @@ class Informatieobject implements Arrayable
     }
 
     /**
-     * Whether this document may be shown to and notified about.
+     * Whether this document may be shown to and notified about, judged on its
+     * status alone. Who may see it is a separate question, answered by the
+     * vertrouwelijkheidaanduiding and the user's role.
      *
-     * Strict allowlist: only the 'definitief' status and documents without an
-     * explicit status (our own uploads and legacy documents) are shown. Every
-     * other status is hidden. This includes the draft statuses (in_bewerking,
-     * ter_vaststelling, concept), 'gearchiveerd' (archived documents must never
-     * be shown, not even to users who may otherwise see documents), and any
-     * unknown or future status.
+     * Allowlist: 'definitief', 'gearchiveerd', and documents without an explicit
+     * status (our own uploads and legacy documents). The draft statuses
+     * (in_bewerking, ter_vaststelling, concept) and any unknown or future status
+     * stay hidden.
+     *
+     * 'gearchiveerd' is included deliberately. In the ZGW standard it marks a
+     * document as frozen for archival purposes, not as unavailable; access is
+     * governed by the vertrouwelijkheidaanduiding and authorisations, and a
+     * document that may genuinely no longer be seen is destroyed or transferred
+     * and then simply no longer returned by the API. Excluding it made every
+     * document vanish the moment a zaak was closed on a backend that archives on
+     * the final status (OneGround/RX Mission does this immediately), which hid
+     * the permit and its attachments from the organiser exactly when they need
+     * them, and from the behandelaar consulting a closed dossier.
      */
-    public function isDefinitief(): bool
+    public function isVastgesteld(): bool
     {
         return $this->status === null
             || $this->status === ''
-            || $this->status === self::STATUS_DEFINITIEF;
+            || $this->status === self::STATUS_DEFINITIEF
+            || $this->status === self::STATUS_GEARCHIVEERD;
     }
 }

--- a/tests/Feature/Jobs/Zaak/BesluitNotificationReceivedTest.php
+++ b/tests/Feature/Jobs/Zaak/BesluitNotificationReceivedTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Jobs\Zaak\BesluitNotificationReceived;
+use App\Models\Municipality;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\OpenNotification;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+uses(RefreshDatabase::class);
+
+function besluitNotification(string $besluitUrl): OpenNotification
+{
+    return new OpenNotification(
+        actie: 'create',
+        kanaal: 'besluiten',
+        resource: 'besluit',
+        hoofdObject: $besluitUrl,
+        resourceUrl: $besluitUrl,
+        aanmaakdatum: now()->toIso8601String(),
+    );
+}
+
+test('clears the cached besluiten and documenten of the zaak the besluit belongs to', function () {
+    $zaakUrl = ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1';
+    $besluitUrl = ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1';
+
+    Http::fake([
+        $besluitUrl => Http::response(['url' => $besluitUrl, 'zaak' => $zaakUrl], 200),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'zaaktype_id' => Zaaktype::factory()->for(Municipality::factory())->create()->id,
+    ]);
+
+    Cache::put("zaak.{$zaak->id}.besluiten", collect(['stale']));
+    Cache::put("zaak.{$zaak->id}.documenten", collect(['stale']));
+
+    (new BesluitNotificationReceived(besluitNotification($besluitUrl)))->handle();
+
+    expect(Cache::has("zaak.{$zaak->id}.besluiten"))->toBeFalse()
+        ->and(Cache::has("zaak.{$zaak->id}.documenten"))->toBeFalse();
+});
+
+test('does nothing when the besluit belongs to a zaak we do not know', function () {
+    $besluitUrl = ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1';
+
+    Http::fake([
+        $besluitUrl => Http::response([
+            'url' => $besluitUrl,
+            'zaak' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/onbekend',
+        ], 200),
+    ]);
+
+    (new BesluitNotificationReceived(besluitNotification($besluitUrl)))->handle();
+})->throwsNoExceptions();
+
+test('a besluit that cannot be read is logged and does not fail the job', function () {
+    $besluitUrl = ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1';
+
+    Http::fake([
+        $besluitUrl => Http::response(['detail' => 'Not found'], 404),
+    ]);
+
+    (new BesluitNotificationReceived(besluitNotification($besluitUrl)))->handle();
+})->throwsNoExceptions();

--- a/tests/Feature/Zaak/BesluitVisibilityTest.php
+++ b/tests/Feature/Zaak/BesluitVisibilityTest.php
@@ -4,21 +4,37 @@ declare(strict_types=1);
 
 use App\Enums\Role;
 use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Illuminate\Support\Facades\Http;
 use Tests\Fakes\ZgwHttpFake;
 
-function fakeBesluit(string $verzenddatum, string $documentStatus): Zaak
+/**
+ * @param  array<string, mixed>  $besluitOverrides
+ */
+function fakeBesluit(string $verzenddatum, ?string $documentStatus, array $besluitOverrides = [], bool $isOneGround = false): Zaak
 {
     $zaakUrl = ZgwHttpFake::fakeSingleZaak();
     $besluitUrl = ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1';
     $besluittypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/besluittypen/1';
-    $docUrl = ZgwHttpFake::fakeSingleDocument('1', ['status' => $documentStatus]);
+
+    // A null document status means the besluit has no besluitinformatieobjecten
+    // at all, which is how a besluit taken in the ZGW backend itself commonly
+    // looks: the decision document is kept as a zaakdocument instead.
+    $besluitInformatieObjecten = [];
+    if ($documentStatus !== null) {
+        $docUrl = ZgwHttpFake::fakeSingleDocument('1', ['status' => $documentStatus]);
+        $besluitInformatieObjecten = [[
+            'url' => ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten/1',
+            'besluit' => $besluitUrl,
+            'informatieobject' => $docUrl,
+        ]];
+    }
 
     Http::fake([
-        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten?*' => Http::response(ZgwHttpFake::envelope([[
+        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten?*' => Http::response(ZgwHttpFake::envelope([array_merge([
             'url' => $besluitUrl,
             'identificatie' => 'BES-1',
             'besluittype' => $besluittypeUrl,
@@ -28,12 +44,8 @@ function fakeBesluit(string $verzenddatum, string $documentStatus): Zaak
             'ingangsdatum' => '2026-01-01',
             'verzenddatum' => $verzenddatum,
             'vervaldatum' => null,
-        ]]), 200),
-        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten?*' => Http::response(ZgwHttpFake::envelope([[
-            'url' => ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten/1',
-            'besluit' => $besluitUrl,
-            'informatieobject' => $docUrl,
-        ]]), 200),
+        ], $besluitOverrides)]), 200),
+        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten?*' => Http::response(ZgwHttpFake::envelope($besluitInformatieObjecten), 200),
         $besluittypeUrl => Http::response([
             'url' => $besluittypeUrl,
             'omschrijving' => 'Vergunning',
@@ -41,11 +53,16 @@ function fakeBesluit(string $verzenddatum, string $documentStatus): Zaak
     ]);
 
     $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
-
-    return Zaak::factory()->create([
+    $zaak = Zaak::factory()->create([
         'zgw_zaak_url' => $zaakUrl,
         'zaaktype_id' => $zaaktype->id,
     ]);
+
+    if ($isOneGround) {
+        config()->set("zgw.connections.{$zaak->zgwConnectionName()}.is_oneground", true);
+    }
+
+    return $zaak;
 }
 
 beforeEach(function () {
@@ -68,4 +85,108 @@ test('a besluit with only a concept document is hidden', function () {
     $zaak = fakeBesluit(verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(), documentStatus: 'in_bewerking');
 
     expect($zaak->besluiten)->toHaveCount(0);
+});
+
+test('a besluit with an archived document is shown', function () {
+    // A backend that archives on the final status (OneGround does so
+    // immediately) sets every document to gearchiveerd. That freezes the
+    // document, it does not withdraw it, so the besluit stays visible.
+    $zaak = fakeBesluit(verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(), documentStatus: 'gearchiveerd');
+
+    expect($zaak->besluiten)->toHaveCount(1);
+});
+
+test('on a OneGround connection a besluit without besluitdocumenten is shown', function () {
+    $zaak = fakeBesluit(
+        verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(),
+        documentStatus: null,
+        isOneGround: true,
+    );
+
+    expect($zaak->besluiten)->toHaveCount(1);
+});
+
+test('on a standard connection a besluit without besluitdocumenten stays hidden', function () {
+    $zaak = fakeBesluit(
+        verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(),
+        documentStatus: null,
+    );
+
+    expect($zaak->besluiten)->toHaveCount(0);
+});
+
+test('a besluit without verzenddatum falls back to its publicatiedatum', function () {
+    // verzenddatum is optional in the ZGW Besluiten API; without a fallback such
+    // a besluit would never become visible.
+    $zaak = fakeBesluit(
+        verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(),
+        documentStatus: 'definitief',
+        besluitOverrides: [
+            'verzenddatum' => null,
+            'publicatiedatum' => now('Europe/Amsterdam')->subDay()->toDateString(),
+        ],
+    );
+
+    expect($zaak->besluiten)->toHaveCount(1);
+});
+
+test('a besluit without any send or publication date is hidden', function () {
+    $zaak = fakeBesluit(
+        verzenddatum: now('Europe/Amsterdam')->subDay()->toDateString(),
+        documentStatus: 'definitief',
+        besluitOverrides: ['verzenddatum' => null],
+    );
+
+    expect($zaak->besluiten)->toHaveCount(0);
+});
+
+test('besluitdocumenten are filtered to what the role may see', function () {
+    // The filter used to build a new value object and throw it away, so nothing
+    // was actually filtered.
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $besluitUrl = ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1';
+    $besluittypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/besluittypen/1';
+    $zichtbaar = ZgwHttpFake::fakeSingleDocument('1', ['status' => 'definitief', 'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk']);
+    $verborgen = ZgwHttpFake::fakeSingleDocument('2', ['status' => 'definitief', 'vertrouwelijkheidaanduiding' => 'geheim']);
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten?*' => Http::response(ZgwHttpFake::envelope([[
+            'url' => $besluitUrl,
+            'identificatie' => 'BES-1',
+            'besluittype' => $besluittypeUrl,
+            'zaak' => $zaakUrl,
+            'datum' => '2026-01-01',
+            'toelichting' => 'Test besluit',
+            'ingangsdatum' => '2026-01-01',
+            'verzenddatum' => now('Europe/Amsterdam')->subDay()->toDateString(),
+            'vervaldatum' => null,
+        ]]), 200),
+        ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten?*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten/1', 'besluit' => $besluitUrl, 'informatieobject' => $zichtbaar],
+            ['url' => ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluitinformatieobjecten/2', 'besluit' => $besluitUrl, 'informatieobject' => $verborgen],
+        ]), 200),
+        $besluittypeUrl => Http::response(['url' => $besluittypeUrl, 'omschrijving' => 'Vergunning'], 200),
+    ]);
+
+    $zaaktype = Zaaktype::factory()->for(Municipality::factory())->create();
+    $zaak = Zaak::factory()->create(['zgw_zaak_url' => $zaakUrl, 'zaaktype_id' => $zaaktype->id]);
+
+    expect($zaak->besluiten)->toHaveCount(1)
+        ->and($zaak->besluiten->first()->besluitDocumenten)->toHaveCount(1)
+        ->and($zaak->besluiten->first()->besluitDocumenten->first()->vertrouwelijkheidaanduiding)->toBe('zaakvertrouwelijk');
+});
+
+test('the tab configuration model is unaffected by these visibility rules', function () {
+    // Guard against a regression where showsTab() and the data reads disagree:
+    // the flags live on the connection, the visibility rules do not.
+    $municipality = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->create([
+        'municipality_id' => $municipality->id,
+        'show_besluiten_tab' => false,
+    ]);
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->for($municipality)->create()->id,
+    ]);
+
+    expect($zaak->showsTab('besluiten'))->toBeFalse();
 });

--- a/tests/Feature/Zaak/DocumentVisibilityTest.php
+++ b/tests/Feature/Zaak/DocumentVisibilityTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The status half of document visibility: may this document be shown at all,
+ * regardless of who is asking. The role half (vertrouwelijkheidaanduiding
+ * weighed against the user's role) is covered by ZaakDocumentVisibilityTest,
+ * which calls filterDocumentenForRole directly. It cannot be exercised through
+ * the `documenten` accessor, which skips the role filter while running in
+ * console.
+ *
+ * The scenarios mirror a zaak closed on a OneGround (RX Mission) connection:
+ * closing archives every document immediately, which used to make the whole
+ * file list disappear from a completed permit.
+ */
+
+use App\Models\Municipality;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+/**
+ * @param  list<array<string, mixed>>  $documents
+ */
+function zaakMetDocumenten(array $documents): Zaak
+{
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+
+    $links = [];
+    foreach ($documents as $index => $document) {
+        $uuid = (string) ($index + 1);
+        $docUrl = ZgwHttpFake::fakeSingleDocument($uuid, $document);
+        $links[] = [
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/'.$uuid,
+            'zaak' => $zaakUrl,
+            'informatieobject' => $docUrl,
+        ];
+    }
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope($links), 200),
+    ]);
+
+    return Zaak::factory()->create([
+        'zgw_zaak_url' => $zaakUrl,
+        'zaaktype_id' => Zaaktype::factory()->for(Municipality::factory())->create()->id,
+    ]);
+}
+
+test('an archived document stays visible', function () {
+    // Archived means frozen for archival purposes, not withdrawn. Hiding it made
+    // the permit and its attachments vanish the moment the zaak was closed.
+    $zaak = zaakMetDocumenten([
+        ['status' => 'gearchiveerd', 'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk'],
+    ]);
+
+    expect($zaak->documenten)->toHaveCount(1);
+});
+
+test('a concept document stays hidden', function (string $status) {
+    $zaak = zaakMetDocumenten([
+        ['status' => $status, 'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk'],
+    ]);
+
+    expect($zaak->documenten)->toHaveCount(0);
+})->with([
+    'in_bewerking' => 'in_bewerking',
+    'ter_vaststelling' => 'ter_vaststelling',
+]);
+
+test('a closed OneGround zaak keeps showing its documents', function () {
+    $zaak = zaakMetDocumenten([
+        ['status' => 'gearchiveerd', 'vertrouwelijkheidaanduiding' => 'openbaar', 'titel' => 'Aanvraagformulier'],
+        ['status' => 'gearchiveerd', 'vertrouwelijkheidaanduiding' => 'openbaar', 'titel' => 'Plattegrond'],
+    ]);
+
+    expect($zaak->documenten)->toHaveCount(2);
+});

--- a/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
+++ b/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 /**
  * Zaak::filterDocumentenForRole applies the configured vertrouwelijkheid
  * visibility per role, but an organiser must always see the documents they
- * submitted themselves (the aanvraag-PDF and bijlagen), even when those are
- * uploaded as a vertrouwelijkheid the organiser role is not configured to see
- * (e.g. openbaar on an RX Mission connection).
+ * submitted themselves (the aanvraag-PDF and bijlagen), even when those carry a
+ * vertrouwelijkheid the organiser role is not configured to see.
  */
 
 use App\Enums\Role;
@@ -39,7 +38,7 @@ function documentWith(string $uuid, string $vertrouwelijkheid): Informatieobject
     );
 }
 
-test('an organiser always sees their own submitted documents, even when openbaar is not in the visible set', function () {
+test('an organiser always sees their own submitted documents, even above their visible set', function () {
     $organiser = User::factory()->create(['role' => Role::Organiser]);
     $zaak = Zaak::factory()->create([
         'organisation_id' => Organisation::factory()->create()->id,
@@ -47,23 +46,62 @@ test('an organiser always sees their own submitted documents, even when openbaar
         'organiser_user_id' => $organiser->id,
     ]);
 
-    // The organiser submitted the openbaar document 'own-openbaar'.
+    // The organiser submitted 'own-vertrouwelijk', a level the organiser role is
+    // not configured to see.
     activity('document')
         ->event('created')
         ->causedBy($organiser)
         ->performedOn($zaak)
-        ->withProperties(['document_uuid' => 'own-openbaar'])
+        ->withProperties(['document_uuid' => 'own-vertrouwelijk'])
         ->log('created');
 
     $documents = collect([
-        documentWith('own-openbaar', 'openbaar'),      // the organiser's own → always visible
-        documentWith('other-openbaar', 'openbaar'),    // openbaar but not theirs → hidden
-        documentWith('case-confidential', 'zaakvertrouwelijk'), // in the organiser's default visible set
+        documentWith('own-vertrouwelijk', 'vertrouwelijk'),      // the organiser's own → always visible
+        documentWith('other-vertrouwelijk', 'vertrouwelijk'),    // same level but not theirs → hidden
+        documentWith('case-confidential', 'zaakvertrouwelijk'),  // in the organiser's default visible set
+        documentWith('public', 'openbaar'),                      // openbaar is visible to every role
     ]);
 
     $visible = $zaak->filterDocumentenForRole($documents, Role::Organiser)->pluck('uuid');
 
-    expect($visible->all())->toEqualCanonicalizing(['own-openbaar', 'case-confidential']);
+    expect($visible->all())->toEqualCanonicalizing(['own-vertrouwelijk', 'case-confidential', 'public']);
+});
+
+test('an openbaar document is visible to every role', function (Role $role) {
+    // openbaar is the least confidential level there is, so a role that may see
+    // zaakvertrouwelijk documents may certainly see public ones. Leaving it out
+    // of the defaults meant a backend that labels its documents openbaar
+    // (OneGround does this for system uploads) showed nothing to anyone.
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create()->id,
+    ]);
+
+    $visible = $zaak->filterDocumentenForRole(collect([documentWith('public', 'openbaar')]), $role);
+
+    expect($visible->pluck('uuid')->all())->toBe(['public']);
+})->with([
+    'organiser' => Role::Organiser,
+    'advisor' => Role::Advisor,
+    'reviewer' => Role::Reviewer,
+    'municipality admin' => Role::MunicipalityAdmin,
+    'coordinator' => Role::Coordinator,
+    'admin' => Role::Admin,
+]);
+
+test('a document above the role its clearance stays hidden', function () {
+    // Allowing openbaar must not turn into "every role sees everything".
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create()->id,
+    ]);
+
+    $documents = collect([
+        documentWith('confidential', 'vertrouwelijk'),
+        documentWith('secret', 'geheim'),
+    ]);
+
+    expect($zaak->filterDocumentenForRole($documents, Role::Organiser))->toHaveCount(0);
 });
 
 test('a non-organiser role only follows the configured visibility, without an own-files exception', function () {
@@ -73,17 +111,17 @@ test('a non-organiser role only follows the configured visibility, without an ow
         'organiser_user_id' => User::factory()->create(['role' => Role::Organiser])->id,
     ]);
 
-    // Even if an openbaar document was submitted by the organiser, a reviewer
-    // only sees the levels configured for the reviewer role (openbaar is not one).
+    // Even if the organiser submitted a geheim document, a reviewer only sees
+    // the levels configured for the reviewer role (geheim is not one).
     activity('document')
         ->event('created')
         ->causedBy(User::factory()->create(['role' => Role::Organiser]))
         ->performedOn($zaak)
-        ->withProperties(['document_uuid' => 'organiser-openbaar'])
+        ->withProperties(['document_uuid' => 'organiser-geheim'])
         ->log('created');
 
     $documents = collect([
-        documentWith('organiser-openbaar', 'openbaar'),
+        documentWith('organiser-geheim', 'geheim'),
         documentWith('reviewer-visible', 'vertrouwelijk'),
     ]);
 

--- a/tests/Unit/Actions/GetIncommingNotificationTypeTest.php
+++ b/tests/Unit/Actions/GetIncommingNotificationTypeTest.php
@@ -30,6 +30,13 @@ test('existing channels keep their classification', function () {
     expect(classify('partial_update', 'zaken', 'zaakeigenschap'))->toBe(OpenNotificationType::UpdateZaakEigenschap)
         ->and(classify('create', 'zaken', 'status'))->toBe(OpenNotificationType::ZaakStatusChanged)
         ->and(classify('create', 'documenten', 'enkelvoudiginformatieobject'))->toBe(OpenNotificationType::NewZaakDocument)
-        ->and(classify('update', 'documenten', 'enkelvoudiginformatieobject'))->toBe(OpenNotificationType::UpdatedZaakDocument)
-        ->and(classify('create', 'besluiten', 'besluit'))->toBeNull();
+        ->and(classify('update', 'documenten', 'enkelvoudiginformatieobject'))->toBe(OpenNotificationType::UpdatedZaakDocument);
+});
+
+test('the besluiten channel is classified so a zaak drops its cached besluiten', function () {
+    // We subscribe to this channel; before it was handled the notification was
+    // dropped and a besluit taken in the ZGW backend never reached the zaak.
+    expect(classify('create', 'besluiten', 'besluit'))->toBe(OpenNotificationType::BesluitChanged)
+        ->and(classify('update', 'besluiten', 'besluit'))->toBe(OpenNotificationType::BesluitChanged)
+        ->and(classify('create', 'besluiten', 'besluitinformatieobject'))->toBe(OpenNotificationType::BesluitChanged);
 });

--- a/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
+++ b/tests/Unit/ValueObjects/InformatieobjectStatusTest.php
@@ -24,23 +24,26 @@ function informatieobjectWithStatus(?string $status): Informatieobject
     );
 }
 
-test('definitief and status-less documents count as final', function (?string $status) {
-    expect(informatieobjectWithStatus($status)->isDefinitief())->toBeTrue();
+test('established, archived and status-less documents may be shown', function (?string $status) {
+    expect(informatieobjectWithStatus($status)->isVastgesteld())->toBeTrue();
 })->with([
     'definitief' => 'definitief',
+    // Archived means frozen for archival purposes, not unavailable: access is
+    // governed by the vertrouwelijkheidaanduiding, and a document that may no
+    // longer be seen is destroyed or transferred and then gone from the API.
+    // Hiding it made every document disappear the moment a zaak was closed on a
+    // backend that archives on the final status.
+    'gearchiveerd' => 'gearchiveerd',
     'null (own upload)' => null,
     'empty (own upload)' => '',
 ]);
 
-test('draft, archived and unknown statuses are not final (strict allowlist)', function (string $status) {
-    expect(informatieobjectWithStatus($status)->isDefinitief())->toBeFalse();
+test('draft and unknown statuses are not shown (strict allowlist)', function (string $status) {
+    expect(informatieobjectWithStatus($status)->isVastgesteld())->toBeFalse();
 })->with([
     'in_bewerking' => 'in_bewerking',
     'ter_vaststelling' => 'ter_vaststelling',
     'concept' => 'concept',
-    // Archived documents must never be shown, not even to users who may
-    // otherwise see documents.
-    'gearchiveerd' => 'gearchiveerd',
     // Anything outside the allowlist is hidden, not just the known drafts.
     'unknown status' => 'iets_onbekends',
 ]);


### PR DESCRIPTION
## Problem

Retesting on Rx.Mission produced two findings: the aanvraag documents were not visible to the organiser on Z2026-00000203, and the configurable tabs showed no files and no besluiten.

Reading that zaak straight from the connection explains all of it:

- The zaak was closed on 15-07 and has archiefstatus `gearchiveerd_procestermijn_onbekend`. OneGround archives on the final status.
- All five documents (four added by the behandelaar, plus our aanvraagformulier) have status `gearchiveerd` **and** vertrouwelijkheid `openbaar`. Each of those two filters hid every document on its own, for every role.
- The besluit does have a `verzenddatum`, but has **zero** besluitinformatieobjecten linked to it, so the rule requiring a finalised besluitdocument hid it.

## Changes

**`gearchiveerd` counts as established** (`isDefinitief()` renamed to `isVastgesteld()`). In the ZGW standard the status marks a document as frozen for archival purposes, not as unavailable. VNG describes the field as indicating "whether form and content may still be modified, or are frozen for archival purposes", and considered renaming the values to `veranderlijk`/`onveranderlijk` for that reason. Access is governed by the vertrouwelijkheidaanduiding and authorisations; a document that may genuinely no longer be seen is destroyed or transferred and then simply no longer returned by the API. Excluding it meant the permit and its attachments disappeared the moment the zaak was closed, from the organiser (who needs the permit during the event) and from the behandelaar consulting a closed dossier. Draft statuses and unknown statuses stay hidden.

**`openbaar` is in the default visible set of every role.** It is the least confidential level there is, so a role that may see zaakvertrouwelijk documents may certainly see public ones. Leaving it out meant a backend that labels its documents `openbaar` (OneGround does this for system uploads, and the Heerlen connection is configured with `upload_default.system = openbaar`) showed no documents at all, to anyone. The existing per-connection `vertrouwelijkheid_map` still overrides the defaults, and documents above a role's clearance stay hidden.

**A besluit on a OneGround connection no longer requires a linked besluitdocument.** There the decision document is commonly kept as a zaakdocument instead; requiring the link hid such a besluit indefinitely. Other connections keep the requirement unchanged. `verzenddatum` falls back to `publicatiedatum` when absent, since the field is optional in the Besluiten API.

**The besluitdocumenten role filter actually filters now.** It built a new value object inside an `each()` and discarded it, so the vertrouwelijkheid filtering on besluitdocumenten did nothing. Changed to `map()`.

**Cache invalidation no longer depends solely on notifications.** The documents and besluiten reads were cached forever, so an empty list read once (before the documents existed) was served indefinitely whenever a subscription was missing, unreachable, or on an unhandled channel. Now: a five minute TTL, explicit invalidation at the end of the finish chain (after the besluit and final status), and the `besluiten` notification channel is handled at last. We subscribe to that channel, but `GetIncommingNotificationType` had no branch for it, so a besluit taken in the ZGW backend itself was dropped and never reached the zaak.

## Deployment note

Existing zaken keep serving their cached, empty document and besluit lists until those entries expire. Clearing the cache after deploying makes the fix visible immediately on already-opened zaken such as Z2026-00000203.

## Tests

- Document visibility end to end (status half) and through `filterDocumentenForRole` (role half, including openbaar per role and the clearance ceiling). The accessor skips the role filter while running in console, so the two halves are covered where each is actually exercised.
- Besluit visibility: archived document, no besluitdocumenten on OneGround versus a standard connection, publicatiedatum fallback, no date at all, and the besluitdocumenten role filter.
- `BesluitNotificationReceived`: clears the caches of the right zaak, and stays quiet on an unknown zaak or an unreadable besluit.
- Two existing tests asserted the old assumptions (archived documents must never be shown; openbaar is invisible to every role) and have been rewritten with the reasoning above.

Full suite passes (1822 tests).