### PR TITLE
fix: correct typo in Type aanvraag radio option label

### DIFF
--- a/app/EventForm/Schema/Steps/WaarvoorWiltUHetEventloketGebruikenStep.php
+++ b/app/EventForm/Schema/Steps/WaarvoorWiltUHetEventloketGebruikenStep.php
@@ -28,7 +28,7 @@ final class WaarvoorWiltUHetEventloketGebruikenStep
                 Radio::make('waarvoorWiltUEventloketGebruiken')
                     ->label('Waarvoor wilt u Eventloket gebruiken?')
                     ->options([
-                        'evenement' => 'U wilt voor uw evementen een aanvraag indienen',
+                        'evenement' => 'U wilt voor uw evenement een aanvraag indienen',
                         'vooraankondiging' => 'U wilt voor uw evenement een vooraankondiging doen en dient later de volledige aanvraag in',
                     ])
                     ->required()


### PR DESCRIPTION
## What

The first radio option on the "Type aanvraag" step contained a spelling mistake in its display label.

Before:

```php
'evenement' => 'U wilt voor uw evementen een aanvraag indienen',
```

After:

```php
'evenement' => 'U wilt voor uw evenement een aanvraag indienen',
```

## Why this has no functional impact

Only the human-readable label changes. The option key stays `'evenement'`, so stored drafts, submitted data, logic rules and the `DetermineAanvraagType` branching are all untouched. The second option (`vooraankondiging`) already spelled "evenement" correctly, so the intended wording is unambiguous.

The Playwright helpers select radios by their `value` attribute, not by label text, and no test asserts this literal string, so no test changes were needed.

## Deliberately not changed

The same sentence also appears in `docker/local-data/open-formulier/formDefinitions.json`, `docker/local-data/open-formulier/formSteps.json`, `docs/formulier-veldenkaart.md`, `docs/formulier-veldenkaart.generated.md` and `docs/formulier-veldenkaart.generated.json`. I left all of those alone:

* The files under `docker/local-data/open-formulier/` are an export of the form definition as it exists in Open Forms. `docker/setup-local-services.sh` imports them into the local Open Forms container and only patches environment specific URLs and primary keys. `docs/ai-instructies-formulier.md` describes this export as the reference and spec anchor for `dev-scripts/verify-scenarios-jsonlogic.mjs`. Hand editing it would make the anchor stop matching the real Open Forms form, which is the leading source. The label should be corrected in Open Forms itself and then re-exported.
* The `docs/formulier-veldenkaart.generated.*` files carry an explicit "generated, do not edit by hand" notice and are produced from that same export, so they follow whenever the export is refreshed.
* `docs/formulier-veldenkaart.md` likewise documents the Open Forms form rather than this codebase.

Separately, the field key `evenmentenInDeBuurtContent` is also misspelled, but it is a key that mirrors Open Forms and not a display text, so it is out of scope here.

## Verification

The change was not exercised locally, because a full run needs the application stack and this is a single display string with no behaviour attached. Syntax was checked with `php -l`; CI covers the rest.
