### PR TITLE
Make connection behaviour follow the connection actually in use

### DIFF
--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -72,11 +72,11 @@ class MunicipalityZgwConnectionResource extends Resource
                     ->description(__('municipality/resources/zgw_connection.sections.endpoints.description'))
                     ->columns(1)
                     ->schema([
-                        TextInput::make('zaken_url')->label(__('municipality/resources/zgw_connection.fields.zaken_url.label'))->url()->maxLength(255),
-                        TextInput::make('catalogi_url')->label(__('municipality/resources/zgw_connection.fields.catalogi_url.label'))->url()->maxLength(255),
-                        TextInput::make('documenten_url')->label(__('municipality/resources/zgw_connection.fields.documenten_url.label'))->url()->maxLength(255),
-                        TextInput::make('besluiten_url')->label(__('municipality/resources/zgw_connection.fields.besluiten_url.label'))->url()->maxLength(255),
-                        TextInput::make('notificaties_url')->label(__('municipality/resources/zgw_connection.fields.notificaties_url.label'))->url()->maxLength(255),
+                        TextInput::make('zaken_url')->label(__('municipality/resources/zgw_connection.fields.zaken_url.label'))->url()->maxLength(255)->helperText(self::inheritedUrlHelper('zaken')),
+                        TextInput::make('catalogi_url')->label(__('municipality/resources/zgw_connection.fields.catalogi_url.label'))->url()->maxLength(255)->helperText(self::inheritedUrlHelper('catalogi')),
+                        TextInput::make('documenten_url')->label(__('municipality/resources/zgw_connection.fields.documenten_url.label'))->url()->maxLength(255)->helperText(self::inheritedUrlHelper('documenten')),
+                        TextInput::make('besluiten_url')->label(__('municipality/resources/zgw_connection.fields.besluiten_url.label'))->url()->maxLength(255)->helperText(self::inheritedUrlHelper('besluiten')),
+                        TextInput::make('notificaties_url')->label(__('municipality/resources/zgw_connection.fields.notificaties_url.label'))->url()->maxLength(255)->helperText(self::inheritedUrlHelper('notificaties')),
                     ]),
 
                 Section::make(__('municipality/resources/zgw_connection.sections.authentication.heading'))
@@ -277,6 +277,22 @@ class MunicipalityZgwConnectionResource extends Resource
         }
 
         return $options;
+    }
+
+    /**
+     * Helper text spelling out which URL a component falls back to when the field
+     * is left empty. An omitted URL is inherited from the main connection, so a
+     * blank field does not disable the component: it points it at another
+     * instance, where a query about this instance's zaak answers HTTP 200 with no
+     * results and the tab simply looks empty.
+     */
+    private static function inheritedUrlHelper(string $component): string
+    {
+        $inherited = config("zgw.connections.main.urls.{$component}");
+
+        return is_string($inherited) && $inherited !== ''
+            ? __('municipality/resources/zgw_connection.fields.url_inheritance.with_url', ['url' => $inherited])
+            : __('municipality/resources/zgw_connection.fields.url_inheritance.without_url');
     }
 
     /**

--- a/app/Livewire/ConnectionVerifier.php
+++ b/app/Livewire/ConnectionVerifier.php
@@ -35,8 +35,17 @@ class ConnectionVerifier extends Component
      */
     public array $steps = [
         'connection' => ['status' => 'pending', 'message' => ''],
+        'apis' => ['status' => 'pending', 'message' => ''],
         'abonnement' => ['status' => 'pending', 'message' => ''],
     ];
+
+    /**
+     * The APIs checked individually after the base connection check, in the order
+     * they are reported.
+     *
+     * @var list<string>
+     */
+    private const CHECKED_APIS = ['zaken', 'documenten', 'besluiten'];
 
     public bool $needsRegister = false;
 
@@ -59,6 +68,14 @@ class ConnectionVerifier extends Component
         $this->runConnectionStep();
 
         if ($this->steps['connection']['status'] !== 'success') {
+            $this->finish(false);
+
+            return;
+        }
+
+        $this->runApisStep();
+
+        if ($this->steps['apis']['status'] !== 'success') {
             $this->finish(false);
 
             return;
@@ -110,6 +127,51 @@ class ConnectionVerifier extends Component
             $this->logFailure('connection step failed', $e);
             $this->steps['connection'] = ['status' => 'fail', 'message' => $this->trans('connection.error')];
         }
+    }
+
+    /**
+     * One read per API this application uses at runtime. `assertUsable()` only
+     * proves the catalogi API works, while a wrong or omitted base URL for the
+     * zaken, documenten or besluiten API surfaces much later as an empty tab: an
+     * omitted URL inherits the main connection's, and a query there for this
+     * instance's zaak returns HTTP 200 with no results.
+     */
+    private function runApisStep(): void
+    {
+        $this->steps['apis'] = ['status' => 'running', 'message' => ''];
+
+        $failed = [];
+        foreach (self::CHECKED_APIS as $api) {
+            try {
+                $this->registerConfig();
+                $this->readFrom($api);
+            } catch (Throwable $e) {
+                $this->logFailure("api check failed: {$api}", $e);
+                $failed[] = __("municipality/resources/zgw_connection.actions.verify.apis.names.{$api}");
+            }
+        }
+
+        $this->steps['apis'] = $failed === []
+            ? ['status' => 'success', 'message' => $this->trans('apis.success')]
+            : ['status' => 'fail', 'message' => __('municipality/resources/zgw_connection.actions.verify.apis.error', [
+                'apis' => implode(', ', $failed),
+            ])];
+    }
+
+    /**
+     * A single, cheap list request against the given API. Any error (unreachable
+     * host, wrong base URL, missing authorisation) throws.
+     */
+    private function readFrom(string $api): void
+    {
+        $connection = Zgw::connection($this->name());
+
+        match ($api) {
+            'zaken' => $connection->zaken()->zaken()->index(['page' => 1])->first(),
+            'documenten' => $connection->documenten()->enkelvoudiginformatieobjecten()->index(['page' => 1])->first(),
+            'besluiten' => $connection->besluiten()->besluiten()->index(['page' => 1])->first(),
+            default => null,
+        };
     }
 
     private function runAbonnementStep(): void

--- a/app/Livewire/Zaken/ZaakDocumentsTable.php
+++ b/app/Livewire/Zaken/ZaakDocumentsTable.php
@@ -174,8 +174,50 @@ class ZaakDocumentsTable extends Component implements HasActions, HasSchemas, Ha
             ->toolbarActions([
                 DownloadDocumentsAction::make($this->zaak),
             ])
-            ->emptyStateHeading('Een ogenblik geduld, de bestanden van de aanvraag komen zometeen beschikbaar...')
-            ->emptyStateDescription(null);
+            ->emptyStateHeading(fn (): string => $this->emptyStateHeading())
+            ->emptyStateDescription(fn (): ?string => $this->emptyStateDescription());
+    }
+
+    /**
+     * An empty table has three quite different causes, which used to be
+     * indistinguishable: nothing has arrived from ZGW yet, everything that did
+     * arrive is hidden by the visibility rules, or (in submission mode) the zaak
+     * only holds documents that were not part of the application. Saying "hold
+     * on, the files are coming" in the latter two cases sends the reader waiting
+     * for something that is never going to appear.
+     */
+    private function emptyStateHeading(): string
+    {
+        if ($this->zaak->documenten->isNotEmpty()) {
+            return __('Geen bestanden om te tonen');
+        }
+
+        return $this->zaakHasDocumentsInZgw()
+            ? __('Geen bestanden om te tonen')
+            : __('Een ogenblik geduld, de bestanden van de aanvraag komen zometeen beschikbaar...');
+    }
+
+    private function emptyStateDescription(): ?string
+    {
+        if ($this->zaak->documenten->isNotEmpty()) {
+            // Documents exist and are visible, but none of them belong to the
+            // application itself.
+            return __('Bij deze aanvraag zijn geen aanvraagdocumenten ingediend.');
+        }
+
+        return $this->zaakHasDocumentsInZgw()
+            ? __('Deze zaak bevat wel bestanden, maar die zijn niet zichtbaar met uw rechten of hun status. Neem contact op met de beheerder als u ze wel zou moeten zien.')
+            : null;
+    }
+
+    /**
+     * Whether ZGW holds any document for this zaak at all, before the status and
+     * role filters are applied. Distinguishes "nothing there yet" from
+     * "everything filtered out".
+     */
+    private function zaakHasDocumentsInZgw(): bool
+    {
+        return $this->zaak->allDocumentsCount() > 0;
     }
 
     public function render(): View

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -117,11 +117,25 @@ class Zaak extends Model implements Eventable
     }
 
     /**
-     * The per-municipality ZGW connection row, or null when this zaak runs on
-     * the global "main" connection (which has no row, hence default behaviour).
+     * The per-municipality ZGW connection row this zaak actually runs on, or
+     * null when it runs on the global "main" connection (which has no row, hence
+     * default behaviour).
+     *
+     * Gated on the resolved connection name so this never contradicts
+     * {@see zgwConnectionName()}, which is what every data call uses. Reading
+     * `municipality->zgwConnection` directly would return the municipality's
+     * connection even when the zaak reads from main: that happens for a zaak on
+     * a main-fallback zaaktype, and for every zaak of a municipality whose
+     * connection is not (or no longer) activated. Behaviour flags such as
+     * {@see showsTab()} would then describe a different instance than the one
+     * the data comes from.
      */
     public function zgwConnectionModel(): ?MunicipalityZgwConnection
     {
+        if ($this->zgwConnectionName() === ZgwConnectionResolver::DEFAULT_CONNECTION) {
+            return null;
+        }
+
         return $this->municipality?->zgwConnection;
     }
 
@@ -385,6 +399,16 @@ class Zaak extends Model implements Eventable
                 return $this->filterDocumentenForRole($documenten, auth()->user()->role);
             },
         );
+    }
+
+    /**
+     * How many documents ZGW holds for this zaak, before the status and role
+     * filters run. Lets a view tell "nothing has arrived yet" apart from
+     * "everything is filtered out", which otherwise look identical.
+     */
+    public function allDocumentsCount(): int
+    {
+        return $this->getDocuments()->count();
     }
 
     /**

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -33,6 +33,10 @@ return [
             'label' => 'Naam',
             'helper' => 'Optioneel label ter herkenning (bijv. de leverancier en gemeente). Heeft geen invloed op de werking.',
         ],
+        'url_inheritance' => [
+            'with_url' => 'Laat u dit veld leeg, dan wordt :url van de hoofdkoppeling gebruikt. Gegevens worden dan bij die instantie opgevraagd en blijven hier leeg.',
+            'without_url' => 'Laat u dit veld leeg, dan wordt de URL van de hoofdkoppeling gebruikt. Gegevens worden dan bij die instantie opgevraagd en blijven hier leeg.',
+        ],
         'zaken_url' => ['label' => 'Zaken API base-URL'],
         'catalogi_url' => ['label' => 'Catalogi API base-URL'],
         'documenten_url' => ['label' => 'Documenten API base-URL'],
@@ -136,11 +140,21 @@ return [
             'close' => 'Sluiten',
             'steps' => [
                 'connection' => 'Verbinding met de ZGW-instantie',
+                'apis' => 'Toegang tot de losse APIs',
                 'abonnement' => 'Notificatie-abonnement',
             ],
             'connection' => [
                 'success' => 'Eventloket kan deze ZGW-instantie bereiken.',
                 'error' => 'Kon de verbinding niet controleren. Probeer het later opnieuw of neem contact op met de beheerder.',
+            ],
+            'apis' => [
+                'success' => 'Zaken, documenten en besluiten zijn alle drie leesbaar.',
+                'error' => 'Deze APIs zijn niet leesbaar: :apis. Controleer de URL en de autorisatie. Let op: een leeg URL-veld neemt de URL van de hoofdkoppeling over, waardoor gegevens bij de verkeerde instantie worden opgevraagd.',
+                'names' => [
+                    'zaken' => 'Zaken',
+                    'documenten' => 'Documenten',
+                    'besluiten' => 'Besluiten',
+                ],
             ],
             'abonnement' => [
                 'healthy' => 'Het abonnement is geregistreerd en werkt.',

--- a/resources/views/filament/zgw/connection-verifier.blade.php
+++ b/resources/views/filament/zgw/connection-verifier.blade.php
@@ -1,6 +1,7 @@
 @php
     $stepLabels = [
         'connection' => __('municipality/resources/zgw_connection.actions.verify.steps.connection'),
+        'apis' => __('municipality/resources/zgw_connection.actions.verify.steps.apis'),
         'abonnement' => __('municipality/resources/zgw_connection.actions.verify.steps.abonnement'),
     ];
 @endphp

--- a/tests/Feature/Livewire/ConnectionVerifierTest.php
+++ b/tests/Feature/Livewire/ConnectionVerifierTest.php
@@ -38,6 +38,28 @@ beforeEach(function () {
     $this->actingAs(managingUser($this->connection->municipality_id));
 });
 
+/**
+ * Fakes the per-component read checks the verifier runs after the base
+ * connection check. Pass an api name to make that one fail.
+ */
+function fakeApiReads(?string $failing = null): array
+{
+    $endpoints = [
+        'zaken' => GEM.'/zaken/api/v1/zaken*',
+        'documenten' => GEM.'/documenten/api/v1/enkelvoudiginformatieobjecten*',
+        'besluiten' => GEM.'/besluiten/api/v1/besluiten*',
+    ];
+
+    $fakes = [];
+    foreach ($endpoints as $api => $pattern) {
+        $fakes[$pattern] = $api === $failing
+            ? Http::response(['detail' => 'not found'], 404)
+            : Http::response(['count' => 0, 'next' => null, 'previous' => null, 'results' => []], 200);
+    }
+
+    return $fakes;
+}
+
 function healthyAbonnement(int $municipalityId, string $name): string
 {
     $aboUrl = GEM.'/notificaties/api/v1/abonnement/abc';
@@ -66,7 +88,7 @@ it('fails fast when the connection is unreachable', function () {
 
 it('completes and stamps the connection when the abonnement is healthy', function () {
     $aboUrl = healthyAbonnement($this->connection->municipality_id, $this->name);
-    Http::fake([
+    Http::fake(array_merge(fakeApiReads(), [
         $aboUrl => Http::response([
             'url' => $aboUrl,
             'kanalen' => collect(AbonnementRegistrar::KANALEN)->map(fn (string $n): array => ['naam' => $n])->all(),
@@ -75,11 +97,12 @@ it('completes and stamps the connection when the abonnement is healthy', functio
             ['count' => 1, 'next' => null, 'previous' => null, 'results' => [['url' => GEM.'/catalogi/api/v1/catalogussen/1']]],
             200,
         ),
-    ]);
+    ]));
 
     livewire(ConnectionVerifier::class, ['connection' => $this->connection])
         ->call('start')
         ->assertSet('steps.connection.status', 'success')
+        ->assertSet('steps.apis.status', 'success')
         ->assertSet('steps.abonnement.status', 'success')
         ->assertSet('finished', true)
         ->assertSet('success', true);
@@ -87,11 +110,38 @@ it('completes and stamps the connection when the abonnement is healthy', functio
     expect($this->connection->refresh()->last_verified_at)->not->toBeNull();
 });
 
+it('reports which API is unreadable and stops before the abonnement step', function (string $failing, string $label) {
+    // The base check only reads the catalogi API, so a wrong or omitted base URL
+    // for another component used to stay invisible until a zaak page came up
+    // empty. An omitted URL inherits the main connection's, where a query about
+    // this instance's zaak answers 200 with no results.
+    Http::fake(array_merge(fakeApiReads(failing: $failing), [
+        GEM.'/catalogi/api/v1/catalogussen*' => Http::response(
+            ['count' => 1, 'next' => null, 'previous' => null, 'results' => [['url' => GEM.'/catalogi/api/v1/catalogussen/1']]],
+            200,
+        ),
+    ]));
+
+    livewire(ConnectionVerifier::class, ['connection' => $this->connection])
+        ->call('start')
+        ->assertSet('steps.connection.status', 'success')
+        ->assertSet('steps.apis.status', 'fail')
+        ->assertSee($label)
+        ->assertSet('steps.abonnement.status', 'skipped')
+        ->assertSet('success', false);
+
+    expect($this->connection->refresh()->last_verified_at)->toBeNull();
+})->with([
+    'zaken' => ['zaken', 'Zaken'],
+    'documenten' => ['documenten', 'Documenten'],
+    'besluiten' => ['besluiten', 'Besluiten'],
+]);
+
 it('offers a register button and registers the abonnement', function () {
     $base = GEM.'/notificaties/api/v1/';
     $aboUrl = $base.'abonnement/abc';
 
-    Http::fake([
+    Http::fake(array_merge(fakeApiReads(), [
         GEM.'/catalogi/api/v1/catalogussen*' => Http::response(
             ['count' => 1, 'next' => null, 'previous' => null, 'results' => [['url' => GEM.'/catalogi/api/v1/catalogussen/1']]],
             200,
@@ -110,7 +160,7 @@ it('offers a register button and registers the abonnement', function () {
             'url' => $aboUrl,
             'kanalen' => collect(AbonnementRegistrar::KANALEN)->map(fn (string $n): array => ['naam' => $n])->all(),
         ], 200),
-    ]);
+    ]));
 
     livewire(ConnectionVerifier::class, ['connection' => $this->connection])
         ->call('start')

--- a/tests/Feature/Livewire/ZaakDocumentsTableTest.php
+++ b/tests/Feature/Livewire/ZaakDocumentsTableTest.php
@@ -13,6 +13,7 @@ use App\Models\Zaak;
 use App\Models\Zaaktype;
 use App\ValueObjects\ZGW\Informatieobject;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
 use Tests\Fakes\ZgwHttpFake;
 
 use function Pest\Livewire\livewire;
@@ -188,8 +189,8 @@ test('an empty table explains itself when every document is filtered out', funct
         'status' => 'in_bewerking',
         'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk,
     ]);
-    Illuminate\Support\Facades\Http::fake([
-        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Illuminate\Support\Facades\Http::response(
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(
             ZgwHttpFake::envelope([[
                 'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
                 'zaak' => $zaakUrl,

--- a/tests/Feature/Livewire/ZaakDocumentsTableTest.php
+++ b/tests/Feature/Livewire/ZaakDocumentsTableTest.php
@@ -167,3 +167,45 @@ test('a platform admin sees "Nieuwe versie" on every document including the aanv
         ->assertTableActionVisible('new-version', 'own-doc-uuid')
         ->assertTableActionVisible('new-version', 'aanvraagformulier-uuid');
 });
+
+test('an empty table says the files are still coming when ZGW holds none', function () {
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->actingAs($reviewer);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $this->zaak])
+        ->assertSee('Een ogenblik geduld');
+});
+
+test('an empty table explains itself when every document is filtered out', function () {
+    // "Hold on, the files are coming" sends the reader waiting for something that
+    // is never going to appear: the documents are there, they are just not
+    // visible with these rights or this status.
+    $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->actingAs($reviewer);
+
+    $zaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $docUrl = ZgwHttpFake::fakeSingleDocument('1', [
+        'status' => 'in_bewerking',
+        'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Zaakvertrouwelijk,
+    ]);
+    Illuminate\Support\Facades\Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Illuminate\Support\Facades\Http::response(
+            ZgwHttpFake::envelope([[
+                'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten/1',
+                'zaak' => $zaakUrl,
+                'informatieobject' => $docUrl,
+            ]]),
+            200,
+        ),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => $this->organisation->id,
+        'zaaktype_id' => $this->zaaktype->id,
+        'zgw_zaak_url' => $zaakUrl,
+    ]);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->assertSee('Geen bestanden om te tonen')
+        ->assertDontSee('Een ogenblik geduld');
+});

--- a/tests/Feature/Notifications/NotificationSuppressionTest.php
+++ b/tests/Feature/Notifications/NotificationSuppressionTest.php
@@ -13,12 +13,17 @@ function zaakWithSuppression(bool $suppress): Zaak
 {
     $municipality = Municipality::factory()->create();
 
-    MunicipalityZgwConnection::factory()->create([
+    MunicipalityZgwConnection::factory()->active()->create([
         'municipality_id' => $municipality->id,
         'suppress_notifications' => $suppress,
     ]);
 
-    $zaaktype = Zaaktype::factory()->create(['municipality_id' => $municipality->id]);
+    // An activated connection and an own-instance zaaktype: only then does the
+    // zaak actually run on this connection, and only then do its flags apply.
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $municipality->id,
+        'connection' => "gemeente_{$municipality->id}",
+    ]);
 
     return Zaak::factory()->create([
         'zaaktype_id' => $zaaktype->id,

--- a/tests/Feature/Zaak/BesluitVisibilityTest.php
+++ b/tests/Feature/Zaak/BesluitVisibilityTest.php
@@ -180,12 +180,16 @@ test('the tab configuration model is unaffected by these visibility rules', func
     // Guard against a regression where showsTab() and the data reads disagree:
     // the flags live on the connection, the visibility rules do not.
     $municipality = Municipality::factory()->create();
-    MunicipalityZgwConnection::factory()->create([
+    MunicipalityZgwConnection::factory()->active()->create([
         'municipality_id' => $municipality->id,
         'show_besluiten_tab' => false,
     ]);
+    // An activated connection and an own-instance zaaktype: the flags only
+    // describe a zaak that actually reads from this connection.
     $zaak = Zaak::factory()->create([
-        'zaaktype_id' => Zaaktype::factory()->for($municipality)->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->for($municipality)->create([
+            'connection' => "gemeente_{$municipality->id}",
+        ])->id,
     ]);
 
     expect($zaak->showsTab('besluiten'))->toBeFalse();

--- a/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
+++ b/tests/Feature/Zgw/ConnectionFeatureFlagsTest.php
@@ -7,17 +7,27 @@ use App\Models\MunicipalityZgwConnection;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 
-function zaakForConnection(array $connectionAttributes = [], bool $withConnection = true): Zaak
+function zaakForConnection(array $connectionAttributes = [], bool $withConnection = true, bool $active = true): Zaak
 {
     $municipality = Municipality::factory()->create();
 
     if ($withConnection) {
-        MunicipalityZgwConnection::factory()->create(array_merge([
+        $factory = MunicipalityZgwConnection::factory();
+        if ($active) {
+            $factory = $factory->active();
+        }
+        $factory->create(array_merge([
             'municipality_id' => $municipality->id,
         ], $connectionAttributes));
     }
 
-    $zaaktype = Zaaktype::factory()->create(['municipality_id' => $municipality->id]);
+    // An own-instance zaaktype: the `connection` column records which instance
+    // hosts it, and it defaults to 'main'. A zaak on a main row reads from main
+    // and therefore keeps main's behaviour, which is covered separately below.
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $municipality->id,
+        'connection' => "gemeente_{$municipality->id}",
+    ]);
 
     return Zaak::factory()->create([
         'zaaktype_id' => $zaaktype->id,
@@ -92,4 +102,46 @@ test('a OneGround connection always blocks organiser withdrawal', function () {
     ]);
 
     expect($zaak->organiserCanWithdraw())->toBeFalse();
+});
+
+test('a connection that is not activated yet keeps the default behaviour', function () {
+    // Until activation the zaak reads from main, so the flags of the connection
+    // being prepared must not describe it. They used to, which meant the tabs and
+    // the status lock followed one instance while the data came from another.
+    $zaak = zaakForConnection([
+        'show_besluiten_tab' => false,
+        'show_bestanden_tab' => false,
+        'lock_status_for_behandelaar' => true,
+        'is_oneground' => true,
+    ], active: false);
+
+    expect($zaak->zgwConnectionName())->toBe('main')
+        ->and($zaak->showsTab('besluiten'))->toBeTrue()
+        ->and($zaak->showsTab('bestanden'))->toBeTrue()
+        ->and($zaak->behandelaarCanChangeStatus())->toBeTrue()
+        ->and($zaak->organiserCanWithdraw())->toBeTrue();
+});
+
+test('a zaak on a main-fallback zaaktype keeps the default behaviour', function () {
+    // The zaaktype records which instance hosts it. A main-catalogus row reads
+    // from main even while the municipality runs its own instance, so the
+    // connection's flags do not apply to this zaak either.
+    $municipality = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->active()->create([
+        'municipality_id' => $municipality->id,
+        'show_bestanden_tab' => false,
+        'lock_status_for_behandelaar' => true,
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'municipality_id' => $municipality->id,
+            'connection' => 'main',
+        ])->id,
+        'zgw_zaak_url' => null,
+    ]);
+
+    expect($zaak->zgwConnectionName())->toBe('main')
+        ->and($zaak->showsTab('bestanden'))->toBeTrue()
+        ->and($zaak->behandelaarCanChangeStatus())->toBeTrue();
 });


### PR DESCRIPTION
Hardening around the ZGW koppeling, prompted by the Rx.Mission retest. None of this caused the four reported findings (those are fixed in the three preceding PRs); each item here turns a silent failure into a visible one, so the "tab is just empty" class of problem stops recurring.

## Behaviour flags now follow the resolved connection

`zgwConnectionModel()` read `municipality->zgwConnection` directly, while every data call resolves through `ZgwConnectionResolver`. The two disagree in two real situations:

- A zaak on a main-fallback zaaktype reads from main, but got the municipality connection's flags.
- Every zaak of a municipality whose connection is not (or no longer) activated reads from main. Deactivation is easy to trigger: any change to a critical field (a URL, a credential, the RSIN) resets `activated_at`.

In both cases the tabs, the status lock, withdrawal and notification suppression described a different instance than the one the data came from. The model is now gated on the resolved connection name, so the two can no longer contradict each other.

## The connection test reads from each API

`assertUsable()` makes one catalogi call, which proves nothing about the zaken, documenten or besluiten API. A wrong or omitted base URL for one of those stayed invisible until a zaak page came up empty, because an omitted URL is inherited from the main connection: the request then succeeds against the wrong instance and returns HTTP 200 with no results for this instance's zaak.

The verifier now performs one cheap list request per API and names the ones that fail, stopping before the abonnement step. The URL fields also spell the inheritance out in their helper text, so a blank field no longer reads as "this component is disabled".

## An empty document table says why it is empty

"Een ogenblik geduld, de bestanden van de aanvraag komen zometeen beschikbaar..." was shown for three quite different situations: nothing has arrived from ZGW yet, everything that arrived is hidden by the visibility rules, or the zaak holds no application documents in submission-only mode. In the last two the reader is waiting for something that will never appear. The heading and description now distinguish them.

## Deliberately not included

The plan also mentioned recording our own uploaded document uuids on the zaak, to replace both the activity-log based own-files fallback and the filename matching in `SubmissionDocumentDetector`. With `openbaar` now in the default visible set (PR #464) that fallback is no longer load-bearing, so the added column and write path would be complexity without a current failure behind it. Worth revisiting if filename matching turns out to break on a backend that renames uploads.

## Tests

- Verifier: each API failing individually is reported by name, the abonnement step is skipped, and the connection is not stamped as verified.
- Feature flags: a connection that is not activated yet, and a zaak on a main-fallback zaaktype, both keep main's behaviour.
- Empty states: "files are coming" only when ZGW genuinely holds nothing.

Two existing tests set up an unactivated connection with a main-catalogus zaaktype while asserting the connection's flags applied. That combination reads from main, so they now build the connection they actually describe: activated, with an own-instance zaaktype.

Full suite passes (1807 tests).