### PR TITLE
Update postcss to resolve a path traversal advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1659,9 +1659,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.15",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-            "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+            "version": "3.3.16",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+            "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
             "dev": true,
             "funding": [
                 {
@@ -1730,9 +1730,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.5.15",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-            "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+            "version": "8.5.24",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+            "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
             "dev": true,
             "funding": [
                 {
@@ -1750,7 +1750,7 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "nanoid": "^3.3.12",
+                "nanoid": "^3.3.16",
                 "picocolors": "^1.1.1",
                 "source-map-js": "^1.2.1"
             },


### PR DESCRIPTION
Resolves the Dependabot alert that came in this evening (high, GHSA-r28c-9q8g-f849).

## The advisory

postcss auto-detects a `/*# sourceMappingURL=... */` comment in the CSS it is asked to parse and tries to load that path from disk, unless the caller explicitly opts out. The candidate path is built with `path.join()`, which normalises but does not sandbox `..` segments, so a crafted comment can make it read a `.map` file outside the intended directory. With no `from` option set, an absolute path in the comment is used verbatim.

Patched in 8.5.18.

## The change

`package-lock.json` only:

- postcss 8.5.15 → 8.5.24
- nanoid 3.3.15 → 3.3.16 (postcss's own dependency, moves with it)

postcss is a dev-only transitive dependency of vite and tailwind, and their range (`^8.5.15`) already allowed the patched version, so `npm update postcss` was enough and no `overrides` entry is needed.

## Verification

`npm ci` followed by `npm run build` completes, so the asset pipeline (including the Filament panel themes, which is where tailwind and postcss actually do their work) is unaffected. The lockfile was regenerated with the same npm version the project container uses, so the diff is limited to the two version bumps.
