### PR TITLE
Count failed logins per account instead of per IP address

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,9 +82,11 @@ OPEN_FORMS_ADMIN_TOKEN=
 # OPEN_FORMS_PREFILL_OBJECT_TYPE_VERSION= not used yet
 APP_REQUIRE_2FA=true
 
-# Auth rate limiting. All values are cast to int and clamped in config/auth.php
-# (max_attempts floor 1, decay_seconds floor 60), so a typo can never disable
-# the limiter. The defaults below are what the application uses when unset.
+# Auth rate limiting. config/auth.php validates every value: a value that is not
+# a number falls back to the default below, and a number below the floor is
+# clamped (max_attempts floor 1, decay_seconds floor 60). So neither an empty
+# nor a mistyped value can disable the limiter or lock the application out.
+# The defaults below are what the application uses when unset.
 # Strict login limiter, per account and IP.
 # LOGIN_MAX_ATTEMPTS=5
 # LOGIN_DECAY_SECONDS=900

--- a/.env.example
+++ b/.env.example
@@ -82,6 +82,28 @@ OPEN_FORMS_ADMIN_TOKEN=
 # OPEN_FORMS_PREFILL_OBJECT_TYPE_VERSION= not used yet
 APP_REQUIRE_2FA=true
 
+# Auth rate limiting. All values are cast to int and clamped in config/auth.php
+# (max_attempts floor 1, decay_seconds floor 60), so a typo can never disable
+# the limiter. The defaults below are what the application uses when unset.
+# Strict login limiter, per account and IP.
+# LOGIN_MAX_ATTEMPTS=5
+# LOGIN_DECAY_SECONDS=900
+# Looser login limiter, per account across all IPs.
+# LOGIN_ACCOUNT_MAX_ATTEMPTS=20
+# LOGIN_ACCOUNT_DECAY_SECONDS=3600
+# Backstop login limiter, per IP. Wide enough for a shared office outbound address.
+# LOGIN_IP_MAX_ATTEMPTS=50
+# LOGIN_IP_DECAY_SECONDS=900
+# Multi-factor challenge limiter, per user.
+# MFA_MAX_ATTEMPTS=5
+# MFA_DECAY_SECONDS=900
+# PASSWORD_RESET_REQUEST_MAX_ATTEMPTS=5
+# PASSWORD_RESET_REQUEST_DECAY_SECONDS=900
+# PASSWORD_RESET_MAX_ATTEMPTS=5
+# PASSWORD_RESET_DECAY_SECONDS=900
+# REGISTRATION_MAX_ATTEMPTS=5
+# REGISTRATION_DECAY_SECONDS=900
+
 OPENZAAK_URL="https://zgw.example.com/"
 OPENZAAK_CLIENT_ID="client-id"
 OPENZAAK_CLIENT_SECRET="%8UIjR^bo9vNql%SEhDx@fLX3L"

--- a/app/Filament/Shared/Pages/Login.php
+++ b/app/Filament/Shared/Pages/Login.php
@@ -7,10 +7,13 @@ use Filament\Auth\Http\Responses\Contracts\LoginResponse;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Hidden;
 use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Contracts\Auth\Guard;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use SensitiveParameter;
 
 class Login extends \Filament\Auth\Pages\Login
 {
@@ -19,7 +22,7 @@ class Login extends \Filament\Auth\Pages\Login
         $isMfaStep = filled($this->userUndertakingMultiFactorAuthentication);
 
         try {
-            return parent::authenticate();
+            $response = parent::authenticate();
         } catch (ValidationException $e) {
             if ($isMfaStep) {
                 activity('auth')
@@ -34,6 +37,12 @@ class Login extends \Filament\Auth\Pages\Login
 
             throw $e;
         }
+
+        if ($response !== null) {
+            $this->clearCredentialRateLimiters();
+        }
+
+        return $response;
     }
 
     protected function rateLimit($maxAttempts, $decaySeconds = 60, $method = null, $component = null): void // @phpstan-ignore-line
@@ -41,35 +50,163 @@ class Login extends \Filament\Auth\Pages\Login
         $method ??= debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, limit: 2)[1]['function'];
         $component ??= static::class;
 
-        try {
-            parent::rateLimit(
-                config('auth.throttle.login.max_attempts', 5),
-                config('auth.throttle.login.decay_seconds', 900),
-                $method,
-                $component
-            );
-        } catch (TooManyRequestsException $e) {
+        // Check only. The counters are incremented in fireFailedEvent(), so a
+        // successful login and the second (multi-factor) submit of a single
+        // login never consume any budget.
+        foreach ($this->getCredentialRateLimiters($method, $component) as $limiter) {
+            if (! RateLimiter::tooManyAttempts($limiter['key'], $limiter['max_attempts'])) {
+                continue;
+            }
+
+            $secondsUntilAvailable = RateLimiter::availableIn($limiter['key']);
+
             activity('auth')
                 ->event('lockout')
                 ->withProperties([
-                    'type' => 'credentials',
-                    'email' => $this->data['email'] ?? null,
+                    'type' => $limiter['type'],
+                    'email' => $this->getRateLimitedEmail(),
                     'ip' => request()->ip(),
                     'user_agent' => request()->userAgent(),
                     'panel' => Filament::getCurrentPanel()?->getId(),
-                    'available_in_seconds' => $e->secondsUntilAvailable,
+                    'available_in_seconds' => $secondsUntilAvailable,
                 ])
                 ->log(__('activity/event.lockout'));
 
-            throw $e;
+            throw new TooManyRequestsException($component, $method, request()->ip(), $secondsUntilAvailable);
         }
+    }
+
+    /**
+     * Increment the credential rate limiters.
+     *
+     * This is the only place where the login counters go up. The parent calls
+     * this method on exactly the two credential failure paths and nowhere else,
+     * which keeps the counters tied to a failure the server established itself
+     * instead of to an attempt the client can shape.
+     *
+     * @param  array<string, mixed>  $credentials
+     */
+    protected function fireFailedEvent(Guard $guard, ?Authenticatable $user, #[SensitiveParameter] array $credentials): void
+    {
+        parent::fireFailedEvent($guard, $user, $credentials);
+
+        foreach ($this->getCredentialRateLimiters(email: $credentials['email'] ?? null) as $limiter) {
+            RateLimiter::hit($limiter['key'], $limiter['decay_seconds']);
+        }
+    }
+
+    /**
+     * Clear the account bound limiters after a fully successful login.
+     *
+     * The IP backstop is deliberately left alone. Clearing it would let anyone
+     * with a valid account of their own reset the spraying budget for their
+     * whole IP address by logging in once.
+     */
+    protected function clearCredentialRateLimiters(): void
+    {
+        foreach ($this->getCredentialRateLimiters() as $limiter) {
+            if ($limiter['type'] === 'credentials_ip') {
+                continue;
+            }
+
+            RateLimiter::clear($limiter['key']);
+        }
+
+        $user = Filament::auth()->user();
+
+        if ($user !== null) {
+            // Safe to clear: this user just proved both their password and their
+            // second factor. Without this, logging in normally a handful of times
+            // within the decay window would lock the user out of their own account.
+            RateLimiter::clear("filament-multi-factor-challenge:{$user->getAuthIdentifier()}");
+        }
+    }
+
+    /**
+     * The credential rate limiters, ordered from strict to wide so the strictest
+     * reason is the one that ends up in the activity log.
+     *
+     * @return list<array{key: string, type: string, max_attempts: int, decay_seconds: int}>
+     */
+    protected function getCredentialRateLimiters(?string $method = null, ?string $component = null, mixed $email = null): array
+    {
+        $method ??= 'authenticate';
+        $component ??= static::class;
+
+        $limiters = [];
+        $email = $this->getRateLimitedEmail($email);
+
+        // A blank or unusable address falls through to the IP backstop only.
+        // Counting it would put every empty submit in the application on one
+        // shared sha1('') bucket.
+        if ($email !== null) {
+            $limiters[] = [
+                'key' => 'login-credentials:'.sha1($email.'|'.request()->ip()),
+                'type' => 'credentials',
+                'max_attempts' => $this->throttleValue('auth.throttle.login.max_attempts', 5, 1),
+                'decay_seconds' => $this->throttleValue('auth.throttle.login.decay_seconds', 900, 60),
+            ];
+
+            $limiters[] = [
+                'key' => 'login-account:'.sha1($email),
+                'type' => 'credentials_account',
+                'max_attempts' => $this->throttleValue('auth.throttle.login_account.max_attempts', 20, 1),
+                'decay_seconds' => $this->throttleValue('auth.throttle.login_account.decay_seconds', 3600, 60),
+            ];
+        }
+
+        $limiters[] = [
+            'key' => $this->getRateLimitKey($method, $component),
+            'type' => 'credentials_ip',
+            'max_attempts' => $this->throttleValue('auth.throttle.login_ip.max_attempts', 50, 1),
+            'decay_seconds' => $this->throttleValue('auth.throttle.login_ip.decay_seconds', 900, 60),
+        ];
+
+        return $limiters;
+    }
+
+    /**
+     * Normalise the address the counters are keyed on.
+     *
+     * CaseInsensitiveUserProvider lowercases the address before looking the user
+     * up, so the counter has to do the same or an attacker escapes it by varying
+     * the casing. The trim() on top makes the counter strictly stricter than the
+     * provider, which is the safe direction to fail in.
+     */
+    protected function getRateLimitedEmail(mixed $email = null): ?string
+    {
+        $email ??= $this->data['email'] ?? null;
+
+        // $this->data is raw, unvalidated Livewire state: a crafted request can
+        // put an array in here.
+        if (! is_string($email)) {
+            return null;
+        }
+
+        // The address ends up in the activity log, so clamp its length. Users
+        // regularly type their password into the email field as well.
+        $email = Str::limit(strtolower(trim($email)), 255, end: '');
+
+        return blank($email) ? null : $email;
+    }
+
+    /**
+     * Read a throttle value, cast and clamped.
+     *
+     * config/auth.php already does this, but Config::set() and a cached config
+     * artefact both bypass that computation. A string decay value blows up deep
+     * inside Carbon, and a zero decay silently disables the limiter altogether.
+     */
+    protected function throttleValue(string $key, int $default, int $floor): int
+    {
+        return max($floor, (int) config($key, $default));
     }
 
     protected function isMultiFactorChallengeRateLimited(Authenticatable $user): bool
     {
         $rateLimitingKey = "filament-multi-factor-challenge:{$user->getAuthIdentifier()}";
-        $maxAttempts = config('auth.throttle.mfa.max_attempts', 5);
-        $decaySeconds = config('auth.throttle.mfa.decay_seconds', 900);
+        $maxAttempts = $this->throttleValue('auth.throttle.mfa.max_attempts', 5, 1);
+        $decaySeconds = $this->throttleValue('auth.throttle.mfa.decay_seconds', 900, 60);
 
         if (RateLimiter::tooManyAttempts($rateLimitingKey, $maxAttempts)) {
             activity('auth')
@@ -77,7 +214,7 @@ class Login extends \Filament\Auth\Pages\Login
                 ->causedBy($user instanceof Model ? $user : null)
                 ->withProperties([
                     'type' => 'mfa',
-                    'email' => $this->data['email'] ?? null,
+                    'email' => $this->getRateLimitedEmail(),
                     'ip' => request()->ip(),
                     'user_agent' => request()->userAgent(),
                     'panel' => Filament::getCurrentPanel()?->getId(),

--- a/app/Filament/Shared/Pages/Login.php
+++ b/app/Filament/Shared/Pages/Login.php
@@ -191,15 +191,24 @@ class Login extends \Filament\Auth\Pages\Login
     }
 
     /**
-     * Read a throttle value, cast and clamped.
+     * Read a throttle value, validated.
      *
      * config/auth.php already does this, but Config::set() and a cached config
      * artefact both bypass that computation. A string decay value blows up deep
      * inside Carbon, and a zero decay silently disables the limiter altogether.
+     *
+     * A value that is not a number falls back to the default instead of being
+     * clamped to the floor. Clamping is the right move for a decay that is set
+     * too low, but for a maximum it fails the wrong way: (int) '' is 0, and
+     * clamping that to 1 would lock every user in the application out after a
+     * single mistyped password. Kept in sync with the $throttle helper in
+     * config/auth.php.
      */
     protected function throttleValue(string $key, int $default, int $floor): int
     {
-        return max($floor, (int) config($key, $default));
+        $value = config($key, $default);
+
+        return is_numeric($value) ? max($floor, (int) $value) : $default;
     }
 
     protected function isMultiFactorChallengeRateLimited(Authenticatable $user): bool

--- a/config/auth.php
+++ b/config/auth.php
@@ -128,28 +128,45 @@ return [
     | 15-minute lockout after 5 failed attempts (OWASP recommendation for
     | government-facing applications).
     |
+    | Every value is cast to an integer and clamped to a safe floor. An env
+    | value always arrives as a string, and an unset or non-numeric value casts
+    | to 0. A decay of 0 would disable the limiter silently, and a maximum of 0
+    | would lock everyone out, so both are clamped towards the strict side.
+    |
     */
 
     'throttle' => [
+        // Strict: per account and IP. This is the limit the OWASP note above describes.
         'login' => [
-            'max_attempts' => env('LOGIN_MAX_ATTEMPTS', 5),
-            'decay_seconds' => env('LOGIN_DECAY_SECONDS', 900),
+            'max_attempts' => max(1, (int) env('LOGIN_MAX_ATTEMPTS', 5)),
+            'decay_seconds' => max(60, (int) env('LOGIN_DECAY_SECONDS', 900)),
+        ],
+        // Looser: per account across all IPs, to catch distributed spraying on one
+        // account without making it cheap to lock a known account out from anywhere.
+        'login_account' => [
+            'max_attempts' => max(1, (int) env('LOGIN_ACCOUNT_MAX_ATTEMPTS', 20)),
+            'decay_seconds' => max(60, (int) env('LOGIN_ACCOUNT_DECAY_SECONDS', 3600)),
+        ],
+        // Backstop: per IP, wide enough for a shared office outbound address.
+        'login_ip' => [
+            'max_attempts' => max(1, (int) env('LOGIN_IP_MAX_ATTEMPTS', 50)),
+            'decay_seconds' => max(60, (int) env('LOGIN_IP_DECAY_SECONDS', 900)),
         ],
         'mfa' => [
-            'max_attempts' => env('MFA_MAX_ATTEMPTS', 5),
-            'decay_seconds' => env('MFA_DECAY_SECONDS', 900),
+            'max_attempts' => max(1, (int) env('MFA_MAX_ATTEMPTS', 5)),
+            'decay_seconds' => max(60, (int) env('MFA_DECAY_SECONDS', 900)),
         ],
         'password_reset_request' => [
-            'max_attempts' => env('PASSWORD_RESET_REQUEST_MAX_ATTEMPTS', 5),
-            'decay_seconds' => env('PASSWORD_RESET_REQUEST_DECAY_SECONDS', 900),
+            'max_attempts' => max(1, (int) env('PASSWORD_RESET_REQUEST_MAX_ATTEMPTS', 5)),
+            'decay_seconds' => max(60, (int) env('PASSWORD_RESET_REQUEST_DECAY_SECONDS', 900)),
         ],
         'password_reset' => [
-            'max_attempts' => env('PASSWORD_RESET_MAX_ATTEMPTS', 5),
-            'decay_seconds' => env('PASSWORD_RESET_DECAY_SECONDS', 900),
+            'max_attempts' => max(1, (int) env('PASSWORD_RESET_MAX_ATTEMPTS', 5)),
+            'decay_seconds' => max(60, (int) env('PASSWORD_RESET_DECAY_SECONDS', 900)),
         ],
         'registration' => [
-            'max_attempts' => env('REGISTRATION_MAX_ATTEMPTS', 5),
-            'decay_seconds' => env('REGISTRATION_DECAY_SECONDS', 900),
+            'max_attempts' => max(1, (int) env('REGISTRATION_MAX_ATTEMPTS', 5)),
+            'decay_seconds' => max(60, (int) env('REGISTRATION_DECAY_SECONDS', 900)),
         ],
     ],
 

--- a/config/auth.php
+++ b/config/auth.php
@@ -133,6 +133,15 @@ return [
     | to 0. A decay of 0 would disable the limiter silently, and a maximum of 0
     | would lock everyone out, so both are clamped towards the strict side.
     |
+    | The login limiters key on request()->ip(), and that is the real client
+    | address because nothing proxies production: TrustProxies is deliberately
+    | not configured, so a client cannot forge X-Forwarded-For to escape the
+    | counters. Putting a CDN, WAF or load balancer in front of the application
+    | changes that assumption: every request would then arrive from one address,
+    | which turns the login_ip backstop into an application-wide lockout and
+    | strips the IP component out of the strict login limiter. Configure
+    | TrustProxies first if that ever happens, and revisit these numbers.
+    |
     */
 
     'throttle' => [

--- a/config/auth.php
+++ b/config/auth.php
@@ -2,6 +2,27 @@
 
 use App\Models\User;
 
+/**
+ * Read a throttle value from the environment, validated.
+ *
+ * An env value always arrives as a string, and (int) turns anything unusable
+ * into 0. A maximum of 0 would lock the whole application out and a decay of 0
+ * would disable the limiter silently, so a value that is not a number falls
+ * back to the documented default rather than being clamped to the floor:
+ * clamping a typo in LOGIN_MAX_ATTEMPTS down to 1 would lock every user out
+ * after a single mistyped password. A numeric value below the floor is still
+ * clamped, because that is a deliberate setting worth honouring as far as it
+ * is safe to.
+ *
+ * Kept in sync with Login::throttleValue(), which repeats this on the call site
+ * because Config::set() and a cached config artefact both bypass this file.
+ */
+$throttle = function (string $key, int $default, int $floor): int {
+    $value = env($key, $default);
+
+    return is_numeric($value) ? max($floor, (int) $value) : $default;
+};
+
 return [
 
     /*
@@ -128,10 +149,10 @@ return [
     | 15-minute lockout after 5 failed attempts (OWASP recommendation for
     | government-facing applications).
     |
-    | Every value is cast to an integer and clamped to a safe floor. An env
-    | value always arrives as a string, and an unset or non-numeric value casts
-    | to 0. A decay of 0 would disable the limiter silently, and a maximum of 0
-    | would lock everyone out, so both are clamped towards the strict side.
+    | Every value is validated by the $throttle helper above: a value that is
+    | not a number falls back to the default, and a numeric value below the
+    | floor is clamped. That way neither an empty nor a mistyped env value can
+    | disable the limiter or turn it into an application-wide lockout.
     |
     | The login limiters key on request()->ip(), and that is the real client
     | address because nothing proxies production: TrustProxies is deliberately
@@ -147,35 +168,35 @@ return [
     'throttle' => [
         // Strict: per account and IP. This is the limit the OWASP note above describes.
         'login' => [
-            'max_attempts' => max(1, (int) env('LOGIN_MAX_ATTEMPTS', 5)),
-            'decay_seconds' => max(60, (int) env('LOGIN_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('LOGIN_MAX_ATTEMPTS', 5, 1),
+            'decay_seconds' => $throttle('LOGIN_DECAY_SECONDS', 900, 60),
         ],
         // Looser: per account across all IPs, to catch distributed spraying on one
         // account without making it cheap to lock a known account out from anywhere.
         'login_account' => [
-            'max_attempts' => max(1, (int) env('LOGIN_ACCOUNT_MAX_ATTEMPTS', 20)),
-            'decay_seconds' => max(60, (int) env('LOGIN_ACCOUNT_DECAY_SECONDS', 3600)),
+            'max_attempts' => $throttle('LOGIN_ACCOUNT_MAX_ATTEMPTS', 20, 1),
+            'decay_seconds' => $throttle('LOGIN_ACCOUNT_DECAY_SECONDS', 3600, 60),
         ],
         // Backstop: per IP, wide enough for a shared office outbound address.
         'login_ip' => [
-            'max_attempts' => max(1, (int) env('LOGIN_IP_MAX_ATTEMPTS', 50)),
-            'decay_seconds' => max(60, (int) env('LOGIN_IP_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('LOGIN_IP_MAX_ATTEMPTS', 50, 1),
+            'decay_seconds' => $throttle('LOGIN_IP_DECAY_SECONDS', 900, 60),
         ],
         'mfa' => [
-            'max_attempts' => max(1, (int) env('MFA_MAX_ATTEMPTS', 5)),
-            'decay_seconds' => max(60, (int) env('MFA_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('MFA_MAX_ATTEMPTS', 5, 1),
+            'decay_seconds' => $throttle('MFA_DECAY_SECONDS', 900, 60),
         ],
         'password_reset_request' => [
-            'max_attempts' => max(1, (int) env('PASSWORD_RESET_REQUEST_MAX_ATTEMPTS', 5)),
-            'decay_seconds' => max(60, (int) env('PASSWORD_RESET_REQUEST_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('PASSWORD_RESET_REQUEST_MAX_ATTEMPTS', 5, 1),
+            'decay_seconds' => $throttle('PASSWORD_RESET_REQUEST_DECAY_SECONDS', 900, 60),
         ],
         'password_reset' => [
-            'max_attempts' => max(1, (int) env('PASSWORD_RESET_MAX_ATTEMPTS', 5)),
-            'decay_seconds' => max(60, (int) env('PASSWORD_RESET_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('PASSWORD_RESET_MAX_ATTEMPTS', 5, 1),
+            'decay_seconds' => $throttle('PASSWORD_RESET_DECAY_SECONDS', 900, 60),
         ],
         'registration' => [
-            'max_attempts' => max(1, (int) env('REGISTRATION_MAX_ATTEMPTS', 5)),
-            'decay_seconds' => max(60, (int) env('REGISTRATION_DECAY_SECONDS', 900)),
+            'max_attempts' => $throttle('REGISTRATION_MAX_ATTEMPTS', 5, 1),
+            'decay_seconds' => $throttle('REGISTRATION_DECAY_SECONDS', 900, 60),
         ],
     ],
 

--- a/tests/Feature/MfaFailedLoggingTest.php
+++ b/tests/Feature/MfaFailedLoggingTest.php
@@ -59,7 +59,9 @@ test('credential lockout is logged after exceeding max attempts', function () {
         'role' => Role::Admin,
     ]);
 
-    $rateLimitKey = 'livewire-rate-limiter:'.sha1(Login::class.'|authenticate|127.0.0.1');
+    // The strict limiter: per account and IP. The wide IP backstop is covered
+    // by its own test in RateLimitLoggingTest.
+    $rateLimitKey = 'login-credentials:'.sha1('admin@example.com|127.0.0.1');
     $maxAttempts = config('auth.throttle.login.max_attempts', 5);
 
     for ($i = 0; $i < $maxAttempts; $i++) {

--- a/tests/Feature/RateLimitLoggingTest.php
+++ b/tests/Feature/RateLimitLoggingTest.php
@@ -476,9 +476,9 @@ test('nonsensical throttle configuration does not disable the login limiter', fu
     Filament::setCurrentPanel(Filament::getPanel('admin'));
 
     // A string decay value used to blow up inside Carbon, and a value casting to
-    // zero would silently switch the limiter off. Both are clamped on the call
-    // site, because Config::set() bypasses the clamp in config/auth.php exactly
-    // like a cached config artefact would.
+    // zero would silently switch the limiter off. Both are handled on the call
+    // site, because Config::set() bypasses the validation in config/auth.php
+    // exactly like a cached config artefact would.
     foreach (['900', '', 'abc'] as $index => $decaySeconds) {
         Config::set('auth.throttle.login.decay_seconds', $decaySeconds);
 
@@ -499,6 +499,39 @@ test('nonsensical throttle configuration does not disable the login limiter', fu
         expect($activity)->not->toBeNull()
             ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
     }
+});
+
+test('a non numeric throttle maximum falls back to the default instead of the floor', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    // (int) '' is 0. Clamping that to the floor of 1 would lock every user in
+    // the application out after a single mistyped password, so an unusable
+    // value has to fall back to the documented default of 5 instead.
+    Config::set('auth.throttle.login.max_attempts', '');
+
+    $email = 'admin@example.com';
+
+    for ($i = 0; $i < 5; $i++) {
+        livewire(Login::class)
+            ->fillForm(['email' => $email, 'password' => 'wrong-password', 'remember' => false])
+            ->call('authenticate');
+    }
+
+    expect(Activity::where('log_name', 'auth')->where('event', 'lockout')->exists())->toBeFalse();
+
+    // The default still has to be a working limit, not an absent one.
+    livewire(Login::class)
+        ->fillForm(['email' => $email, 'password' => 'wrong-password', 'remember' => false])
+        ->call('authenticate');
+
+    $activity = Activity::where('log_name', 'auth')
+        ->where('event', 'lockout')
+        ->where('properties->type', 'credentials')
+        ->first();
+
+    expect($activity)->not->toBeNull()
+        ->and($activity->properties->get('email'))->toBe($email)
+        ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
 });
 
 test('normal password reset request does not create a lockout log', function () {

--- a/tests/Feature/RateLimitLoggingTest.php
+++ b/tests/Feature/RateLimitLoggingTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 use App\Enums\Role;
 use App\Filament\Organiser\Pages\Register;
+use App\Filament\Shared\Pages\Login;
 use App\Filament\Shared\Pages\PasswordReset\RequestPasswordReset;
 use App\Filament\Shared\Pages\PasswordReset\ResetPassword;
 use App\Models\User;
 use Filament\Facades\Filament;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\RateLimiter;
+use PragmaRX\Google2FA\Google2FA;
 use Spatie\Activitylog\Models\Activity;
 
 use function Pest\Livewire\livewire;
@@ -162,6 +164,275 @@ test('registration lockout is logged after exceeding max attempts per email', fu
         ->and($activity->properties->get('email'))->toBe($email)
         ->and($activity->properties->get('panel'))->toBe('organiser')
         ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Login rate limiting
+|--------------------------------------------------------------------------
+|
+| Three counters, from strict to wide:
+|   A  login-credentials:sha1("<email>|<ip>")                 per account and IP
+|   B  login-account:sha1("<email>")                          per account, all IPs
+|   C  livewire-rate-limiter:sha1("<component>|authenticate|<ip>")  the IP backstop
+|
+| They are only incremented on a failed credential check, never on a
+| successful login and never on the multi-factor submit of a single login.
+|
+*/
+
+test('login lockout per account and IP is logged after exceeding max attempts', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+    ]);
+
+    $strictKey = 'login-credentials:'.sha1('admin@example.com|127.0.0.1');
+    $maxAttempts = config('auth.throttle.login.max_attempts', 5);
+
+    for ($i = 0; $i < $maxAttempts; $i++) {
+        RateLimiter::hit($strictKey);
+    }
+
+    livewire(Login::class)
+        ->fillForm(['email' => 'admin@example.com', 'password' => 'password', 'remember' => false])
+        ->call('authenticate');
+
+    $activity = Activity::where('log_name', 'auth')
+        ->where('event', 'lockout')
+        ->where('properties->type', 'credentials')
+        ->first();
+
+    expect($activity)->not->toBeNull()
+        ->and($activity->description)->toBe('Geblokkeerd')
+        ->and($activity->properties->get('email'))->toBe('admin@example.com')
+        ->and($activity->properties->get('panel'))->toBe('admin')
+        ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0)
+        ->and(Filament::auth()->check())->toBeFalse();
+});
+
+test('a colleague behind the same IP is not locked out by another account', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+    ]);
+
+    // The factory always seeds an app authentication secret, which would send
+    // this login through the multi-factor step. Null keeps it a plain login.
+    $colleague = User::factory()->create([
+        'email' => 'colleague@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+        'app_authentication_secret' => null,
+    ]);
+
+    $strictKey = 'login-credentials:'.sha1('admin@example.com|127.0.0.1');
+
+    for ($i = 0; $i < config('auth.throttle.login.max_attempts', 5); $i++) {
+        RateLimiter::hit($strictKey);
+    }
+
+    livewire(Login::class)
+        ->fillForm(['email' => $colleague->email, 'password' => 'password', 'remember' => false])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(Filament::auth()->check())->toBeTrue()
+        ->and(Activity::where('log_name', 'auth')->where('event', 'lockout')->exists())->toBeFalse();
+});
+
+test('uppercase and surrounding whitespace do not escape the login counter', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+    ]);
+
+    $strictKey = 'login-credentials:'.sha1('admin@example.com|127.0.0.1');
+
+    for ($i = 0; $i < config('auth.throttle.login.max_attempts', 5); $i++) {
+        RateLimiter::hit($strictKey);
+    }
+
+    livewire(Login::class)
+        ->fillForm(['email' => '  ADMIN@Example.COM ', 'password' => 'password', 'remember' => false])
+        ->call('authenticate');
+
+    $activity = Activity::where('log_name', 'auth')
+        ->where('event', 'lockout')
+        ->where('properties->type', 'credentials')
+        ->first();
+
+    expect($activity)->not->toBeNull()
+        ->and($activity->properties->get('email'))->toBe('admin@example.com');
+});
+
+test('a successful login consumes no rate limit budget', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $user = User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+        'app_authentication_secret' => null,
+    ]);
+
+    livewire(Login::class)
+        ->fillForm(['email' => $user->email, 'password' => 'password', 'remember' => false])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(Filament::auth()->check())->toBeTrue()
+        ->and(RateLimiter::attempts('login-credentials:'.sha1('admin@example.com|127.0.0.1')))->toBe(0)
+        ->and(RateLimiter::attempts('login-account:'.sha1('admin@example.com')))->toBe(0)
+        ->and(RateLimiter::attempts('livewire-rate-limiter:'.sha1(Login::class.'|authenticate|127.0.0.1')))->toBe(0);
+});
+
+test('the multi-factor step consumes no rate limit budget', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $secret = app(Google2FA::class)->generateSecretKey(16);
+
+    $user = User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+        'app_authentication_secret' => $secret,
+    ]);
+
+    $component = livewire(Login::class)
+        ->fillForm(['email' => $user->email, 'password' => 'password', 'remember' => false])
+        ->call('authenticate');
+
+    expect(Filament::auth()->check())->toBeFalse();
+
+    $component
+        ->set('data', [
+            'email' => $user->email,
+            'password' => 'password',
+            'remember' => false,
+            'multiFactor' => [
+                'app' => [
+                    'code' => app(Google2FA::class)->getCurrentOtp($secret),
+                    'useRecoveryCode' => false,
+                ],
+            ],
+        ])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    expect(Filament::auth()->check())->toBeTrue()
+        ->and(RateLimiter::attempts('login-credentials:'.sha1('admin@example.com|127.0.0.1')))->toBe(0)
+        ->and(RateLimiter::attempts('login-account:'.sha1('admin@example.com')))->toBe(0)
+        ->and(RateLimiter::attempts('livewire-rate-limiter:'.sha1(Login::class.'|authenticate|127.0.0.1')))->toBe(0)
+        ->and(RateLimiter::attempts("filament-multi-factor-challenge:{$user->getAuthIdentifier()}"))->toBe(0);
+});
+
+test('a successful login clears the account counters but not the IP backstop', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $user = User::factory()->create([
+        'email' => 'admin@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+        'app_authentication_secret' => null,
+    ]);
+
+    $strictKey = 'login-credentials:'.sha1('admin@example.com|127.0.0.1');
+    $accountKey = 'login-account:'.sha1('admin@example.com');
+    $ipKey = 'livewire-rate-limiter:'.sha1(Login::class.'|authenticate|127.0.0.1');
+
+    for ($i = 0; $i < 3; $i++) {
+        livewire(Login::class)
+            ->fillForm(['email' => $user->email, 'password' => 'wrong-password', 'remember' => false])
+            ->call('authenticate');
+    }
+
+    expect(RateLimiter::attempts($strictKey))->toBe(3)
+        ->and(RateLimiter::attempts($accountKey))->toBe(3)
+        ->and(RateLimiter::attempts($ipKey))->toBe(3);
+
+    livewire(Login::class)
+        ->fillForm(['email' => $user->email, 'password' => 'password', 'remember' => false])
+        ->call('authenticate')
+        ->assertHasNoFormErrors();
+
+    // The IP backstop must survive: clearing it would turn one valid account
+    // into an unlimited reset primitive for the whole IP address.
+    expect(Filament::auth()->check())->toBeTrue()
+        ->and(RateLimiter::attempts($strictKey))->toBe(0)
+        ->and(RateLimiter::attempts($accountKey))->toBe(0)
+        ->and(RateLimiter::attempts($ipKey))->toBe(3);
+});
+
+test('a reused multi-factor step still counts towards the limiters', function () {
+    //
+})->skip('Handmatig uit te werken, zie plan sectie 9 test 7');
+
+test('the IP backstop fires across many different accounts', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Config::set('auth.throttle.login_ip.max_attempts', 3);
+
+    foreach (['one@example.com', 'two@example.com', 'three@example.com'] as $email) {
+        livewire(Login::class)
+            ->fillForm(['email' => $email, 'password' => 'wrong-password', 'remember' => false])
+            ->call('authenticate');
+    }
+
+    livewire(Login::class)
+        ->fillForm(['email' => 'four@example.com', 'password' => 'wrong-password', 'remember' => false])
+        ->call('authenticate');
+
+    $activity = Activity::where('log_name', 'auth')
+        ->where('event', 'lockout')
+        ->where('properties->type', 'credentials_ip')
+        ->first();
+
+    expect($activity)->not->toBeNull()
+        ->and($activity->properties->get('email'))->toBe('four@example.com')
+        ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
+});
+
+test('the account counter fires across multiple IP addresses', function () {
+    //
+})->skip('Handmatig uit te werken, zie plan sectie 9 test 9');
+
+test('nonsensical throttle configuration does not disable the login limiter', function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    // A string decay value used to blow up inside Carbon, and a value casting to
+    // zero would silently switch the limiter off. Both are clamped on the call
+    // site, because Config::set() bypasses the clamp in config/auth.php exactly
+    // like a cached config artefact would.
+    foreach (['900', '', 'abc'] as $index => $decaySeconds) {
+        Config::set('auth.throttle.login.decay_seconds', $decaySeconds);
+
+        $email = "user{$index}@example.com";
+
+        for ($i = 0; $i < 6; $i++) {
+            livewire(Login::class)
+                ->fillForm(['email' => $email, 'password' => 'wrong-password', 'remember' => false])
+                ->call('authenticate');
+        }
+
+        $activity = Activity::where('log_name', 'auth')
+            ->where('event', 'lockout')
+            ->where('properties->type', 'credentials')
+            ->where('properties->email', $email)
+            ->first();
+
+        expect($activity)->not->toBeNull()
+            ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
+    }
 });
 
 test('normal password reset request does not create a lockout log', function () {

--- a/tests/Feature/RateLimitLoggingTest.php
+++ b/tests/Feature/RateLimitLoggingTest.php
@@ -374,8 +374,45 @@ test('a successful login clears the account counters but not the IP backstop', f
 });
 
 test('a reused multi-factor step still counts towards the limiters', function () {
-    //
-})->skip('Handmatig uit te werken, zie plan sectie 9 test 7');
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    $secret = app(Google2FA::class)->generateSecretKey(16);
+
+    $attacker = User::factory()->create([
+        'email' => 'attacker@example.com',
+        'password' => 'password',
+        'role' => Role::Admin,
+        'app_authentication_secret' => $secret,
+    ]);
+
+    // Step one with their own valid credentials leaves the multi-factor flag set
+    // on the component. A Livewire snapshot is a plain HMAC over the state with
+    // no nonce or expiry, so that snapshot can be replayed indefinitely.
+    $component = livewire(Login::class)
+        ->fillForm(['email' => $attacker->email, 'password' => 'password', 'remember' => false])
+        ->call('authenticate');
+
+    expect(Filament::auth()->check())->toBeFalse()
+        ->and($component->instance()->userUndertakingMultiFactorAuthentication)->not->toBeNull();
+
+    // Same component state, now guessing somebody else's password. Holding on to
+    // the component instance is what a replayed snapshot amounts to.
+    $component
+        ->set('data', [
+            'email' => 'victim@example.com',
+            'password' => 'wrong-password',
+            'remember' => false,
+        ])
+        ->call('authenticate');
+
+    // The credential check fails before the multi-factor branch is ever reached,
+    // so this must cost budget on all three counters. Skipping them here would
+    // hand out an unlimited password oracle.
+    expect(Filament::auth()->check())->toBeFalse()
+        ->and(RateLimiter::attempts('login-credentials:'.sha1('victim@example.com|127.0.0.1')))->toBe(1)
+        ->and(RateLimiter::attempts('login-account:'.sha1('victim@example.com')))->toBe(1)
+        ->and(RateLimiter::attempts('livewire-rate-limiter:'.sha1(Login::class.'|authenticate|127.0.0.1')))->toBe(1);
+});
 
 test('the IP backstop fires across many different accounts', function () {
     Filament::setCurrentPanel(Filament::getPanel('admin'));
@@ -403,8 +440,37 @@ test('the IP backstop fires across many different accounts', function () {
 });
 
 test('the account counter fires across multiple IP addresses', function () {
-    //
-})->skip('Handmatig uit te werken, zie plan sectie 9 test 9');
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    Config::set('auth.throttle.login_account.max_attempts', 3);
+
+    $email = 'admin@example.com';
+    $strictKey = 'login-credentials:'.sha1($email.'|127.0.0.1');
+    $accountKey = 'login-account:'.sha1($email);
+
+    // The account key deliberately carries no IP component, so failures from
+    // other addresses land in this same bucket. The Livewire test harness builds
+    // a fresh request per call and pins REMOTE_ADDR to 127.0.0.1, so those other
+    // addresses are seeded here instead of driven through the component.
+    for ($i = 0; $i < 3; $i++) {
+        RateLimiter::hit($accountKey);
+    }
+
+    livewire(Login::class)
+        ->fillForm(['email' => $email, 'password' => 'wrong-password', 'remember' => false])
+        ->call('authenticate');
+
+    $activity = Activity::where('log_name', 'auth')
+        ->where('event', 'lockout')
+        ->first();
+
+    // This IP has not failed once, so only the account counter can be the reason.
+    expect(RateLimiter::attempts($strictKey))->toBe(0)
+        ->and($activity)->not->toBeNull()
+        ->and($activity->properties->get('type'))->toBe('credentials_account')
+        ->and($activity->properties->get('email'))->toBe($email)
+        ->and($activity->properties->get('available_in_seconds'))->toBeGreaterThan(0);
+});
 
 test('nonsensical throttle configuration does not disable the login limiter', function () {
     Filament::setCurrentPanel(Filament::getPanel('admin'));


### PR DESCRIPTION
Logging in from an office with a shared outbound IP address locked out everyone behind that address. The login limiter ran purely on IP, counted every submit including successful ones, and counted a two-factor login twice, so a handful of colleagues signing in one after another exhausted the budget for the whole office.

## What changes

**Throttle configuration is cast and clamped.** Every value in `config/auth.php` arrives from the environment as a string, which blows up deep inside Carbon when it reaches `RateLimiter::hit()`. A bare cast is not enough either: an unset or non-numeric value casts to `0`, and a decay of `0` disables the limiter without a single line in the log, while a maximum of `0` locks out the entire application. Both are clamped towards the strict side, on the call site as well, because `Config::set()` and a cached config artefact both bypass the computation in the config file.

**Failures are counted instead of attempts.** `rateLimit()` now only checks; the counters go up in an override of `fireFailedEvent()`, which the parent calls on exactly the two credential failure paths. A successful login and the second (multi-factor) submit of a single login no longer consume any budget. This also removes two ways around the old design: a replayed Livewire snapshot with the multi-factor flag set now costs budget like any other failed guess, because the counter hangs on a failure the server established itself rather than on client state.

**Three counters, strict to wide:**

| Key | Limit | Against |
|---|---|---|
| `login-credentials:sha1(email\|ip)` | 5 per 900s | Guessing one account from one place |
| `login-account:sha1(email)` | 20 per 3600s | Distributed guessing on one known account |
| `livewire-rate-limiter:sha1(component\|authenticate\|ip)` | 50 per 900s | Spraying many accounts from one IP |

The third key is the existing one, reused unchanged, so existing production data keeps its meaning. A strict counter on the account alone was rejected on purpose: it would let anyone shut a known account out from anywhere with five requests, which OWASP ASVS V2.2.1 warns against.

**A successful login clears the account counters only.** The IP backstop is never cleared. Clearing it would turn one valid account, and the organiser panel has open self-registration, into an unlimited reset for the whole address. The multi-factor counter is cleared as well, because it had the same bug: it counted successful challenges and was never cleared, so signing in normally a few times within the window locked a user out of their own account.

## Effect

| Situation | Before | After |
|---|---|---|
| Reviewer signs in correctly with 2FA | 2 of 5 on the shared IP counter | no hits at all |
| Three colleagues sign in | counter full, office locked out for 15 minutes | no hits at all |
| One colleague mistypes three times | 3 of 5, hits everyone | 3 of 5 on their own account and IP, nobody else affected |
| Attacker hammers one account from one IP | stops after 5, takes the office down with it | stops after 5, only that account from that address |
| Attacker hammers one account from 40 IPs | stops after 5 per IP, office down | stops after 20 per hour |
| Attacker sprays 60 accounts from one IP | stops after 5 | stops after 50 |

The numbers are backed by the activity log: the lockouts in production come from a single IP address spread over many different email addresses, which is the shared-outbound-address pattern this fixes.

## Notes

The limiters key on `request()->ip()`, which is the real client address because nothing proxies production. That assumption is now recorded in `config/auth.php`, because adding a CDN, WAF or load balancer would collapse every request onto one address and turn the IP backstop into an application-wide lockout.
