### PR TITLE
Add user-facing release notes for v1.1.2

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -12,6 +12,8 @@ categories:
     label: 'changelog: breaking'
   - title: '✨ New feautures'
     label: 'changelog: feature'
+  - title: '🔒 Security'
+    label: 'changelog: security'
   - title: '🐛 Bug Fixes'
     label: 'changelog: bug'
   - title: '📝 Documentation'

--- a/docs/releases/RELEASE_NOTES_v1.1.2_NL.md
+++ b/docs/releases/RELEASE_NOTES_v1.1.2_NL.md
@@ -1,0 +1,43 @@
+# Eventloket versie 1.1.2: wat is er nieuw?
+
+**Releasedatum:** 28 juli 2026
+
+---
+
+Deze versie is een korte onderhoudsrelease. Er zijn twee storingen opgelost waarbij een scherm volledig vastliep, en er is een aantal externe softwarecomponenten bijgewerkt naar een veilige versie. Er zijn geen nieuwe functies en er verandert niets aan de manier van werken.
+
+---
+
+## 🐛 Opgeloste problemen
+
+### Adviesinbox liep vast na het verwijderen van een aanvraag
+
+**Voor wie:** Adviseurs
+
+Stond er in de adviesinbox een adviesvraag waarvan de bijbehorende aanvraag inmiddels was verwijderd, dan liep het hele dashboard vast met een foutmelding. Niet alleen die ene regel, maar het volledige overzicht was daardoor onbereikbaar.
+
+Zulke adviesvragen worden nu niet meer in de inbox getoond. Dat is ook logisch: de bijbehorende aanvraag bestaat niet meer, dus er valt niets meer te openen of te beantwoorden. De rest van de inbox werkt weer gewoon.
+
+---
+
+### Aanvraag zonder gekoppelde organisatie liet het scherm vastlopen
+
+**Voor wie:** Organisatoren
+
+Opende een organisator een aanvraag die niet aan een organisatie gekoppeld is, dan liep de pagina vast met een foutmelding in plaats van dat er iets zinnigs werd getoond. Dat is opgelost. Zo'n aanvraag is voor een organisator niet toegankelijk, en dat wordt nu netjes afgehandeld in plaats van met een storing.
+
+---
+
+## 🔒 Beveiliging
+
+**Voor wie:** Iedereen, maar er is niets zichtbaars aan
+
+Een aantal externe softwarecomponenten dat Eventloket gebruikt, is bijgewerkt naar een versie zonder bekende kwetsbaarheden. Het gaat om onderdelen voor het maken van PDF-bestanden, het versturen van verzoeken naar andere systemen en het bouwen van de schermopmaak.
+
+Deze updates lossen meldingen op die door de beveiligingscontrole van de broncode zijn gesignaleerd. Er zijn geen aanwijzingen dat er misbruik van is gemaakt. Aan de werking van de applicatie verandert niets.
+
+---
+
+## 📱 Wat moet je doen?
+
+**Niets!** De verbeteringen werken automatisch na de update.


### PR DESCRIPTION
Prepares the v1.1.2 release, following the pattern of #453 and #459.

## User-facing release notes

`docs/releases/RELEASE_NOTES_v1.1.2_NL.md`, in the same shape as the v1.1.1 notes: what changed, for whom, and what the reader has to do.

v1.1.2 is a maintenance release: the two fatal errors from #460 and #461, and the dependency updates from #466 and #468. The security section describes the updates in plain terms, without naming packages or advisories, since the audience is municipal staff rather than developers.

## A security category for the release drafter

`changelog: security` was already listed as a patch-level label in the version resolver, but there was no matching entry under `categories`. A PR carrying only that label therefore ended up in "Other changes" without anyone noticing. The section is added above "Bug Fixes", so a security fix leads the notes rather than trailing them.

## Related label correction

Not part of this diff, but relevant to the draft: #466 had no changelog label at all and landed in "Other changes", while #468 was auto-labelled `changelog: bug` because its branch starts with `fix/`. Both are dependency updates, so both now carry `changelog: dependencies` and the draft groups them together.

The autolabeler is what caused that split: any branch matching `fix/*` gets `changelog: bug`. Naming future dependency branches `chore/*` avoids it, which is why the rule is left as is rather than made more clever.
