### PR TITLE
Bump league/commonmark from 2.8.2 to 2.9.2

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3515,16 +3515,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "72e9a87efcf41a8e83be3ed0866b69d77565cb12"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/72e9a87efcf41a8e83be3ed0866b69d77565cb12",
+                "reference": "72e9a87efcf41a8e83be3ed0866b69d77565cb12",
                 "shasum": ""
             },
             "require": {
@@ -3546,8 +3546,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -3561,7 +3561,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -3618,7 +3618,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-11T00:58:45+00:00"
         },
         {
             "name": "league/config",


### PR DESCRIPTION
Lock-only update of `league/commonmark` from **2.8.2 to 2.9.2**. The package is not in `composer.json`; it comes in transitively through `laravel/framework`, so `composer.lock` is the only changed file.

## Why 2.9.2 and not 2.9.0

2.9.0 fixes five denial-of-service issues and one unsafe-link-filter bypass, but it is not the end of the line:

- **2.9.1** is itself a security release with three more DoS fixes in the core parser (catastrophic backtracking in the fenced code block start pattern, quadratic shortcut reference link resolution, unbounded delimiter processor cache keys) plus a further unsafe-link/event-handler filter bypass (`GHSA-f8fg-pg57-v4j8`, `GHSA-j8pm-gj4c-rq4x`, `GHSA-jjv6-8j6v-6j52`).
- **2.9.2** fixes a behavioural regression introduced in 2.9.0: `Cursor::match()` matched against the whole line at a byte offset instead of the remainder, which silently changed the meaning of `\b`, `\A`, lookbehinds and a leading `^` for any pattern passed to it.

Stopping at 2.9.0 would therefore both leave advisories open and pull in that regression.

## Where does CommonMark actually parse outside input here?

This is the part that decides whether the bump is urgent or routine, so it was verified against the code on `main` rather than inferred from the advisory severity.

**One entry point.** The only path that reaches CommonMark is Laravel's markdown mail rendering (`Illuminate\Mail\Markdown`), reached from the `->markdown(...)` mailables and notifications in `app/Mail` and `app/Notifications`. There is no `Str::markdown()`, no `Markdown::parse()` and no markdown rendering in any web response. The rich text editors in the application store editor content, not markdown, and render through their own renderer.

**Most of the advisories are not reachable.** That converter registers only `CommonMarkCoreExtension` and `TableExtension`, and `config/mail.php` declares no `markdown.extensions`. `FootnoteExtension`, `AttributesExtension` and `SmartPunctExtension` are never loaded, so the duplicate-footnote-definition issue and both attribute-block issues (inline and adjacent-block) cannot fire in this application at all. What remains reachable is the core-parser set: quadratic parsing of multibyte lines, the fenced code block pattern, shortcut reference links, delimiter processing, and the unsafe link filter.

**Outside input does reach the parser, but only as short fields.** The mail templates interpolate an event name, an organisation name, an advisory name, a sender name and a thread title. Blade escaping in the mail pipeline escapes HTML, but not markdown metacharacters such as `[`, backticks or `*`, and the secured-encoding mode that would also escape `[` is not enabled. So crafted markdown in those fields does get parsed.

**But the size is bounded and the work is off the request path.** The thread title is a `varchar(255)` column. The event name field is server-side validated at 1000 characters. Quadratic behaviour over inputs of at most ~1 KB is not a usable denial of service. On top of that, every one of these notifications implements `ShouldQueue`, so parsing happens in a queue worker and never inside a web request.

## Conclusion

**Hygiene, not an incident.** The reachable advisories are real but capped by input length and isolated on the queue; the two footnote/attribute advisory groups are not reachable at all. Merge on the normal schedule.

Nothing outside `composer.lock` is touched, so no application behaviour changes with this PR.