### PR TITLE
Let coordinators choose who may view an uploaded document

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -150,7 +150,7 @@ class UploadDocumentAction
             });
 
         $userRole = auth()->user()->role;
-        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::MunicipalityAdmin, Role::Admin])) {
+        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin])) {
             $fields[] = Select::make('vertrouwelijkheidaanduiding')
                 ->label(__('Wie mag dit document inzien?'))
                 ->options(function () {

--- a/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
+++ b/app/Filament/Shared/Resources/Zaken/Tables/ZakenTable.php
@@ -76,7 +76,7 @@ class ZakenTable
                     ->toggleable()
                     ->searchable()
                     ->forceSearchCaseInsensitive()
-                    ->visible(fn () => in_array(auth()->user()->role, [Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin, Role::Reviewer, Role::Admin])),
+                    ->visible(fn () => in_array(auth()->user()->role, [Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::Reviewer, Role::Admin])),
                 TextColumn::make('reference_data.status_name')
                     ->label(__('resources/zaak.columns.status.label'))
                     ->sortable()

--- a/app/Models/Scopes/ZaakEventScope.php
+++ b/app/Models/Scopes/ZaakEventScope.php
@@ -14,7 +14,7 @@ class ZaakEventScope implements Scope
      */
     public function apply(Builder $builder, Model $model): void
     {
-        if (auth()->check() && in_array(auth()->user()->role, [Role::Advisor, Role::Admin, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin, Role::Reviewer])) {
+        if (auth()->check() && in_array(auth()->user()->role, [Role::Advisor, Role::Admin, Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::Reviewer])) {
             $builder->select('id', 'public_id', 'reference_data', 'zaaktype_id', 'organisation_id', 'organiser_user_id', 'zgw_zaak_url', 'imported_data')->with(['organisation' => function ($query) {
                 $query->select('id', 'name', 'type', 'email', 'phone', 'address');
             }, 'zaaktype', 'organiserUser']);

--- a/tests/Feature/CoordinatorRoleTest.php
+++ b/tests/Feature/CoordinatorRoleTest.php
@@ -2,6 +2,7 @@
 
 use App\Enums\Role;
 use App\Filament\Shared\Resources\Zaken\Pages\ViewZaak;
+use App\Models\Event;
 use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
@@ -497,5 +498,37 @@ describe('coordinator assignable as reviewer', function () {
             ->assertHasActionErrors(['reviewer_user_id']);
 
         expect($zaak->refresh()->reviewer_user_id)->toBeNull();
+    });
+});
+
+// --- ZaakEventScope ---
+
+describe('ZaakEventScope for coordinator', function () {
+    beforeEach(function () {
+        $this->organiserUser = User::factory()->create(['role' => Role::Organiser]);
+
+        $this->event = Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'organisation_id' => $this->organisation->id,
+            'organiser_user_id' => $this->organiserUser->id,
+        ]);
+    });
+
+    it('selects the full column set for a coordinator, just like a reviewer', function () {
+        $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+        $coordinator->municipalities()->attach($this->municipality);
+
+        $this->actingAs($coordinator);
+        $asCoordinator = Event::find($this->event->id);
+
+        $reviewer = User::factory()->create(['role' => Role::Reviewer]);
+        $reviewer->municipalities()->attach($this->municipality);
+
+        $this->actingAs($reviewer);
+        $asReviewer = Event::find($this->event->id);
+
+        expect(array_keys($asCoordinator->getAttributes()))
+            ->toEqualCanonicalizing(array_keys($asReviewer->getAttributes()))
+            ->and($asCoordinator->organiser_user_id)->toBe($this->organiserUser->id);
     });
 });

--- a/tests/Feature/Filament/Shared/Resources/ZaakInternZaaknummerTest.php
+++ b/tests/Feature/Filament/Shared/Resources/ZaakInternZaaknummerTest.php
@@ -77,6 +77,26 @@ test('admin sees intern zaaknummer column in zaken table', function () {
         ->assertSee(__('resources/zaak.columns.intern_zaaknummer.label'));
 });
 
+test('coordinator sees intern zaaknummer column in zaken table', function () {
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+    ZgwHttpFake::wildcardFake();
+
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => referenceDataWithInternZaaknummer('INT-001'),
+    ]);
+
+    $coordinator = User::factory()->create(['role' => Role::Coordinator]);
+    $coordinator->municipalities()->attach($this->municipality);
+
+    $this->actingAs($coordinator);
+    Filament::setTenant($this->municipality);
+
+    livewire(ListZaken::class)
+        ->assertOk()
+        ->assertSee(__('resources/zaak.columns.intern_zaaknummer.label'));
+});
+
 test('organiser does not see intern zaaknummer column in zaken table', function () {
     Filament::setCurrentPanel(Filament::getPanel('organiser'));
     ZgwHttpFake::wildcardFake();

--- a/tests/Feature/MultiUploadDocumentActionTest.php
+++ b/tests/Feature/MultiUploadDocumentActionTest.php
@@ -1,13 +1,18 @@
 <?php
 
+use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\OrganisationRole;
 use App\Enums\Role;
+use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Livewire\Zaken\ZaakDocumentsTable;
+use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Repeater;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
@@ -22,9 +27,14 @@ beforeEach(function () {
     $this->organiser = User::factory()->create(['role' => Role::Organiser]);
     $this->organisation = Organisation::factory()->create(['type' => 'business']);
     $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+    $this->municipality = Municipality::factory()->create();
     $this->zaaktype = Zaaktype::factory()->create([
         'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        'municipality_id' => $this->municipality->id,
     ]);
+
+    $this->coordinator = User::factory()->create(['role' => Role::Coordinator]);
+    $this->coordinator->municipalities()->attach($this->municipality);
 });
 
 test('upload action exists on ZaakDocumentsTable', function () {
@@ -113,4 +123,91 @@ test('download documents bulk action exists on ZaakDocumentsTable', function () 
 
     livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
         ->assertTableBulkActionExists('download-documents');
+});
+
+test('coordinator gets the confidentiality select in the multi upload schema', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    $fieldNames = array_map(
+        fn (Field|Repeater $field): string => $field->getName(),
+        UploadDocumentAction::schema($zaak),
+    );
+
+    expect($fieldNames)->toContain('vertrouwelijkheidaanduiding');
+});
+
+test('organiser does not get the confidentiality select in the multi upload schema', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    $fieldNames = array_map(
+        fn (Field|Repeater $field): string => $field->getName(),
+        UploadDocumentAction::schema($zaak),
+    );
+
+    expect($fieldNames)->not->toContain('vertrouwelijkheidaanduiding');
+});
+
+test('coordinator can choose the confidentiality level when uploading documents', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/coordinator-file.pdf';
+    Storage::put($path, '%PDF-1.4 coordinator file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen*' => Http::response([
+            [
+                'uuid' => '1',
+                'url' => $documentTypeUrl,
+                'omschrijving' => 'Bijlage',
+                'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+            ],
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
+            'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Confidentieel->value,
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Intern advies', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->vertrouwelijkheidaanduiding === DocumentVertrouwelijkheden::Confidentieel->value,
+    );
 });


### PR DESCRIPTION
## Problem

A user with the **coordinator** role does not see the "Wie mag dit document inzien?" select in the "Nieuw bestand toevoegen" modal on the documents tab of a zaak. A behandelaar and a gemeentelijk beheerder (+behandelaar) do see it. Reported by the municipality of Heerlen.

Because the field is hidden, the upload falls back to the default confidentiality level `vertrouwelijk`, which means documents uploaded by a coordinator are **not visible to the organiser**.

## Cause

`UploadDocumentAction::schema()` omits `Role::Coordinator` from the role list that gates the field. This is a regression: the coordinator role was originally added to this list, but the multi-document upload rewrite reintroduced `schema()` without it. The sibling `singleFileSchema()`, used for attachments in threads, kept the coordinator, which is why the same user gets the choice in one place and not the other.

The coordinator is already allowed to upload documents by `ZaakPolicy::uploadDocument()` and already receives all three confidentiality levels from `DocumentVertrouwelijkheden::fromUserRole()`, so only the form condition was wrong.

## Changes

- `UploadDocumentAction::schema()` now includes `Role::Coordinator`, matching `singleFileSchema()`.
- `ZaakEventScope` includes `Role::Coordinator`, so coordinators get the full column selection on event queries (previously missing `organiser_user_id`, `imported_data`, the `organiserUser` relation and the extended organisation fields).
- The "intern zaaknummer" column in the zaken table is now visible to coordinators.

## Note for administrators

Documents that coordinators uploaded before this fix are stored as `vertrouwelijk` and are therefore not visible to the organiser. They are not migrated by this change and can be adjusted per document where needed.