### PR TITLE
Stop besluitdocumenten from leaking metadata to the organiser

### DIFF
--- a/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Shared/Resources/Zaken/Pages/ViewZaak.php
@@ -353,10 +353,13 @@ class ViewZaak extends ViewRecord
                                             }
                                             $besluittype = new BesluitType(...(new Openzaak)->get($get('besluit_type'))->toArray());
 
-                                            // dd($record->documenten);
-                                            return $record->documenten->filter(function ($document) use ($besluittype) {
-                                                return in_array($document->informatieobjecttype, $besluittype->informatieobjecttypen);
-                                            })->pluck('titel', 'url')->toArray();
+                                            // A besluitdocument always goes to the organiser, so only
+                                            // documents the organiser may see can be selected here.
+                                            return $record->documenten
+                                                ->whereIn('vertrouwelijkheidaanduiding', DocumentVertrouwelijkheden::fromUserRole(Role::Organiser))
+                                                ->filter(function ($document) use ($besluittype) {
+                                                    return in_array($document->informatieobjecttype, $besluittype->informatieobjecttypen);
+                                                })->pluck('titel', 'url')->toArray();
 
                                         }
                                     )

--- a/app/Http/Controllers/DocumentController.php
+++ b/app/Http/Controllers/DocumentController.php
@@ -14,7 +14,12 @@ class DocumentController extends Controller
 {
     public function __invoke(DocumentRequest $request, Zaak $zaak, string $documentuuid, ?string $type = 'view')
     {
-        $document = $zaak->documenten->where('uuid', $documentuuid)->firstOrFail();
+        // documenten is already filtered to what the current role may see, so a
+        // miss means either "no such document" or "not for this user". Both get a
+        // 404: a 403 would confirm the document exists on this zaak.
+        $document = $zaak->documenten->firstWhere('uuid', $documentuuid);
+
+        abort_if($document === null, 404);
 
         $validated = $request->validated();
         if (isset($validated['version']) && $validated['version'] != $document->versie) {

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -238,11 +238,20 @@ class Zaak extends Model implements Eventable
     {
         return Attribute::make(
             get: function ($value, $attributes) {
-                return $this->getBesluiten()->each(function (Besluit $besluit) {
-                    $besluit = new Besluit(...array_merge($besluit->toArrayWithObjects(), [
-                        'besluitDocumenten' => $besluit->besluitDocumenten?->filter(fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, DocumentVertrouwelijkheden::fromUserRole(auth()->user()->role))),
-                    ]));
-                });
+                if (app()->runningInConsole()) {
+                    // Queue and console have no authenticated user; the role filter
+                    // is applied before the job is queued, mirroring documenten().
+                    return $this->getBesluiten();
+                }
+
+                // map(), not each(): each() returns the collection unchanged and the
+                // rebuilt Besluit would be thrown away, leaving every role with all
+                // besluitdocumenten. map() also leaves the cached collection alone.
+                return $this->getBesluiten()->map(fn (Besluit $besluit) => new Besluit(...array_merge($besluit->toArrayWithObjects(), [
+                    'besluitDocumenten' => $besluit->besluitDocumenten?->filter(
+                        fn (Informatieobject $informatieobject) => in_array($informatieobject->vertrouwelijkheidaanduiding, DocumentVertrouwelijkheden::fromUserRole(auth()->user()->role))
+                    )->values(),
+                ])));
             },
         );
     }

--- a/tests/Feature/BesluitDocumentVisibilityTest.php
+++ b/tests/Feature/BesluitDocumentVisibilityTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Livewire\Zaken\BesluitenInfolist;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\ZGW\Besluit;
+use App\ValueObjects\ZGW\BesluitType;
+use App\ValueObjects\ZGW\Informatieobject;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+    Http::fake([ZgwHttpFake::$baseUrl.'*' => Http::response([], 200)]);
+
+    // documenten() and besluiten() skip the role filter in console context, and
+    // the test suite runs through the CLI. Flip the memoized flag so these tests
+    // exercise the web-request path they are about.
+    (new ReflectionProperty($this->app, 'isRunningInConsole'))->setValue($this->app, false);
+
+    $this->municipality = Municipality::factory()->create();
+
+    $this->organiser = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->organisation->users()->attach($this->organiser, ['role' => OrganisationRole::Admin]);
+
+    $this->reviewer = User::factory()->create(['role' => Role::Reviewer]);
+    $this->municipality->users()->attach($this->reviewer);
+
+    $this->zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $this->municipality->id,
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+
+    $this->zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/1',
+    ]);
+});
+
+/**
+ * Builds a besluitdocument value object at the given vertrouwelijkheid.
+ */
+function besluitDocument(string $uuid, string $titel, string $vertrouwelijkheid): Informatieobject
+{
+    return new Informatieobject(
+        uuid: $uuid,
+        url: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$uuid,
+        creatiedatum: now()->format('Y-m-d'),
+        titel: $titel,
+        vertrouwelijkheidaanduiding: $vertrouwelijkheid,
+        auteur: 'Test',
+        versie: 1,
+        bestandsnaam: $uuid.'.pdf',
+        inhoud: ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobject/'.$uuid.'/download',
+        beschrijving: '',
+        informatieobjecttype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1',
+        formaat: 'application/pdf',
+        locked: false,
+    );
+}
+
+/**
+ * Seeds the besluiten cache with a single besluit holding one zaakvertrouwelijk
+ * and one vertrouwelijk besluitdocument, bypassing the ZGW HTTP layer.
+ */
+function seedBesluitenCache(Zaak $zaak): void
+{
+    Cache::forever("zaak.{$zaak->id}.besluiten", collect([
+        new Besluit(
+            url: ZgwHttpFake::$baseUrl.'/besluiten/api/v1/besluiten/1',
+            identificatie: 'BESLUIT-1',
+            besluittype: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/besluittypen/1',
+            zaak: (string) $zaak->zgw_zaak_url,
+            datum: now()->format('Y-m-d'),
+            toelichting: 'Toelichting',
+            ingangsdatum: now()->format('Y-m-d'),
+            verzenddatum: now()->format('Y-m-d'),
+            besluittypeObject: new BesluitType(
+                url: ZgwHttpFake::$baseUrl.'/catalogi/api/v1/besluittypen/1',
+                omschrijving: 'Vergunning',
+                omschrijvingGeneriek: 'Vergunning',
+                zaaktypen: [ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1'],
+                informatieobjecttypen: [ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1'],
+                toelichting: '',
+            ),
+            besluitDocumenten: collect([
+                besluitDocument('open-doc', 'Openbaar besluitdocument', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value),
+                besluitDocument('geheim-doc', 'Vertrouwelijk besluitdocument', DocumentVertrouwelijkheden::Vertrouwelijk->value),
+            ]),
+        ),
+    ]));
+}
+
+test('the organiser only gets the besluitdocumenten their role may see', function () {
+    seedBesluitenCache($this->zaak);
+
+    $this->actingAs($this->organiser);
+
+    $documenten = $this->zaak->besluiten->first()->besluitDocumenten;
+
+    expect($documenten->pluck('uuid')->all())->toBe(['open-doc']);
+});
+
+test('a reviewer keeps all besluitdocumenten', function () {
+    seedBesluitenCache($this->zaak);
+
+    $this->actingAs($this->reviewer);
+
+    $documenten = $this->zaak->besluiten->first()->besluitDocumenten;
+
+    expect($documenten->pluck('uuid')->all())->toBe(['open-doc', 'geheim-doc']);
+});
+
+test('filtering for one role does not leak into the next read', function () {
+    seedBesluitenCache($this->zaak);
+
+    $this->actingAs($this->organiser);
+    $this->zaak->besluiten;
+
+    // The cached collection must be untouched: a second reader with a wider role
+    // still sees everything (map() builds a new collection, each()/transform()
+    // would have written the filtered list back into the cache).
+    // A fresh model instance, because Eloquent caches accessor results per model.
+    $this->actingAs($this->reviewer);
+
+    expect(Zaak::findOrFail($this->zaak->id)->besluiten->first()->besluitDocumenten->pluck('uuid')->all())
+        ->toBe(['open-doc', 'geheim-doc']);
+});
+
+test('the besluiten infolist does not show a vertrouwelijk document to the organiser', function () {
+    seedBesluitenCache($this->zaak);
+
+    $this->actingAs($this->organiser);
+
+    livewire(BesluitenInfolist::class, ['zaak' => $this->zaak])
+        ->assertOk()
+        ->assertSee('Openbaar besluitdocument')
+        ->assertDontSee('Vertrouwelijk besluitdocument');
+});
+
+test('viewing a document the role may not see returns a 404 instead of a 500', function () {
+    Cache::forever("zaak.{$this->zaak->id}.documenten", collect([
+        besluitDocument('open-doc', 'Openbaar document', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value),
+        besluitDocument('geheim-doc', 'Vertrouwelijk document', DocumentVertrouwelijkheden::Vertrouwelijk->value),
+    ]));
+
+    $this->actingAs($this->organiser);
+
+    $this->get(route('zaak.documents.view', [
+        'zaak' => $this->zaak->id,
+        'documentuuid' => 'geheim-doc',
+        'type' => 'view',
+    ]))->assertNotFound();
+});
+
+test('viewing an unknown document uuid returns a 404', function () {
+    Cache::forever("zaak.{$this->zaak->id}.documenten", collect([
+        besluitDocument('open-doc', 'Openbaar document', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value),
+    ]));
+
+    $this->actingAs($this->organiser);
+
+    $this->get(route('zaak.documents.view', [
+        'zaak' => $this->zaak->id,
+        'documentuuid' => 'bestaat-niet',
+        'type' => 'view',
+    ]))->assertNotFound();
+});


### PR DESCRIPTION
## Why

An organiser saw the metadata of a confidential document (title, document type, creation date, version, author, filename) in the besluiten infolist, and clicking "Bekijken" returned a 500. Two independent defects stacked:

1. The role filter on besluitdocumenten was a no-op. `Zaak::besluiten()` rebuilt each `Besluit` with a filtered document collection inside `Collection::each()`, which returns the original collection and throws the rebuilt value object away. Every role, including the organiser, received all besluitdocumenten.
2. The `besluit_documenten` select in the finish wizard filtered on informatieobjecttype only, using the logged in handler's document list. A coordinator could therefore designate a `vertrouwelijk` or `confidentieel` document as besluitdocument, while a besluitdocument by definition goes to the organiser.

The 500 came from `DocumentController`, where `firstOrFail()` on a `Collection` throws `ItemNotFoundException`. Laravel does not translate that into a 404, unlike `ModelNotFoundException`. The document content never leaked, the metadata did.

## What changed

* `Zaak::besluiten()` uses `map()` instead of `each()`, so the rebuilt besluit replaces the original. `map()` also leaves the cached collection alone, where `transform()` would write the filtered list back into the cache and break the next reader with a different role. A `runningInConsole()` guard was added, mirroring `documenten()`, because `auth()->user()` is null in queue context.
* The `besluit_documenten` select filters on the organiser's visibility before filtering on informatieobjecttype, identical to what `message_documenten` already does.
* `DocumentController` returns a 404 when the uuid is not in the role-filtered document list. A 403 would confirm that the document exists on this zaak, which is exactly the metadata being withheld, and it would leave the leak open through a bookmarked or shared URL.

`Zaak::besluitDocumenten()` flatMaps over `besluiten` and inherits the fix.

## Impact per role

Based on `DocumentVertrouwelijkheden::fromUserRole()`:

* Reviewer, coordinator, municipality admin and admin get all three levels the application uses, so the filter is a no-op for them. They see exactly what they see today.
* Advisor loses `confidentieel`, which is already the rule for regular zaakdocumenten. This makes both lists consistent.
* Organiser keeps `zaakvertrouwelijk` only. That is the fix.

Documents that coordinators uploaded before #470 sit at `vertrouwelijk` and become invisible to the organiser. That is the intended end state, not a regression. Before this change they were visible with a broken view button. There is deliberately no backfill or correction command. If a document really has to be visible, the coordinator re-uploads it with the right vertrouwelijkheid, which has been an explicit choice at upload time since #470.

## Tests

`tests/Feature/BesluitDocumentVisibilityTest.php` seeds the besluiten and documenten caches directly, so no ZGW backend is needed:

* the organiser only gets the besluitdocumenten their role may see, a reviewer keeps all of them
* filtering for one role does not leak into the cached collection read by the next role
* the besluiten infolist does not render the vertrouwelijk title for the organiser
* requesting a document the role may not see, or an unknown uuid, returns a 404

Four of the six tests fail on `main`.
