### PR TITLE
Create a copied aanvraag in the municipality the organiser picked

### DIFF
--- a/app/EventForm/Components/AddressNL.php
+++ b/app/EventForm/Components/AddressNL.php
@@ -126,6 +126,12 @@ final class AddressNL
             $postcode = $get("{$key}.postcode");
             $huisnummer = $get("{$key}.huisnummer");
 
+            // Invalidate the stored gemeente first: it belongs to the address as
+            // it was before this edit. The location check trusts it verbatim, so
+            // leaving it in place while the lookup below fails (or resolves a
+            // different address) would route the aanvraag to the wrong gemeente.
+            $set("{$key}.brkGemeente", null);
+
             if (! self::hasLookupInput($postcode, $huisnummer)) {
                 return;
             }

--- a/app/EventForm/Persistence/PrefillLoader.php
+++ b/app/EventForm/Persistence/PrefillLoader.php
@@ -187,12 +187,36 @@ class PrefillLoader
 
         foreach ($addresses as $index => $row) {
             if (is_array($row)) {
-                unset($addresses[$index]['brkGemeente']);
+                $addresses[$index] = $this->withoutBrkGemeente($row);
             }
         }
 
         $values['adresVanDeGebouwEn'] = $addresses;
 
         return $values;
+    }
+
+    /**
+     * Removes every `brkGemeente` entry from a copied address row, at whatever
+     * depth it sits. The value does not live on the row itself but under the
+     * AddressNL fieldset prefix (currently
+     * `adresVanHetGebouwWaarUwEvenementPlaatsvindt1.brkGemeente`), so clearing
+     * the row's own keys would miss it entirely. Walking the row instead of
+     * hardcoding that prefix keeps this working when the schema key changes.
+     *
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function withoutBrkGemeente(array $row): array
+    {
+        unset($row['brkGemeente']);
+
+        foreach ($row as $key => $value) {
+            if (is_array($value)) {
+                $row[$key] = $this->withoutBrkGemeente($value);
+            }
+        }
+
+        return $row;
     }
 }

--- a/app/EventForm/Persistence/PrefillLoader.php
+++ b/app/EventForm/Persistence/PrefillLoader.php
@@ -125,6 +125,27 @@ class PrefillLoader
     }
 
     /**
+     * Location-dependent state from the source zaak. These are fetch results and
+     * a choice made for the source event's location, not answers the organiser
+     * gave: carrying them over would let the copy be routed to the original
+     * municipality even after the location is changed. They are rebuilt from the
+     * new location by the location gate.
+     *
+     * `evenementInGemeente` is derived, never written by the current form, but is
+     * stripped defensively: a materialised value in the values bag would win
+     * whenever the derivation yields null.
+     *
+     * @var list<string>
+     */
+    private const LOCATION_DEPENDENT_KEYS = [
+        'userSelectGemeente',
+        'inGemeentenResponse',
+        'gemeenteVariabelen',
+        'evenementenInDeGemeente',
+        'evenementInGemeente',
+    ];
+
+    /**
      * Knip afgeleide state eruit zodat de prefill een "leeg-met-invullen"
      * gevoel geeft, niet een "volgende submit"-gevoel.
      */
@@ -136,6 +157,42 @@ class PrefillLoader
         $clean['field_hidden'] = [];
         $clean['step_applicable'] = [];
 
+        if (isset($clean['values']) && is_array($clean['values'])) {
+            foreach (self::LOCATION_DEPENDENT_KEYS as $key) {
+                unset($clean['values'][$key]);
+            }
+
+            $clean['values'] = $this->stripAddressBrkGemeente($clean['values']);
+        }
+
         return FormState::fromSnapshot($clean);
+    }
+
+    /**
+     * Drops the hidden `brkGemeente` the PDOK auto-fill stored on each copied
+     * address row. It identifies the municipality of the *source* address, and
+     * the location check trusts it verbatim, so a copied row whose auto-fill
+     * does not re-fire would keep routing the aanvraag to the old municipality.
+     * Clearing it forces a fresh postcode + house number lookup.
+     *
+     * @param  array<string, mixed>  $values
+     * @return array<string, mixed>
+     */
+    private function stripAddressBrkGemeente(array $values): array
+    {
+        $addresses = $values['adresVanDeGebouwEn'] ?? null;
+        if (! is_array($addresses)) {
+            return $values;
+        }
+
+        foreach ($addresses as $index => $row) {
+            if (is_array($row)) {
+                unset($addresses[$index]['brkGemeente']);
+            }
+        }
+
+        $values['adresVanDeGebouwEn'] = $addresses;
+
+        return $values;
     }
 }

--- a/app/EventForm/Services/ServiceFetcher.php
+++ b/app/EventForm/Services/ServiceFetcher.php
@@ -19,6 +19,21 @@ use App\Models\User;
  */
 class ServiceFetcher
 {
+    /**
+     * De state-variabelen die deze fetcher schrijft. Ze horen bij de server:
+     * ze worden berekend uit de ingevulde velden en mogen nooit vanuit de
+     * Livewire-`$data` terug de state in komen. `EventFormPage` filtert ze
+     * er in `withoutServerOwnedState()` op basis van deze lijst uit.
+     *
+     * @var list<string>
+     */
+    public const FETCHED_VARIABLES = [
+        'eventloketSession',
+        'gemeenteVariabelen',
+        'evenementenInDeGemeente',
+        'inGemeentenResponse',
+    ];
+
     public function __construct(
         private readonly LocationServerCheckService $locationService,
         private readonly MunicipalityVariablesService $municipalityService,

--- a/app/EventForm/State/FormDerivedState.php
+++ b/app/EventForm/State/FormDerivedState.php
@@ -213,8 +213,16 @@ final class FormDerivedState
     {
         $pick = $this->state->get('userSelectGemeente');
         if (is_string($pick) && $pick !== '') {
-            // De `gemeenten`-map is keyed by brk_identification.
-            return $this->state->get("gemeenten.{$pick}");
+            // De `gemeenten`-map is keyed by brk_identification. A pick that is
+            // no longer among the municipalities found for the current location
+            // is stale (a copied aanvraag whose location has changed, or an
+            // edited location) and must not win: falling through to the
+            // auto-pick keeps the aanvraag with the actual location instead of
+            // silently routing it to the previous municipality.
+            $gemeente = $this->state->get("gemeenten.{$pick}");
+            if ($gemeente !== null) {
+                return $gemeente;
+            }
         }
 
         $items = $this->state->get('inGemeentenResponse.all.items');

--- a/app/EventForm/Submit/ResolveZaaktype.php
+++ b/app/EventForm/Submit/ResolveZaaktype.php
@@ -57,6 +57,8 @@ final class ResolveZaaktype
     {
         $brk = $state->get('evenementInGemeente.brk_identification');
         if (is_string($brk) && $brk !== '') {
+            $this->assertMunicipalityMatchesLocation($state, $brk);
+
             $muni = Municipality::where('brk_identification', $brk)->first();
             if ($muni) {
                 return $muni;
@@ -74,5 +76,34 @@ final class ResolveZaaktype
             DetermineAanvraagType::VOORAANKONDIGING => 'Vooraankondiging',
             default => throw new RuntimeException(sprintf('Onbekende aard "%s".', $aard)),
         };
+    }
+
+    /**
+     * Guards the invariant that the municipality a zaak is created for is one of
+     * the municipalities the current location actually falls in. The location
+     * check result is authoritative here: it is recomputed on the location gate
+     * from the submitted addresses, areas and routes.
+     *
+     * Without this a stale gemeente in the state (a copied aanvraag, an edited
+     * location) would silently create the zaak for the previous municipality,
+     * and with it on the previous municipality's ZGW instance. Failing the
+     * submit is the lesser harm; the organiser is sent back through the location
+     * step. A state without a location check result (older drafts) is left
+     * alone.
+     */
+    private function assertMunicipalityMatchesLocation(FormState $state, string $brk): void
+    {
+        $gemeenten = $state->get('inGemeentenResponse.all.object');
+        if (! is_array($gemeenten) || $gemeenten === []) {
+            return;
+        }
+
+        if (! array_key_exists($brk, $gemeenten)) {
+            throw new RuntimeException(sprintf(
+                'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
+                $brk,
+                implode(', ', array_keys($gemeenten)),
+            ));
+        }
     }
 }

--- a/app/EventForm/Submit/ResolveZaaktype.php
+++ b/app/EventForm/Submit/ResolveZaaktype.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Submit;
 
 use App\EventForm\State\FormState;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Models\Municipality;
 use App\Models\Zaaktype;
 use RuntimeException;
@@ -87,9 +88,14 @@ final class ResolveZaaktype
      * Without this a stale gemeente in the state (a copied aanvraag, an edited
      * location) would silently create the zaak for the previous municipality,
      * and with it on the previous municipality's ZGW instance. Failing the
-     * submit is the lesser harm; the organiser is sent back through the location
-     * step. A state without a location check result (older drafts) is left
-     * alone.
+     * submit is the lesser harm. A state without a location check result (older
+     * drafts) is left alone.
+     *
+     * @throws GemeenteLocatieMismatchException so the submit handler can tell
+     *                                          the organiser to revisit the
+     *                                          location step, instead of the
+     *                                          generic "try again" that a plain
+     *                                          failure produces.
      */
     private function assertMunicipalityMatchesLocation(FormState $state, string $brk): void
     {
@@ -99,11 +105,7 @@ final class ResolveZaaktype
         }
 
         if (! array_key_exists($brk, $gemeenten)) {
-            throw new RuntimeException(sprintf(
-                'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
-                $brk,
-                implode(', ', array_keys($gemeenten)),
-            ));
+            throw new GemeenteLocatieMismatchException($brk, array_map(strval(...), array_keys($gemeenten)));
         }
     }
 }

--- a/app/Exceptions/GemeenteLocatieMismatchException.php
+++ b/app/Exceptions/GemeenteLocatieMismatchException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Thrown when the gemeente in the FormState is not among the municipalities the
+ * location check found for the submitted location. Creating the zaak anyway
+ * would put it in the wrong municipality, and with it on the wrong ZGW instance.
+ *
+ * Its own type so the submit handler can tell the organiser what to do about it:
+ * retrying is pointless, the location step has to be revisited.
+ */
+class GemeenteLocatieMismatchException extends RuntimeException
+{
+    /**
+     * @param  string  $brk  The brk_identification held in the FormState.
+     * @param  list<string>  $foundBrkIdentifications  The municipalities found for the submitted location.
+     */
+    public function __construct(
+        public readonly string $brk,
+        public readonly array $foundBrkIdentifications,
+    ) {
+        parent::__construct(sprintf(
+            'De gemeente uit de FormState (%s) hoort niet bij de gevonden gemeenten voor de opgegeven locatie (%s).',
+            $brk,
+            implode(', ', $foundBrkIdentifications),
+        ));
+    }
+}

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -11,6 +11,7 @@ use App\EventForm\Schema\EventFormSchema;
 use App\EventForm\Services\ServiceFetcher;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\SubmitEventForm;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Resources\Zaken\ZaakResource;
 use App\Models\Municipality;
 use App\Models\Organisation;
@@ -701,6 +702,21 @@ class EventFormPage extends Page implements HasForms
 
         try {
             $zaak = app(SubmitEventForm::class)->execute($this->state, $user, $org, $this->activeDraft());
+        } catch (GemeenteLocatieMismatchException $e) {
+            report($e);
+            $this->submitting = false;
+
+            // Opnieuw proberen lost dit nooit op: de gemeente in de state hoort
+            // niet bij de opgegeven locatie. De generieke "probeer het opnieuw"
+            // zou de organisator op een doodlopend pad zetten.
+            Notification::make()
+                ->danger()
+                ->title('Aanvraag niet ingediend')
+                ->body('De gemeente in uw aanvraag hoort niet bij de locatie die u heeft opgegeven. Ga terug naar de stap "Locatie", controleer het adres en bepaal de gemeente opnieuw.')
+                ->persistent()
+                ->send();
+
+            return;
         } catch (\Throwable $e) {
             report($e);
             // Reset zodat de gebruiker kan retry'en nu de fout zichtbaar is —

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -9,7 +9,9 @@ use App\EventForm\Persistence\Draft;
 use App\EventForm\Persistence\DraftStore;
 use App\EventForm\Schema\EventFormSchema;
 use App\EventForm\Services\ServiceFetcher;
+use App\EventForm\State\FormDerivedState;
 use App\EventForm\State\FormState;
+use App\EventForm\Submit\ResolveZaaktype;
 use App\EventForm\Submit\SubmitEventForm;
 use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Resources\Zaken\ZaakResource;
@@ -153,7 +155,7 @@ class EventFormPage extends Page implements HasForms
         $this->refreshFetchesFromExistingState();
 
         $this->stateSnapshot = $this->serializableSnapshot($this->state);
-        $this->form->fill($this->state->fields());
+        $this->form->fill($this->withoutServerOwnedState($this->state->fields()));
 
         // Filament's $form->fill() filtert complex value-objects soms weg
         // wanneer een veld z'n schema niet rendert (bv. de Locatie-stap is
@@ -323,6 +325,51 @@ class EventFormPage extends Page implements HasForms
     }
 
     /**
+     * Merge formulier-data terug in de state, zonder de state-keys die de
+     * server bezit. Elke absorb-aanroep gaat hier doorheen.
+     *
+     * @param  array<string, mixed>  $data
+     */
+    private function absorbFormData(array $data): void
+    {
+        $this->state->absorbFields($this->withoutServerOwnedState($data));
+    }
+
+    /**
+     * Haalt de door de server berekende state-keys uit een array die van (of
+     * via) de client komt: de service-responses van {@see ServiceFetcher} en
+     * de afgeleide variabelen van {@see FormDerivedState}.
+     *
+     * Beide groepen worden berekend uit de ingevulde velden, maar leven in
+     * dezelfde values-bag als die velden. Daardoor belandden ze via
+     * `$form->fill()` ook in Livewire's `$data`, waar niets ze nog bijwerkt:
+     * `$data` houdt de waarde van het moment dat de pagina werd geopend. Een
+     * absorb van `$data` (of van `getStateSnapshot()`, dat `$data` teruggeeft)
+     * zette de verse locatiecheck daarmee terug naar de oude — bij indienen
+     * kwam de aanvraag dan in de gemeente van die oude check terecht, ongeacht
+     * de keuze van de organisator. Zichtbaar bij een gekopieerde aanvraag (die
+     * begint met de check van de bron-aanvraag) en bij een hervat concept
+     * waarvan de locatie daarna wijzigt.
+     *
+     * Meteen ook een integriteitsgrens: `$data` komt van de client, dus zonder
+     * deze filter kan een aangepaste `inGemeentenResponse` de aanvraag naar een
+     * willekeurige gemeente sturen — inclusief langs de controle in
+     * {@see ResolveZaaktype}, die tegen diezelfde
+     * response vergelijkt.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    private function withoutServerOwnedState(array $data): array
+    {
+        return array_diff_key(
+            $data,
+            array_flip(ServiceFetcher::FETCHED_VARIABLES),
+            FormDerivedState::COMPUTED_KEYS,
+        );
+    }
+
+    /**
      * Verwijder niet-serialiseerbare waarden (Eloquent-modellen) uit de
      * snapshot die via de wire gaat.
      *
@@ -379,7 +426,7 @@ class EventFormPage extends Page implements HasForms
             return;
         }
 
-        $this->state->absorbFields($this->data ?? []);
+        $this->absorbFormData($this->data ?? []);
 
         // Service-fetches die voorheen door fetch-rules in de RulesEngine
         // werden afgevuurd, staan nu hier direct. Per veld dat verandert
@@ -411,7 +458,7 @@ class EventFormPage extends Page implements HasForms
      */
     public function saveDraftNow(): void
     {
-        $this->state->absorbFields($this->data ?? []);
+        $this->absorbFormData($this->data ?? []);
         $this->stateSnapshot = $this->serializableSnapshot($this->state);
         $this->persistDraft();
         $this->lastDraftSaveAt = time();
@@ -562,7 +609,7 @@ class EventFormPage extends Page implements HasForms
      */
     public function runLocationGate(): void
     {
-        $this->state->absorbFields($this->data ?? []);
+        $this->absorbFormData($this->data ?? []);
 
         $fetcher = app(ServiceFetcher::class);
         $fetcher->fetch('inGemeentenResponse', $this->state);
@@ -683,7 +730,7 @@ class EventFormPage extends Page implements HasForms
         // de correcte paden.
         $dehydrationState = [];
         $this->form->callBeforeStateDehydrated($dehydrationState);
-        $this->state->absorbFields($this->form->getStateSnapshot());
+        $this->absorbFormData($this->form->getStateSnapshot());
 
         $user = $this->state->get('authUser');
         $org = $this->state->get('authOrganisation');

--- a/tests/Feature/EventForm/Pages/EventFormPageServerStateTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageServerStateTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * De locatiecheck (`inGemeentenResponse`) en de daaruit afgeleide gemeente
+ * horen bij de server. Ze leven wel in dezelfde values-bag als de
+ * formuliervelden, dus ze belandden via `$form->fill()` ook in Livewire's
+ * `$data` — waar niets ze meer bijwerkt.
+ *
+ * Bugrapport: een organisator kopieert een aanvraag zonder route, tekent een
+ * route door andere gemeenten en kiest daar één van. De aanvraag kwam toch in
+ * de gemeente van het oorspronkelijke evenement terecht. Bij het indienen
+ * absorbeerde `submit()` namelijk `$this->form->getStateSnapshot()` (= `$data`)
+ * over de state heen, waarmee de locatiecheck terugsprong naar die van het
+ * moment van openen. De keuze van de organisator stond dan buiten de
+ * gemeentenlijst en werd als verouderd genegeerd, waarna de enige gemeente uit
+ * die oude lijst overbleef: de bron-gemeente.
+ *
+ * Hetzelfde gold voor een hervat concept waarvan de locatie daarna wijzigde.
+ */
+
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\EventForm\Persistence\PrefillLoader;
+use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Filament\Facades\Filament;
+use Filament\Support\Exceptions\Halt;
+use Illuminate\Support\Facades\Http;
+use Livewire\Livewire;
+
+/**
+ * De gate-closure van de locatiestap, los aanroepbaar met een echte
+ * EventFormPage. Een volledige wizard-navigatie zou alle 18 stappen renderen.
+ */
+function locatieGate(): Closure
+{
+    $step = LocatieVanHetEvenement2Step::make();
+    $ref = new ReflectionProperty($step, 'afterValidation');
+    $ref->setAccessible(true);
+
+    /** @var Closure $callback */
+    $callback = $ref->getValue($step);
+
+    return $callback;
+}
+
+/** Map-state zoals de kaartcomponent voor een route wegschrijft. */
+function routeMapState(array $coordinates): array
+{
+    return [
+        'lat' => 0.0,
+        'lng' => 0.0,
+        'geojson' => [
+            'type' => 'FeatureCollection',
+            'features' => [[
+                'type' => 'Feature',
+                'properties' => new stdClass,
+                'geometry' => ['type' => 'LineString', 'coordinates' => $coordinates],
+            ]],
+        ],
+    ];
+}
+
+/** De locatiecheck-response zoals die na één gevonden gemeente in de state staat. */
+function locatieCheckVoor(string $brk, string $naam): array
+{
+    return [
+        'all' => [
+            'items' => [['brk_identification' => $brk, 'name' => $naam]],
+            'object' => [$brk => ['brk_identification' => $brk, 'name' => $naam]],
+            'within' => true,
+        ],
+    ];
+}
+
+/** Wat `submit()` met de state doet vlak voordat het zaaktype wordt bepaald. */
+function absorbeerZoalsSubmit(EventFormPage $page): void
+{
+    $dehydrationState = [];
+    $form = $page->getSchema('form');
+    $form->callBeforeStateDehydrated($dehydrationState);
+
+    $method = new ReflectionMethod($page, 'absorbFormData');
+    $method->setAccessible(true);
+    $method->invoke($page, $form->getStateSnapshot());
+}
+
+beforeEach(function () {
+    $this->bron = Municipality::factory()->create([
+        'brk_identification' => 'GM0001', 'name' => 'BronGemeente',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]]}',
+    ]);
+    Municipality::factory()->create([
+        'brk_identification' => 'GM0002', 'name' => 'RouteStart',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[2,-1],[4,-1],[4,1],[2,1],[2,-1]]]]}',
+    ]);
+    Municipality::factory()->create([
+        'brk_identification' => 'GM0003', 'name' => 'RouteEind',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[5,-1],[7,-1],[7,1],[5,1],[5,-1]]]]}',
+    ]);
+
+    $this->user = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach($this->organisation->id, ['role' => 'admin']);
+
+    $this->actingAs($this->user);
+    Filament::setCurrentPanel(Filament::getPanel('organiser'));
+    Filament::setTenant($this->organisation);
+
+    // De PDOK-lookup voor het gekopieerde adres levert de bron-gemeente.
+    Http::fake(['*' => Http::response([
+        'response' => ['docs' => [['gemeentecode' => '0001', 'gemeentenaam' => 'BronGemeente']]],
+    ])]);
+});
+
+test('kopie van een aanvraag zonder route: de gekozen route-gemeente overleeft het indienen', function () {
+    $zaaktype = Zaaktype::factory()->create(['municipality_id' => $this->bron->id, 'is_active' => true]);
+    $bronZaak = Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'organiser_user_id' => $this->user->id,
+        'form_state_snapshot' => ['values' => [
+            'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest',
+            'waarVindtHetEvenementPlaats' => ['gebouw'],
+            'adresVanDeGebouwEn' => ['row-1' => [
+                'naamVanDeLocatieGebouw' => 'Zaal',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6411AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0001',
+                    'straatnaam' => 'Straat', 'plaatsnaam' => 'Plaats',
+                ],
+            ]],
+            'inGemeentenResponse' => locatieCheckVoor('GM0001', 'BronGemeente'),
+            'evenementInGemeente' => ['brk_identification' => 'GM0001', 'name' => 'BronGemeente'],
+        ], 'system' => []],
+    ]);
+
+    $state = (new PrefillLoader)->load((string) $bronZaak->id, $this->user, $this->organisation);
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => $state->toSnapshot(),
+        'current_step_key' => null,
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $draft->id]);
+
+    // Organisator schakelt over naar een route door GM0002 en GM0003.
+    $component->set('data.waarVindtHetEvenementPlaats', ['route']);
+    $component->set('data.routesOpKaart', routeMapState([[3.0, 0.0], [6.0, 0.0]]));
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
+    // Meerdere gemeenten en nog geen keuze: de poort blokkeert.
+    expect(fn () => locatieGate()($page))->toThrow(Halt::class);
+
+    $component->set('data.userSelectGemeente', 'GM0002');
+    $page = $component->instance();
+    locatieGate()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0002');
+
+    // En na de absorb die het indienen doet, staat de keuze er nog steeds.
+    absorbeerZoalsSubmit($page);
+
+    expect($page->state()->get('inGemeentenResponse.all.object'))->toHaveKey('GM0002')
+        ->and($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0002');
+});
+
+test('hervat concept waarvan de route verlegd wordt: het indienen zet de locatiecheck niet terug', function () {
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [
+            'watIsDeNaamVanHetEvenementVergunning' => 'Optocht',
+            'waarVindtHetEvenementPlaats' => ['route'],
+            'routesOpKaart' => routeMapState([[-0.5, 0.0], [0.5, 0.0]]), // binnen GM0001
+            'inGemeentenResponse' => locatieCheckVoor('GM0001', 'BronGemeente'),
+        ], 'system' => []],
+        'current_step_key' => null,
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $draft->id]);
+    $component->set('data.routesOpKaart', routeMapState([[3.0, 0.0], [6.0, 0.0]]));
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+
+    expect(fn () => locatieGate()($page))->toThrow(Halt::class);
+
+    $component->set('data.userSelectGemeente', 'GM0003');
+    $page = $component->instance();
+    locatieGate()($page);
+
+    absorbeerZoalsSubmit($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0003');
+});
+
+test('een gemanipuleerde locatiecheck in de client-data stuurt de aanvraag niet naar een andere gemeente', function () {
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [
+            'waarVindtHetEvenementPlaats' => ['route'],
+            'routesOpKaart' => routeMapState([[-0.5, 0.0], [0.5, 0.0]]), // binnen GM0001
+        ], 'system' => []],
+        'current_step_key' => null,
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $draft->id]);
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+    locatieGate()($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0001');
+
+    // Client schuift een eigen locatiecheck plus gemeente naar binnen.
+    $page->data['inGemeentenResponse'] = locatieCheckVoor('GM0003', 'RouteEind');
+    $page->data['evenementInGemeente'] = ['brk_identification' => 'GM0003', 'name' => 'RouteEind'];
+
+    absorbeerZoalsSubmit($page);
+
+    expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0001');
+});

--- a/tests/Feature/EventForm/Pages/EventFormPageSubmitGuardTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageSubmitGuardTest.php
@@ -25,6 +25,7 @@ use App\Enums\Role;
 use App\EventForm\Persistence\Draft;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\SubmitEventForm;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Pages\EventFormPage;
 use App\Models\Municipality;
 use App\Models\Organisation;
@@ -33,6 +34,7 @@ use App\Models\Users\OrganiserUser;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Filament\Facades\Filament;
+use Filament\Notifications\Notification as FilamentNotification;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Notification;
@@ -197,6 +199,35 @@ test('na een mislukte submit kan de organisator opnieuw proberen', function () {
     $page->submit();
 
     expect($fake->aantalAanroepen)->toBe(2);
+});
+
+test('een gemeente die niet bij de locatie hoort levert een melding op die naar de locatiestap verwijst', function () {
+    // De generieke "probeer het opnieuw" is hier misleidend: opnieuw indienen
+    // geeft gegarandeerd dezelfde fout. De organisator moet terug naar de
+    // locatiestap, en dat moet de melding ook zeggen.
+    $fake = new FakeSubmitEventForm(
+        gooitException: new GemeenteLocatieMismatchException('GM0917', ['GM0935']),
+    );
+    app()->instance(SubmitEventForm::class, $fake);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+    setupValidSubmit($page, $this->user, $this->organisation);
+
+    $page->submit();
+
+    $component->assertNotified(
+        FilamentNotification::make()
+            ->danger()
+            ->title('Aanvraag niet ingediend')
+            ->body('De gemeente in uw aanvraag hoort niet bij de locatie die u heeft opgegeven. Ga terug naar de stap "Locatie", controleer het adres en bepaal de gemeente opnieuw.')
+            ->persistent()
+    );
+
+    // De vlag moet gereset zijn: de organisator kan na het corrigeren van de
+    // locatie opnieuw indienen zonder de pagina te herladen.
+    expect($page->submitting)->toBeFalse();
 });
 
 test('submit() op leeg formulier gooit validatiefouten en roept SubmitEventForm niet aan', function () {

--- a/tests/Feature/EventForm/State/FormDerivedStateEquivalenceTest.php
+++ b/tests/Feature/EventForm/State/FormDerivedStateEquivalenceTest.php
@@ -100,6 +100,39 @@ test('evenementInGemeente — userSelectGemeente wint bij ≥2 gevonden', functi
     ]))->toBe(['brk_identification' => 'GM0917', 'name' => 'Heerlen']);
 });
 
+test('evenementInGemeente — stale keuze buiten de gevonden gemeenten valt terug op de auto-pick', function () {
+    // Komt voor bij "Nieuwe aanvraag met deze gegevens" met een gewijzigde
+    // locatie: de keuze van de bron-aanvraag mag de nieuwe gemeente niet
+    // overrulen.
+    expect(derive('evenementInGemeente', [
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+            'object' => [
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+            ],
+        ]],
+    ]))->toBe(['brk_identification' => 'GM0935', 'name' => 'Maastricht']);
+});
+
+test('evenementInGemeente — stale keuze bij meerdere gevonden gemeenten → null (keuze opnieuw maken)', function () {
+    expect(derive('evenementInGemeente', [
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [
+                ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+                ['brk_identification' => 'GM0882', 'name' => 'Sittard-Geleen'],
+            ],
+            'object' => [
+                'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+                'GM0882' => ['brk_identification' => 'GM0882', 'name' => 'Sittard-Geleen'],
+            ],
+        ]],
+    ]))->toBeNull();
+});
+
 test('evenementInGemeente — niets gevonden, niets gekozen → null', function () {
     expect(derive('evenementInGemeente', [
         'inGemeentenResponse' => ['all' => ['items' => []]],

--- a/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
+++ b/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
@@ -213,10 +213,30 @@ test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
     // Het verborgen brkGemeente-veld wordt door de locatiecheck verbatim
     // vertrouwd; een gekopieerde waarde zou een gewijzigd adres naar de oude
     // gemeente routeren.
+    //
+    // De rijvorm is die van de repeater in LocatieVanHetEvenement2Step: rijen
+    // gekeyed op uuid, met het adres genest onder de AddressNL-prefix. Dezelfde
+    // vorm die ServiceFetcher::collectAddressesFromEditgrid() uitleest.
     $sc = scenarioZaakMetSnapshot([
         'adresVanDeGebouwEn' => [
-            ['postcode' => '6411CD', 'huisnummer' => '32', 'straatnaam' => 'Coriovallumstraat', 'brkGemeente' => 'GM0917'],
-            ['postcode' => '6361BZ', 'huisnummer' => '1', 'straatnaam' => 'Deweverplein', 'brkGemeente' => 'GM1954'],
+            'row-1' => [
+                'naamVanDeLocatieGebouw' => 'Hoofdgebouw',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6411CD',
+                    'huisnummer' => '32',
+                    'straatnaam' => 'Coriovallumstraat',
+                    'brkGemeente' => 'GM0917',
+                ],
+            ],
+            'row-2' => [
+                'naamVanDeLocatieGebouw' => 'Bijgebouw',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6361BZ',
+                    'huisnummer' => '1',
+                    'straatnaam' => 'Deweverplein',
+                    'brkGemeente' => 'GM1954',
+                ],
+            ],
         ],
     ]);
 
@@ -224,11 +244,13 @@ test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
     $adressen = $state->get('adresVanDeGebouwEn');
 
     expect($adressen)->toHaveCount(2)
-        ->and($adressen[0])->not->toHaveKey('brkGemeente')
-        ->and($adressen[1])->not->toHaveKey('brkGemeente')
+        ->and($adressen)->toHaveKeys(['row-1', 'row-2'])
+        ->and($adressen['row-1']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1'])->not->toHaveKey('brkGemeente')
+        ->and($adressen['row-2']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1'])->not->toHaveKey('brkGemeente')
         // De ingevulde adresgegevens zelf blijven staan.
-        ->and($adressen[0]['postcode'])->toBe('6411CD')
-        ->and($adressen[1]['straatnaam'])->toBe('Deweverplein');
+        ->and($adressen['row-1']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1']['postcode'])->toBe('6411CD')
+        ->and($adressen['row-1']['naamVanDeLocatieGebouw'])->toBe('Hoofdgebouw')
+        ->and($adressen['row-2']['adresVanHetGebouwWaarUwEvenementPlaatsvindt1']['straatnaam'])->toBe('Deweverplein');
 });
 
 test('velden die niet meer in het schema zitten komen stil mee uit de snapshot', function () {

--- a/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
+++ b/tests/Feature/EventForm/Submit/PrefillFromZaakTest.php
@@ -183,6 +183,54 @@ test('gehashte waarden (hash:-prefix) worden gewist zodat applySessionPrefill ze
         ->and($state->get('auth_bsn'))->toBeNull();
 });
 
+test('locatie-afhankelijke state van de bron-zaak komt niet mee', function () {
+    // De gemeentekeuze en de locatieserver-resultaten horen bij de locatie van
+    // de bron-aanvraag. Zouden ze meekomen, dan wordt een kopie met een andere
+    // locatie alsnog in de oorspronkelijke gemeente aangevraagd.
+    $sc = scenarioZaakMetSnapshot([
+        'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest 2027',
+        'userSelectGemeente' => 'GM0917',
+        'inGemeentenResponse' => ['all' => [
+            'items' => [['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+            'object' => ['GM0917' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen']],
+        ]],
+        'gemeenteVariabelen' => ['use_new_report_questions' => true],
+        'evenementenInDeGemeente' => ['items' => []],
+        'evenementInGemeente' => ['brk_identification' => 'GM0917', 'name' => 'Heerlen'],
+    ]);
+
+    $state = $this->loader->load($sc['zaak']->id, $sc['user'], $sc['org']);
+
+    expect($state->get('watIsDeNaamVanHetEvenementVergunning'))->toBe('Buurtfeest 2027')
+        ->and($state->get('userSelectGemeente'))->toBeNull()
+        ->and($state->get('inGemeentenResponse'))->toBeNull()
+        ->and($state->get('gemeenteVariabelen'))->toBeNull()
+        ->and($state->get('evenementenInDeGemeente'))->toBeNull()
+        ->and($state->get('evenementInGemeente'))->toBeNull();
+});
+
+test('de brkGemeente van gekopieerde adresrijen wordt gewist', function () {
+    // Het verborgen brkGemeente-veld wordt door de locatiecheck verbatim
+    // vertrouwd; een gekopieerde waarde zou een gewijzigd adres naar de oude
+    // gemeente routeren.
+    $sc = scenarioZaakMetSnapshot([
+        'adresVanDeGebouwEn' => [
+            ['postcode' => '6411CD', 'huisnummer' => '32', 'straatnaam' => 'Coriovallumstraat', 'brkGemeente' => 'GM0917'],
+            ['postcode' => '6361BZ', 'huisnummer' => '1', 'straatnaam' => 'Deweverplein', 'brkGemeente' => 'GM1954'],
+        ],
+    ]);
+
+    $state = $this->loader->load($sc['zaak']->id, $sc['user'], $sc['org']);
+    $adressen = $state->get('adresVanDeGebouwEn');
+
+    expect($adressen)->toHaveCount(2)
+        ->and($adressen[0])->not->toHaveKey('brkGemeente')
+        ->and($adressen[1])->not->toHaveKey('brkGemeente')
+        // De ingevulde adresgegevens zelf blijven staan.
+        ->and($adressen[0]['postcode'])->toBe('6411CD')
+        ->and($adressen[1]['straatnaam'])->toBe('Deweverplein');
+});
+
 test('velden die niet meer in het schema zitten komen stil mee uit de snapshot', function () {
     // Voorbeeld: een veld dat bij de vorige submit bestond maar inmiddels
     // vervangen is door een andere key. Dat mag niet crashen; de waarde

--- a/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
+++ b/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
@@ -20,6 +20,7 @@
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\DetermineAanvraagType;
 use App\EventForm\Submit\ResolveZaaktype;
+use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Models\Municipality;
 use App\Models\Zaaktype;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -127,8 +128,10 @@ test('gemeente die niet bij de gevonden locatie hoort → harde fout in plaats v
         'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
     ]);
 
+    // Een eigen exceptietype, zodat de submit-handler de organisator naar de
+    // locatiestap kan sturen in plaats van de generieke "probeer het opnieuw".
     expect(fn () => $this->resolve->forState($state))
-        ->toThrow(RuntimeException::class, 'hoort niet bij de gevonden gemeenten');
+        ->toThrow(GemeenteLocatieMismatchException::class, 'hoort niet bij de gevonden gemeenten');
 });
 
 test('gemeente die wel bij de gevonden locatie hoort wordt gewoon gebruikt', function () {

--- a/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
+++ b/tests/Unit/EventForm/Submit/ResolveZaaktypeTest.php
@@ -107,3 +107,45 @@ test('gemeente uit state matcht niets in de DB → exception', function () {
     expect(fn () => $this->resolve->forState($state))
         ->toThrow(RuntimeException::class);
 });
+
+test('gemeente die niet bij de gevonden locatie hoort → harde fout in plaats van een zaak in de verkeerde gemeente', function () {
+    // Vangt de situatie af waarin een verouderde gemeente in de state blijft
+    // staan (gekopieerde aanvraag, gewijzigde locatie). Zonder deze controle
+    // wordt de zaak stilzwijgend in de oude gemeente aangemaakt.
+    $heerlen = Municipality::factory()->create(['name' => 'Heerlen', 'brk_identification' => 'GM0917']);
+    Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Heerlen',
+        'municipality_id' => $heerlen->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0917'],
+        'inGemeentenResponse' => ['all' => ['object' => [
+            'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]]],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect(fn () => $this->resolve->forState($state))
+        ->toThrow(RuntimeException::class, 'hoort niet bij de gevonden gemeenten');
+});
+
+test('gemeente die wel bij de gevonden locatie hoort wordt gewoon gebruikt', function () {
+    $maastricht = Municipality::factory()->create(['name' => 'Maastricht', 'brk_identification' => 'GM0935']);
+    $verwacht = Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning gemeente Maastricht',
+        'municipality_id' => $maastricht->id,
+        'is_active' => true,
+    ]);
+
+    $state = new FormState(values: [
+        'evenementInGemeente' => ['brk_identification' => 'GM0935'],
+        'inGemeentenResponse' => ['all' => ['object' => [
+            'GM0935' => ['brk_identification' => 'GM0935', 'name' => 'Maastricht'],
+        ]]],
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+
+    expect($this->resolve->forState($state)->id)->toBe($verwacht->id);
+});


### PR DESCRIPTION
An organiser copies an event that had no route, draws a route through other municipalities and picks one of them. The aanvraag is still created in the municipality of the original event, on that municipality's ZGW instance, whichever municipality they pick.

## Cause

Two separate problems stack up.

**The copy carried the source location.** `PrefillLoader` copied the whole form state of the source aanvraag, including the gemeente choice, the location check response, `gemeenteVariabelen` and the hidden `brkGemeente` on every address row. Nothing revalidated those against the new location.

**Submitting rolled the location check back.** `submit()` absorbs the Livewire form data over the form state right before the zaaktype is resolved. That data holds more than the organiser's answers: `mount()` fills the form with the whole values bag, so the service responses (`inGemeentenResponse` and friends) and the derived variables travel along, and nothing updates them afterwards. The copy in `$data` keeps the value it had when the page was opened, and submitting restores it.

The gemeente the organiser picked is then no longer among the found municipalities, the derivation discards it as stale, and the only municipality left in the rolled-back result wins: the one from the source event. The guard in `ResolveZaaktype` cannot catch this, because it compares against that same rolled-back response.

The second problem is not limited to copies. A concept that is resumed and whose location changes during the session ends up in the previously found municipality in exactly the same way.

## Changes

- Server-owned state (the `ServiceFetcher` responses and the `FormDerivedState` variables) is stripped from every absorb and is no longer put into the form data at mount. This also closes an integrity hole, since `$data` comes from the client: a forged `inGemeentenResponse` could point the aanvraag at any municipality and pass the `ResolveZaaktype` guard on the way.
- `PrefillLoader` strips the location-dependent state and the per-address `brkGemeente` when copying, so the location gate rebuilds them from the new input.
- `evenementInGemeente` ignores a `userSelectGemeente` that is no longer among the municipalities found for the current location, and falls through to the auto-pick.
- `ResolveZaaktype` asserts the gemeente from the state is among the municipalities found for the submitted location, and fails the submit with a dedicated exception instead of creating the zaak in the wrong municipality. The organiser gets a message pointing back to the location step rather than the generic "try again".
- The address auto-fill clears `brkGemeente` before looking up, so a failed or non-firing lookup cannot leave the previous municipality attached to an edited address.

The last four points are a backport of #463, which was merged into `next/v1.2` only. Merging `main` back into `next/v1.2` after this lands keeps both branches on the same behaviour.