### PR TITLE
Strip the copied brkGemeente where it actually lives, and name the gemeente mismatch

### DIFF
--- a/app/EventForm/Persistence/PrefillLoader.php
+++ b/app/EventForm/Persistence/PrefillLoader.php
@@ -187,12 +187,36 @@ class PrefillLoader
 
         foreach ($addresses as $index => $row) {
             if (is_array($row)) {
-                unset($addresses[$index]['brkGemeente']);
+                $addresses[$index] = $this->withoutBrkGemeente($row);
             }
         }
 
         $values['adresVanDeGebouwEn'] = $addresses;
 
         return $values;
+    }
+
+    /**
+     * Removes every `brkGemeente` entry from a copied address row, at whatever
+     * depth it sits. The value does not live on the row itself but under the
+     * AddressNL fieldset prefix (currently
+     * `adresVanHetGebouwWaarUwEvenementPlaatsvindt1.brkGemeente`), so clearing
+     * the row's own keys would miss it entirely. Walking the row instead of
+     * hardcoding that prefix keeps this working when the schema key changes.
+     *
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function withoutBrkGemeente(array $row): array
+    {
+        unset($row['brkGemeente']);
+
+        foreach ($row as $key => $value) {
+            if (is_array($value)) {
+                $row[$key] = $this->withoutBrkGemeente($value);
+            }
+        }
+
+        return $row;
     }
 }

--- a/app/EventForm/Submit/ResolveZaaktype.php
+++ b/app/EventForm/Submit/ResolveZaaktype.php
@@ -6,6 +6,7 @@ namespace App\EventForm\Submit;
 
 use App\Enums\ZaaktypeRole;
 use App\EventForm\State\FormState;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaaktype;
@@ -153,9 +154,14 @@ final class ResolveZaaktype
      * Without this a stale gemeente in the state (a copied aanvraag, an edited
      * location) would silently create the zaak for the previous municipality,
      * and with it on the previous municipality's ZGW instance. Failing the
-     * submit is the lesser harm; the organiser is sent back through the location
-     * step. A state without a location check result (older drafts) is left
-     * alone.
+     * submit is the lesser harm. A state without a location check result (older
+     * drafts) is left alone.
+     *
+     * @throws GemeenteLocatieMismatchException so the submit handler can tell
+     *                                          the organiser to revisit the
+     *                                          location step, instead of the
+     *                                          generic "try again" that a plain
+     *                                          failure produces.
      */
     private function assertMunicipalityMatchesLocation(FormState $state, string $brk): void
     {
@@ -165,11 +171,7 @@ final class ResolveZaaktype
         }
 
         if (! array_key_exists($brk, $gemeenten)) {
-            throw new RuntimeException(sprintf(
-                'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
-                $brk,
-                implode(', ', array_keys($gemeenten)),
-            ));
+            throw new GemeenteLocatieMismatchException($brk, array_map(strval(...), array_keys($gemeenten)));
         }
     }
 }

--- a/app/Exceptions/GemeenteLocatieMismatchException.php
+++ b/app/Exceptions/GemeenteLocatieMismatchException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when the gemeente in the FormState is not among the municipalities the
+ * location check found for the submitted location. Creating the zaak anyway
+ * would put it in the wrong municipality, and with it on the wrong ZGW instance.
+ *
+ * Its own type so the submit handler can tell the organiser what to do about it:
+ * retrying is pointless, the location step has to be revisited.
+ */
+class GemeenteLocatieMismatchException extends RuntimeException
+{
+    /**
+     * @param  string  $brk  The brk_identification held in the FormState.
+     * @param  list<string>  $foundBrkIdentifications  The municipalities found for the submitted location.
+     */
+    public function __construct(
+        public readonly string $brk,
+        public readonly array $foundBrkIdentifications,
+    ) {
+        parent::__construct(sprintf(
+            'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
+            $brk,
+            implode(', ', $foundBrkIdentifications),
+        ));
+    }
+}

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -11,6 +11,7 @@ use App\EventForm\Schema\EventFormSchema;
 use App\EventForm\Services\ServiceFetcher;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\SubmitEventForm;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Resources\Zaken\ZaakResource;
 use App\Models\Municipality;
 use App\Models\Organisation;
@@ -700,6 +701,21 @@ class EventFormPage extends Page implements HasForms
 
         try {
             $zaak = app(SubmitEventForm::class)->execute($this->state, $user, $org, $this->activeDraft());
+        } catch (GemeenteLocatieMismatchException $e) {
+            report($e);
+            $this->submitting = false;
+
+            // Opnieuw proberen lost dit nooit op: de gemeente in de state hoort
+            // niet bij de opgegeven locatie. De generieke "probeer het opnieuw"
+            // zou de organisator op een doodlopend pad zetten.
+            Notification::make()
+                ->danger()
+                ->title('Aanvraag niet ingediend')
+                ->body('De gemeente in uw aanvraag hoort niet bij de locatie die u heeft opgegeven. Ga terug naar de stap "Locatie", controleer het adres en bepaal de gemeente opnieuw.')
+                ->persistent()
+                ->send();
+
+            return;
         } catch (\Throwable $e) {
             report($e);
             // Reset zodat de gebruiker kan retry'en nu de fout zichtbaar is —

--- a/tests/Feature/EventForm/Pages/EventFormPageSubmitGuardTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageSubmitGuardTest.php
@@ -25,6 +25,7 @@ use App\Enums\Role;
 use App\EventForm\Persistence\Draft;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\SubmitEventForm;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Pages\EventFormPage;
 use App\Models\Municipality;
 use App\Models\Organisation;
@@ -33,6 +34,7 @@ use App\Models\Users\OrganiserUser;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
@@ -197,6 +199,35 @@ test('na een mislukte submit kan de organisator opnieuw proberen', function () {
     $page->submit();
 
     expect($fake->aantalAanroepen)->toBe(2);
+});
+
+test('een gemeente die niet bij de locatie hoort levert een melding op die naar de locatiestap verwijst', function () {
+    // De generieke "probeer het opnieuw" is hier misleidend: opnieuw indienen
+    // geeft gegarandeerd dezelfde fout. De organisator moet terug naar de
+    // locatiestap, en dat moet de melding ook zeggen.
+    $fake = new FakeSubmitEventForm(
+        gooitException: new GemeenteLocatieMismatchException('GM0917', ['GM0935']),
+    );
+    app()->instance(SubmitEventForm::class, $fake);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+    setupValidSubmit($page, $this->user, $this->organisation);
+
+    $page->submit();
+
+    $component->assertNotified(
+        FilamentNotification::make()
+            ->danger()
+            ->title('Aanvraag niet ingediend')
+            ->body('De gemeente in uw aanvraag hoort niet bij de locatie die u heeft opgegeven. Ga terug naar de stap "Locatie", controleer het adres en bepaal de gemeente opnieuw.')
+            ->persistent()
+    );
+
+    // De vlag moet gereset zijn: de organisator kan na het corrigeren van de
+    // locatie opnieuw indienen zonder de pagina te herladen.
+    expect($page->submitting)->toBeFalse();
 });
 
 test('submit() op leeg formulier gooit validatiefouten en roept SubmitEventForm niet aan', function () {

--- a/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
+++ b/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
@@ -213,10 +213,30 @@ test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
     // Het verborgen brkGemeente-veld wordt door de locatiecheck verbatim
     // vertrouwd; een gekopieerde waarde zou een gewijzigd adres naar de oude
     // gemeente routeren.
+    //
+    // De rijvorm is die van de repeater in LocatieVanHetEvenement2Step: rijen
+    // gekeyed op uuid, met het adres genest onder de AddressNL-prefix. Dezelfde
+    // vorm die ServiceFetcher::collectAddressesFromEditgrid() uitleest.
     $sc = scenarioZaakMetSnapshot([
         'adresVanDeGebouwEn' => [
-            ['postcode' => '6411CD', 'huisnummer' => '32', 'straatnaam' => 'Coriovallumstraat', 'brkGemeente' => 'GM0917'],
-            ['postcode' => '6361BZ', 'huisnummer' => '1', 'straatnaam' => 'Deweverplein', 'brkGemeente' => 'GM1954'],
+            'row-1' => [
+                'naamVanDeLocatieGebouw' => 'Hoofdgebouw',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6411CD',
+                    'huisnummer' => '32',
+                    'straatnaam' => 'Coriovallumstraat',
+                    'brkGemeente' => 'GM0917',
+                ],
+            ],
+            'row-2' => [
+                'naamVanDeLocatieGebouw' => 'Bijgebouw',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6361BZ',
+                    'huisnummer' => '1',
+                    'straatnaam' => 'Deweverplein',
+                    'brkGemeente' => 'GM1954',
+                ],
+            ],
         ],
     ]);
 
@@ -224,11 +244,13 @@ test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
     $adressen = $state->get('adresVanDeGebouwEn');
 
     expect($adressen)->toHaveCount(2)
-        ->and($adressen[0])->not->toHaveKey('brkGemeente')
-        ->and($adressen[1])->not->toHaveKey('brkGemeente')
+        ->and($adressen)->toHaveKeys(['row-1', 'row-2'])
+        ->and($adressen['row-1']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1'])->not->toHaveKey('brkGemeente')
+        ->and($adressen['row-2']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1'])->not->toHaveKey('brkGemeente')
         // De ingevulde adresgegevens zelf blijven staan.
-        ->and($adressen[0]['postcode'])->toBe('6411CD')
-        ->and($adressen[1]['straatnaam'])->toBe('Deweverplein');
+        ->and($adressen['row-1']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1']['postcode'])->toBe('6411CD')
+        ->and($adressen['row-1']['naamVanDeLocatieGebouw'])->toBe('Hoofdgebouw')
+        ->and($adressen['row-2']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1']['straatnaam'])->toBe('Deweverplein');
 });
 
 test('velden die niet meer in het schema zitten komen stil mee uit de snapshot', function () {

--- a/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
+++ b/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
@@ -21,6 +21,7 @@ use App\Enums\ZaaktypeRole;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\DetermineAanvraagType;
 use App\EventForm\Submit\ResolveZaaktype;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\MunicipalityZgwConnection;
@@ -311,8 +312,10 @@ test('gemeente die niet bij de gevonden locatie hoort → harde fout in plaats v
         'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
     ]);
 
+    // Een eigen exceptietype, zodat de submit-handler de organisator naar de
+    // locatiestap kan sturen in plaats van de generieke "probeer het opnieuw".
     expect(fn () => $this->resolve->forState($state))
-        ->toThrow(RuntimeException::class, 'hoort niet bij de gevonden gemeenten');
+        ->toThrow(GemeenteLocatieMismatchException::class, 'hoort niet bij de gevonden gemeenten');
 });
 
 test('gemeente die wel bij de gevonden locatie hoort wordt gewoon gebruikt', function () {


### PR DESCRIPTION
Two follow-ups on #463, found while reviewing it after the merge. Both are small; the first one is a fix that was believed to be in place and was not.

## The copied `brkGemeente` was never stripped

`PrefillLoader::stripAddressBrkGemeente()` cleared `brkGemeente` on the address row itself. In the repeater the address lives one level down, under the AddressNL fieldset prefix (`adresVanHetGebouwWaarUwEvenementPlaatsvindt1`), which is also where `ServiceFetcher::collectAddressesFromEditgrid()` reads it from. The key the strip unset does not exist, so a copied aanvraag kept the hidden municipality of the source address, and the location check trusts that value verbatim.

Its test asserted a flat row shape the form never produces, so it stayed green while the code did nothing. That is the part worth fixing regardless of impact: a passing test on the exact behaviour the PR is about.

The row is now walked instead, so the entry is removed wherever it sits and a schema key rename cannot silently disable this again. The test uses the real snapshot shape (rows keyed by uuid, address nested), and fails against the old implementation.

Practical exposure was limited, because #463 also made `AddressNL::lookupCallback()` clear `brkGemeente` before every lookup. That is the layer that was actually protecting this path.

## A gemeente that does not match the location says what to do

The guard in `ResolveZaaktype` threw a plain `RuntimeException`, which the catch-all in `EventFormPage::submit()` turned into "Er is een fout opgetreden bij het indienen. Probeer het opnieuw." Retrying produces the identical failure, so the organiser is stuck without being told that the location step is where the problem is.

Now a dedicated `GemeenteLocatieMismatchException` with its own catch and message: the gemeente does not belong to the location given, go back to the "Locatie" step, check the address and determine the gemeente again. The `submitting` flag is still reset, so submitting again after correcting the location works without a reload.

## Tests

- `PrefillFromZaakTest`: the brkGemeente test now uses the repeater shape and covers the nested key. Verified that it fails without the fix.
- `EventFormPageSubmitGuardTest`: a mismatch produces the location-specific notification and resets the submit flag.
- `ResolveZaaktypeTest`: asserts the dedicated exception type rather than any `RuntimeException`.

`tests/Feature/EventForm` and `tests/Unit/EventForm` pass (540 tests). Pint and PHPStan clean.
