### PR TITLE
Fix the "Kies een gemeente" loop on routes crossing several gemeenten

### DIFF
--- a/app/EventForm/State/FormFieldVisibility.php
+++ b/app/EventForm/State/FormFieldVisibility.php
@@ -465,9 +465,18 @@ final class FormFieldVisibility
      * `evenementInGemeente` is óf `null` óf een array, beide nooit gelijk
      * aan een lege string. Daardoor stond de tekst er altijd, óók zonder
      * bekende gemeente — met een lege gemeentenaam erachter.
+     *
+     * Wijkt bij een route door meerdere gemeenten voor de uitgebreidere
+     * `contentRouteDoorkuistMeerdereGemeenteInfo`, die dezelfde gemeente
+     * noemt plus vertelt dat de overige gemeenten geïnformeerd worden.
+     * Beide tonen zou hetzelfde twee keer zeggen.
      */
     public function content200(): ?bool
     {
+        if ($this->contentRouteDoorkuistMeerdereGemeenteInfo() === false) {
+            return null; // door-fall: de route-variant neemt 't over
+        }
+
         $gemeente = $this->state->get('evenementInGemeente');
         if (is_array($gemeente) && ! empty($gemeente['brk_identification'])) {
             return false; // show
@@ -552,13 +561,31 @@ final class FormFieldVisibility
     }
 
     /**
-     * `contentRouteDoorkuistMeerdereGemeenteInfo`-veld zichtbaarheid.
-     *  - OF-rule 3247522b-8603-4c7c-ae8d-b92a75fb35d6 → show wanneer: JsTruthy::of($s->get('routeDoorGemeentenNamen')) && ((is_array($s->get('routeDoorGemeentenNamen')) ? count($s->get('routeDoorGemeentenNamen')) : 0) >= 2) && JsTruthy::of($s->get('userSelectGemeente11'))
+     * `contentRouteDoorkuistMeerdereGemeenteInfo`-veld zichtbaarheid — "de
+     * route doorkruist gemeente X en Y, u vult dit formulier in voor
+     * gemeente X, de overige gemeenten worden automatisch geïnformeerd".
+     *
+     * Wijkt bewust af van OF-rule 3247522b-8603-4c7c-ae8d-b92a75fb35d6, die
+     * naast ≥2 doorkruiste gemeenten ook `userSelectGemeente11` truthy
+     * eiste. Dat veld bestaat in de hele OF-export niet als component of
+     * variabele, waardoor de trigger nooit waar werd en deze tekst in OF
+     * permanent onzichtbaar was. Bij de migratie is die conditie 1-op-1
+     * meegekomen, met hetzelfde resultaat.
+     *
+     * De bedoelde conditie is: er is een route door ≥2 gemeenten én er is
+     * een gemeente bepaald (de tekst noemt die gemeente bij naam, dus
+     * zonder is 'ie zinloos).
      */
     public function contentRouteDoorkuistMeerdereGemeenteInfo(): ?bool
     {
         $s = $this->state;
-        if ((JsTruthy::of($s->get('routeDoorGemeentenNamen')) && ((is_array($s->get('routeDoorGemeentenNamen')) ? count($s->get('routeDoorGemeentenNamen')) : 0) >= 2) && JsTruthy::of($s->get('userSelectGemeente11')))) {
+        $namen = $s->get('routeDoorGemeentenNamen');
+        if (! is_array($namen) || count($namen) < 2) {
+            return null; // door-fall: default visibility uit step-file
+        }
+
+        $gemeente = $s->get('evenementInGemeente');
+        if (is_array($gemeente) && ! empty($gemeente['brk_identification'])) {
             return false; // show
         }
 

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -574,32 +574,52 @@ class EventFormPage extends Page implements HasForms
 
     /**
      * Cleart `userSelectGemeente` wanneer de zojuist berekende gemeente-
-     * intersectie de eerdere keuze van de organisator twijfelachtig
-     * maakt: route start+eindigt in dezelfde gemeente, terwijl 'ie wel
-     * door ≥2 gemeenten gaat. In zo'n geval moet de keuze opnieuw
-     * gemaakt worden — anders blijft een stale brk_identification de
-     * `evenementInGemeente`-derivation aansturen.
+     * intersectie de eerdere keuze van de organisator ongeldig maakt: de
+     * gekozen gemeente zit niet langer tussen de gevonden gemeenten. Dat
+     * gebeurt wanneer de organisator z'n route of locatie zo verlegt dat
+     * die gemeente er niet meer bij is. Zonder deze reset zou een stale
+     * brk_identification de `evenementInGemeente`-derivation blijven
+     * aansturen; die levert dan `null` op en de gate blokkeert met de
+     * misleidende melding "Gemeente niet bepaald" i.p.v. om een nieuwe
+     * keuze te vragen.
      *
-     * Migreert OF-rule `be547255-4a1b-4f37-96e8-919d5351e7a5`
-     * (AlsIsGelijkAanTrueEnReductieVanEvenemen). OF gebruikte
-     * `userSelectGemeente11` als trigger-marker (interne duplicate-key-
-     * suffix); wij hebben alleen één veld, dus checken we dat direct.
+     * Bewust idempotent: een keuze die nog in de gevonden set zit blijft
+     * staan, hoe vaak deze check ook draait. De gate (`runLocationGate()`)
+     * roept 'm aan bij élke Volgende-klik, dus een niet-idempotente reset
+     * betekent een oneindige lus tussen "keuze gewist" en "kies een
+     * gemeente".
+     *
+     * Wijkt bewust af van OF-rule `be547255-4a1b-4f37-96e8-919d5351e7a5`
+     * (AlsIsGelijkAanTrueEnReductieVanEvenemen), die wiste zodra een route
+     * in dezelfde gemeente start en eindigt terwijl 'ie door ≥2 gemeenten
+     * gaat. Die regel heeft in OF nooit gevuurd: z'n trigger vergeleek
+     * `inGemeentenResponse.line.start_end_equal` (bool) met de string
+     * `"True"` en eiste daarnaast `userSelectGemeente11`, een veld dat in
+     * de hele OF-export niet als component of variabele bestaat. Letterlijk
+     * overnemen maakte er live logica van die precies de meest voorkomende
+     * routevorm (rondje dat net over een gemeentegrens komt) onindienbaar
+     * maakte.
      */
     private function resetStaleGemeenteKeuze(): void
     {
-        $startEndEqual = $this->state->get('inGemeentenResponse.line.start_end_equal');
-        if ($startEndEqual !== true) {
-            return;
-        }
-
-        $namen = $this->state->get('evenementInGemeentenNamen');
-        if (! is_array($namen) || count($namen) < 2) {
-            return;
-        }
-
         $pick = $this->state->get('userSelectGemeente');
         if (! is_string($pick) || $pick === '') {
             return;
+        }
+
+        // `gemeenten` is `inGemeentenResponse.all.object`: de gevonden
+        // gemeenten gekeyed op brk_identification, exact de optie-keys van
+        // de keuze-radio.
+        $gemeenten = $this->state->get('gemeenten');
+        if (! is_array($gemeenten) || $gemeenten === []) {
+            // Nog geen (geslaagde) location-check, dus niets om de keuze
+            // tegen af te zetten. Laten staan; de gate blokkeert alsnog
+            // wanneer er geen gemeente bepaald kan worden.
+            return;
+        }
+
+        if (array_key_exists($pick, $gemeenten)) {
+            return; // keuze is nog steeds geldig
         }
 
         $this->state->setVariable('userSelectGemeente', '');

--- a/tests/Feature/EventForm/Pages/EventFormPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageTest.php
@@ -232,64 +232,93 @@ test('mount valt terug op stap 1 bij onbekende current_step_key', function () {
     expect($reflection->invoke($page))->toBe(1);
 });
 
-test('route die start+eindigt in dezelfde gemeente maar door ≥2 gemeenten gaat → eerdere gemeente-keuze wordt geleegd', function () {
-    // Bug-rapport-equivalent uit OF: de organisator had al een
-    // gemeente gekozen (Heerlen), tekent dan een route die start+eindigt
-    // in Heerlen maar door Maastricht ook loopt. Heerlen-keuze hoort
-    // dan opnieuw bevestigd te worden — anders blijft 't gebaseerd op
-    // een outdated route-state. Migreert OF-rule
-    // be547255-4a1b-4f37-96e8-919d5351e7a5.
+/**
+ * Zet een `inGemeentenResponse` in de state met de gegeven gemeenten. Bevat
+ * zowel `all.items` (voor de tellingen) als `all.object` (de map waarop
+ * `gemeenten` — en daarmee de staleness-check — draait).
+ *
+ * @param  list<array{0: string, 1: string}>  $gemeenten  [brk_identification, naam]
+ * @param  array<string, mixed>  $extra  Losse response-takken, bv. `line`.
+ */
+function seedInGemeentenResponse(EventFormPage $page, array $gemeenten, array $extra = []): void
+{
+    $items = [];
+    $object = [];
+    foreach ($gemeenten as [$brk, $naam]) {
+        $items[] = ['brk_identification' => $brk, 'name' => $naam];
+        $object[$brk] = ['brk_identification' => $brk, 'name' => $naam];
+    }
+
+    $page->state()->setVariable('inGemeentenResponse', array_merge([
+        'all' => ['items' => $items, 'object' => $object],
+    ], $extra));
+}
+
+test('route verlegd waardoor de gekozen gemeente wegvalt → keuze wordt geleegd', function () {
+    // De organisator had Heerlen gekozen en verlegt daarna z'n route zo dat
+    // Heerlen er niet meer bij zit. De keuze wijst dan naar een gemeente die
+    // niet meer in de radio-opties staat en moet opnieuw gemaakt worden;
+    // zonder reset levert `evenementInGemeente` null op en blokkeert de gate
+    // met de misleidende melding "Gemeente niet bepaald".
     $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
 
     /** @var EventFormPage $page */
     $page = $component->instance();
 
-    // Seed inGemeentenResponse via setVariable (state-level — niet door
-    // Filament's form gerouteerd). userSelectGemeente moet in `$data`
-    // staan want updated() doet absorbFields($data) als eerste actie.
-    $page->state()->setVariable('inGemeentenResponse', [
-        'all' => ['items' => [
-            ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
-            ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
-        ]],
-        'line' => ['start_end_equal' => true],
+    // Seed via setVariable (state-level — niet door Filament's form
+    // gerouteerd). userSelectGemeente moet in `$data` staan want updated()
+    // doet absorbFields($data) als eerste actie.
+    seedInGemeentenResponse($page, [
+        ['GM0935', 'Maastricht'],
+        ['GM1883', 'Eijsden-Margraten'],
     ]);
-    $page->data['userSelectGemeente'] = 'GM0917';
+    $page->data['userSelectGemeente'] = 'GM0917'; // Heerlen, niet meer geraakt
 
-    $page->updated('data.locatieSOpKaart');
+    $page->updated('data.routesOpKaart');
 
     expect($page->state()->get('userSelectGemeente'))->toBe('')
         ->and($page->data['userSelectGemeente'])->toBe('');
 });
 
-test('zonder ≥2 gemeenten of zonder eerdere keuze → geen reset', function () {
-    // Conditie 1: maar 1 gemeente in de response → niets te resetten
+test('keuze die nog tussen de gevonden gemeenten zit blijft staan, ook bij een rondroute', function () {
+    // Rondroute: start en eind in Heerlen, onderweg door Maastricht. Precies
+    // de vorm waarop de gemigreerde OF-rule be547255 de keuze wiste bij élke
+    // gate-pass, wat een oneindige lus opleverde met "Kies een gemeente".
     $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
 
     /** @var EventFormPage $page */
     $page = $component->instance();
 
-    $page->state()->setVariable('inGemeentenResponse', [
-        'all' => ['items' => [['brk_identification' => 'GM0917', 'name' => 'Heerlen']]],
-        'line' => ['start_end_equal' => true],
-    ]);
+    seedInGemeentenResponse($page, [
+        ['GM0917', 'Heerlen'],
+        ['GM0935', 'Maastricht'],
+    ], ['line' => ['start_end_equal' => true]]);
     $page->data['userSelectGemeente'] = 'GM0917';
 
-    $page->updated('data.locatieSOpKaart');
+    $page->updated('data.routesOpKaart');
 
     expect($page->state()->get('userSelectGemeente'))->toBe('GM0917');
 
-    // Conditie 2: ≥2 gemeenten maar route start≠eind → keuze blijft
-    $page->state()->setVariable('inGemeentenResponse', [
-        'all' => ['items' => [
-            ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
-            ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
-        ]],
-        'line' => ['start_end_equal' => false],
-    ]);
+    // Idempotent: nog een ronde verandert er niets aan. Een niet-idempotente
+    // reset is precies wat de lus veroorzaakte.
+    $page->updated('data.routesOpKaart');
+
+    expect($page->state()->get('userSelectGemeente'))->toBe('GM0917')
+        ->and($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0917');
+});
+
+test('nog geen location-check gedaan → keuze blijft ongemoeid', function () {
+    // Zonder `gemeenten`-map is er niets om de keuze tegen af te zetten;
+    // hem dan wissen zou een uit een concept geladen keuze weggooien voordat
+    // de eerste check gedraaid heeft.
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
     $page->data['userSelectGemeente'] = 'GM0917';
 
-    $page->updated('data.locatieSOpKaart');
+    $page->updated('data.routesOpKaart');
 
     expect($page->state()->get('userSelectGemeente'))->toBe('GM0917');
 });
@@ -457,6 +486,64 @@ test('gate: een getekend vlak bepaalt de gemeente autoritatief (kaart blijft wer
     locatieGateCallback()($page);
 
     expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0999');
+});
+
+test('gate: rondroute door 2 gemeenten laat een gemaakte keuze staan (geen "Kies een gemeente"-lus)', function () {
+    // Bug-rapport: een route die in gemeente A start, door B loopt en weer in
+    // A eindigt. De organisator koos een gemeente, klikte Volgende, kreeg
+    // "Kies een gemeente" en zag z'n keuze leeg — elke ronde opnieuw. De gate
+    // riep een niet-idempotente reset aan die de keuze bij iedere pass wiste.
+    Municipality::factory()->create([
+        'brk_identification' => 'GM_A',
+        'name' => 'Gemeente A',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[-1,-1],[0,-1],[0,1],[-1,1],[-1,-1]]]]}',
+    ]);
+    Municipality::factory()->create([
+        'brk_identification' => 'GM_B',
+        'name' => 'Gemeente B',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[0.01,-1],[2,-1],[2,1],[0.01,1],[0.01,-1]]]]}',
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id])->instance();
+    $page->data['routesOpKaart'] = [
+        'row-1' => [
+            'routeVanHetEvenement' => [
+                'lat' => 0.0, 'lng' => 0.0,
+                'geojson' => [
+                    'type' => 'FeatureCollection',
+                    'features' => [[
+                        'type' => 'Feature',
+                        'properties' => new stdClass,
+                        'geometry' => [
+                            'type' => 'LineString',
+                            // Start (-0.5, 0) en eind (-0.4, 0.1) liggen beide
+                            // in A, de knik op (1, 0) ligt in B.
+                            'coordinates' => [[-0.5, 0.0], [1.0, 0.0], [-0.4, 0.1]],
+                        ],
+                    ]],
+                ],
+            ],
+        ],
+    ];
+
+    // Nog geen keuze bij 2 gemeenten → terecht blokkeren.
+    expect(fn () => locatieGateCallback()($page))->toThrow(Halt::class);
+    expect($page->state()->get('inGemeentenResponse.line.start_end_equal'))->toBeTrue()
+        ->and($page->state()->get('inGemeentenResponse.all.items'))->toHaveCount(2);
+
+    // Keuze gemaakt → de gate hoort door te laten en de keuze te bewaren.
+    $page->data['userSelectGemeente'] = 'GM_A';
+    locatieGateCallback()($page);
+
+    expect($page->data['userSelectGemeente'])->toBe('GM_A')
+        ->and($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM_A');
+
+    // Nog een pass (de organisator klikt Vorige en weer Volgende) mag de
+    // keuze evenmin wissen.
+    locatieGateCallback()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM_A');
 });
 
 test('mount clears the "Mijn omgeving" placeholder left in an old draft of a personal organisation', function () {

--- a/tests/Feature/EventForm/State/FormFieldVisibilityTest.php
+++ b/tests/Feature/EventForm/State/FormFieldVisibilityTest.php
@@ -62,3 +62,75 @@ test('evenmentenInDeBuurtContent verschijnt zodra evenementenInDeGemeente truthy
     expect($state->isFieldHidden('evenmentenInDeBuurtContent'))
         ->toBeNull('zonder overlap is de waarschuwing default-hidden');
 });
+
+test('contentRouteDoorkuistMeerdereGemeenteInfo verschijnt bij een route door ≥2 gemeenten met een bepaalde gemeente', function () {
+    // Deze InfoText ("de route doorkruist gemeente X en Y, u vult in voor X,
+    // de overige gemeenten worden geïnformeerd") stond permanent hidden: de
+    // OF-rule eiste `userSelectGemeente11`, een veld dat in de OF-export niet
+    // bestaat. De bedoelde conditie is route-door-≥2-gemeenten plus een
+    // bepaalde gemeente.
+    $state = new FormState;
+
+    // Zonder route → default hidden.
+    expect($state->isFieldHidden('contentRouteDoorkuistMeerdereGemeenteInfo'))->toBeNull();
+
+    // Route door 1 gemeente → nog steeds hidden (dan valt er niets te melden).
+    $state->setVariable('inGemeentenResponse', [
+        'all' => [
+            'items' => [['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+            'object' => ['GM0917' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+        ],
+        'line' => ['items' => [['brk_identification' => 'GM0917', 'name' => 'Heerlen']]],
+    ]);
+    expect($state->isFieldHidden('contentRouteDoorkuistMeerdereGemeenteInfo'))->toBeNull();
+    // Met één gemeente doet `content200` het werk ("U gaat verder voor …").
+    expect($state->isFieldHidden('content200'))->toBeFalse();
+
+    // Route door 2 gemeenten, keuze gemaakt → tonen, en `content200` wijkt.
+    $state->setVariable('inGemeentenResponse', [
+        'all' => [
+            'items' => [
+                ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+            'object' => [
+                'GM0917' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+        ],
+        'line' => ['items' => [
+            ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+            ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]],
+    ]);
+    $state->setVariable('userSelectGemeente', 'GM0917');
+
+    expect($state->isFieldHidden('contentRouteDoorkuistMeerdereGemeenteInfo'))
+        ->toBeFalse('route door 2 gemeenten met keuze hoort de route-tekst te tonen')
+        ->and($state->isFieldHidden('content200'))
+        ->toBeNull('content200 wijkt voor de uitgebreidere route-tekst');
+});
+
+test('contentRouteDoorkuistMeerdereGemeenteInfo blijft hidden zolang er geen gemeente bepaald is', function () {
+    // De tekst noemt de gemeente bij naam; zonder keuze bij ≥2 gemeenten is
+    // `evenementInGemeente` null en zou er een lege naam in de zin staan.
+    $state = new FormState;
+    $state->setVariable('inGemeentenResponse', [
+        'all' => [
+            'items' => [
+                ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+            'object' => [
+                'GM0917' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+        ],
+        'line' => ['items' => [
+            ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+            ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]],
+    ]);
+
+    expect($state->isFieldHidden('contentRouteDoorkuistMeerdereGemeenteInfo'))->toBeNull();
+});


### PR DESCRIPTION
## Problem

An organiser drawing a route that starts and ends in the same gemeente but passes through another one could never get past the location step. Reported flow: draw the route, pick the gemeente you want to apply to, click Volgende, get the warning "Kies een gemeente" with the radio emptied again, repeat forever.

Routes ending in a different gemeente than they start in were unaffected, which is why the bug looked intermittent. Loop routes are the common shape for optochten, processies and wandeltochten, so a large share of route applications hit this.

## Cause

`EventFormPage::resetStaleGemeenteKeuze()` cleared `userSelectGemeente` whenever `inGemeentenResponse.line.start_end_equal` was true and the input touched two or more gemeenten. Since commit 684d660 the location gate calls that method on every Volgende click, so the choice was wiped on each pass and the gate then blocked on the very field it had just emptied.

The rule was ported from OF rule `be547255-4a1b-4f37-96e8-919d5351e7a5`, which never fired in Open Forms. Its trigger compared `inGemeentenResponse.line.start_end_equal` (a boolean) against the string `"True"`, and additionally required `userSelectGemeente11`, a field that appears nowhere in the form export as a component or variable (only twice in `formLogic.json`, both times as a trigger variable). Porting it literally turned dead logic into live logic.

## Fix

The reset now expresses what it was meant to: clear the choice only when it no longer appears among the gemeenten found by the location check, which is what actually happens when the organiser moves the route away from that gemeente. That condition is idempotent, so repeated gate passes can no longer empty a valid choice.

This also removes a second problem. A stale choice used to leave `evenementInGemeente` null, so the gate reported "Gemeente niet bepaald" instead of asking for a new choice.

## Also included

The notice "de ingetekende route doorkruist de volgende gemeente(n) ... de overige gemeenten worden automatisch geinformeerd" was permanently hidden, because its visibility rule required the same non-existent `userSelectGemeente11`. It was invisible in Open Forms too, so this is not a regression, but the text is clearly meant to be shown. It now appears for a route through two or more gemeenten once a gemeente is determined, and `content200` yields to it so the same thing is not stated twice.