### PR TITLE
Add #472 to the v1.1.3 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### 🐛 Bug Fixes
 
+* Stop besluitdocumenten from leaking metadata to the organiser (#472) @Michel-Verhoeven
 * fix: correct typo in Type aanvraag radio option label (#471) @Michel-Verhoeven
 * Let coordinators choose who may view an uploaded document (#470) @Michel-Verhoeven
 


### PR DESCRIPTION
The v1.1.3 tag and release were moved to `8b97d8b4` after publication so they include #472. The changelog entry for v1.1.3 was generated when the release was first published and still listed only #470 and #471, so this brings CHANGELOG.md in line with the release notes.

Documentation only, no code changes.