### PR TITLE
Fix report questions, submission summary and invite acceptance

### DIFF
--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -7,6 +7,7 @@ namespace App\EventForm\Reporting;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
+use App\EventForm\Submit\DetermineAanvraagType;
 use Carbon\Carbon;
 use Closure;
 use Filament\Forms\Components\CheckboxList;
@@ -44,6 +45,16 @@ use ReflectionObject;
  */
 final class SubmissionReport
 {
+    /**
+     * Fields that are present in the state (usually derived automatically) but
+     * do not belong in the summary or PDF of a melding.
+     *
+     * @var list<string>
+     */
+    private const HIDDEN_FOR_MELDING = [
+        'inWelkSeizoenVindtHetEvenementPlaats',
+    ];
+
     /**
      * @param  list<Step>  $steps
      * @return list<array{title: string, entries: list<array{label: string, value: string}>}>
@@ -264,6 +275,16 @@ final class SubmissionReport
     }
 
     /**
+     * Whether this submission is a melding (and therefore not a permit
+     * application or a vooraankondiging), using the same determination as the
+     * zaaktype routing.
+     */
+    private function isMelding(FormState $state): bool
+    {
+        return app(DetermineAanvraagType::class)->forState($state) === DetermineAanvraagType::MELDING;
+    }
+
+    /**
      * @return array{label: string, value: string, svg?: string}|null
      */
     private function buildEntry(Field $component, FormState $state, string $key, object $stubLivewire): ?array
@@ -272,6 +293,13 @@ final class SubmissionReport
         // resolved BRK gemeente) that is never meant for the human-facing
         // summary or PDF. Skip them regardless of value.
         if ($component instanceof Hidden) {
+            return null;
+        }
+
+        // A melding never fills in the risicoscan step, but the season field is
+        // derived automatically from the start date and would otherwise still
+        // show up in the summary and the PDF.
+        if (in_array($key, self::HIDDEN_FOR_MELDING, true) && $this->isMelding($state)) {
             return null;
         }
 

--- a/app/EventForm/Reporting/TypeAanvraagOnderdelen.php
+++ b/app/EventForm/Reporting/TypeAanvraagOnderdelen.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Reporting;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Submit\DetermineAanvraagType;
 
 /**
  * Centrale berekening van de "onderdelen van uw aanvraag"-lijst.
@@ -25,24 +26,28 @@ final class TypeAanvraagOnderdelen
      */
     public static function buildList(FormState $state): array
     {
-        $items = [];
-
-        $waarvoor = $state->get('waarvoorWiltUEventloketGebruiken');
-        $afsluit = $state->get('wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer');
-
-        if ($waarvoor === 'vooraankondiging') {
-            $items[] = 'Vooraankondiging';
-        } elseif ($afsluit === 'Nee') {
-            $items[] = 'Melding';
-        } elseif ($waarvoor === 'evenement') {
-            $items[] = 'Evenementenvergunning';
+        // Without a choice for `waarvoorWiltUEventloketGebruiken` there is
+        // nothing to say about the type of application yet, so we show no
+        // (empty) section.
+        if (((string) ($state->get('waarvoorWiltUEventloketGebruiken') ?? '')) === '') {
+            return [];
         }
 
-        // `alcoholvergunning` is een afgeleide variabele die `'Ja'` of
-        // `null` returnt (zie FormDerivedState::alcoholvergunning) —
-        // niet een bool. Zonder die specifieke check zou de ontheffing
-        // nooit in de "Onderdelen aanvraag"-lijst belanden.
-        return $items;
+        // Derive the main item from the same canonical determination that picks
+        // the zaaktype (`ResolveZaaktype`) and drives the summary and PDF
+        // (`SubmissionReport::isMelding`). This method used to hold its own
+        // legacy-only copy of that logic (the road-closure question alone),
+        // which made municipalities on the new ReportQuestion system (such as
+        // Heerlen) see "Evenementenvergunning" for a melding.
+        $type = app(DetermineAanvraagType::class)->forState($state);
+
+        // The label matches the zaaktype name prefix per type, the convention
+        // the shared catalogus uses.
+        return [match ($type) {
+            DetermineAanvraagType::MELDING => 'Melding',
+            DetermineAanvraagType::VOORAANKONDIGING => 'Vooraankondiging',
+            default => 'Evenementenvergunning',
+        }];
     }
 
     /**

--- a/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReportQuestionsRelationManager.php
+++ b/app/Filament/Admin/Resources/MunicipalityResource/RelationManagers/ReportQuestionsRelationManager.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Admin\Resources\MunicipalityResource\RelationManagers;
 
+use App\Filament\Shared\Resources\ReportQuestions\Concerns\SafelyReordersReportQuestions;
 use App\Filament\Shared\Resources\ReportQuestions\Schemas\ReportQuestionForm;
 use App\Filament\Shared\Resources\ReportQuestions\Tables\ReportQuestionsTable;
 use Filament\Resources\RelationManagers\RelationManager;
@@ -11,6 +12,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class ReportQuestionsRelationManager extends RelationManager
 {
+    use SafelyReordersReportQuestions;
+
     protected static string $relationship = 'reportQuestions';
 
     public static function getTitle(Model $ownerRecord, string $pageClass): string

--- a/app/Filament/Municipality/Clusters/Settings/Resources/ReportQuestions/Pages/ListReportQuestions.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/ReportQuestions/Pages/ListReportQuestions.php
@@ -3,8 +3,8 @@
 namespace App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages;
 
 use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\ReportQuestionResource;
+use App\Filament\Shared\Resources\ReportQuestions\Concerns\SafelyReordersReportQuestions;
 use App\Models\Municipality;
-use App\Models\ReportQuestion;
 use Filament\Facades\Filament;
 use Filament\Forms\Components\Toggle;
 use Filament\Notifications\Notification;
@@ -15,13 +15,14 @@ use Filament\Schemas\Components\RenderHook;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
 use Filament\View\PanelsRenderHook;
-use Illuminate\Support\Facades\DB;
 
 /**
  * @property Schema $municipalitySettingsForm
  */
 class ListReportQuestions extends ListRecords
 {
+    use SafelyReordersReportQuestions;
+
     protected static string $resource = ReportQuestionResource::class;
 
     /**
@@ -77,40 +78,5 @@ class ListReportQuestions extends ListRecords
                 ->compact(),
             RenderHook::make(PanelsRenderHook::RESOURCE_PAGES_LIST_RECORDS_TABLE_AFTER),
         ]);
-    }
-
-    /**
-     * Override Filament's default bulk CASE WHEN update to avoid unique constraint
-     * violations on (municipality_id, order). Works on both PostgreSQL and MySQL.
-     *
-     * Strategy: first shift all affected orders to a temporary high value (no conflicts
-     * within the same municipality), then set the final values one by one.
-     *
-     * @param  array<int|string>  $order
-     */
-    public function reorderTable(array $order, int|string|null $draggedRecordKey = null): void
-    {
-        if (! $this->getTable()->isReorderable()) {
-            return;
-        }
-
-        $this->getTable()->callBeforeReordering($order);
-
-        DB::transaction(function () use ($order): void {
-            $ids = array_values($order);
-
-            // Pass 1: shift all to high values so none of the 1-10 slots are occupied.
-            // Max 10 records with order values 1–10; adding 200 safely stays within
-            // the unsignedTinyInteger range (max 255).
-            ReportQuestion::whereIn('id', $ids)->increment('order', 200);
-
-            // Pass 2: write the final positions. No conflicts because all targeted
-            // records are currently sitting at 201–210.
-            foreach ($order as $index => $id) {
-                ReportQuestion::where('id', $id)->update(['order' => $index + 1]);
-            }
-        });
-
-        $this->getTable()->callAfterReordering($order);
     }
 }

--- a/app/Filament/Shared/Resources/ReportQuestions/Concerns/SafelyReordersReportQuestions.php
+++ b/app/Filament/Shared/Resources/ReportQuestions/Concerns/SafelyReordersReportQuestions.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Filament\Shared\Resources\ReportQuestions\Concerns;
+
+use App\Models\ReportQuestion;
+use Illuminate\Support\Facades\DB;
+
+trait SafelyReordersReportQuestions
+{
+    /**
+     * Override Filament's default bulk CASE WHEN update to avoid unique
+     * constraint violations on (municipality_id, order). Works on both
+     * PostgreSQL and MySQL.
+     *
+     * Strategy: first shift all affected orders to a temporary high value
+     * (no conflicts within the same municipality), then set the final
+     * values one by one.
+     *
+     * @param  array<int|string>  $order
+     */
+    public function reorderTable(array $order, int|string|null $draggedRecordKey = null): void
+    {
+        if (! $this->getTable()->isReorderable()) {
+            return;
+        }
+
+        $this->getTable()->callBeforeReordering($order);
+
+        DB::transaction(function () use ($order): void {
+            $ids = array_values($order);
+
+            // Pass 1: shift all to high values so none of the 1-10 slots are occupied.
+            // Max 10 records with order values 1–10; adding 200 safely stays within
+            // the unsignedTinyInteger range (max 255).
+            ReportQuestion::whereIn('id', $ids)->increment('order', 200);
+
+            // Pass 2: write the final positions. No conflicts because all targeted
+            // records are currently sitting at 201–210.
+            foreach ($order as $index => $id) {
+                ReportQuestion::where('id', $id)->update(['order' => $index + 1]);
+            }
+        });
+
+        $this->getTable()->callAfterReordering($order);
+    }
+}

--- a/app/Filament/Shared/Resources/ReportQuestions/Schemas/ReportQuestionForm.php
+++ b/app/Filament/Shared/Resources/ReportQuestions/Schemas/ReportQuestionForm.php
@@ -20,6 +20,7 @@ class ReportQuestionForm
                 TextInput::make('question')
                     ->label(__('resources/report_question.form.question.label'))
                     ->helperText(__('resources/report_question.form.question.helper_text'))
+                    ->required()
                     ->maxLength(1000)
                     ->columnSpanFull(),
                 Toggle::make('is_active')

--- a/app/Livewire/AcceptInvites/AbstractAcceptInvite.php
+++ b/app/Livewire/AcceptInvites/AbstractAcceptInvite.php
@@ -100,18 +100,19 @@ abstract class AbstractAcceptInvite extends SimplePage implements HasSchemas
 
     public function acceptInvite(): void
     {
-        if (! auth()->check()) {
+        $user = auth()->user();
+
+        if (! $user instanceof User) {
             abort(403);
         }
 
-        if (auth()->user()->email != $this->invite->email) {
+        if ($user->email != $this->invite->email) {
             abort(403);
         }
 
-        $this->attachTenantRelation(auth()->user());
+        $this->attachTenantRelation($user);
 
         if ($this->getPanelName() == 'admin') {
-            $user = auth()->user();
             $user->role = $this->getRole();
             $user->save();
         }

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -192,6 +192,26 @@ test('Type-aanvraag-stap: meldingspad → Melding zonder aanvullende ontheffinge
     expect($sections[0]['entries'][0]['value'])->toBe('Melding');
 });
 
+test('Type-aanvraag-stap: nieuw ReportQuestion-pad (alle Ja) → Melding, niet Evenementenvergunning', function () {
+    // Gemeenten op het nieuwe ReportQuestion-systeem (zoals Heerlen) hebben
+    // geen wegafsluiting-antwoord; het type volgt uit de reportQuestion-
+    // antwoorden. Alle 'Ja' betekent een melding. De legacy-only kopie van
+    // deze logica toonde hier ten onrechte "Evenementenvergunning".
+    $state = new FormState(values: [
+        'waarvoorWiltUEventloketGebruiken' => 'evenement',
+        'gemeenteVariabelen' => [
+            'use_new_report_questions' => true,
+            'report_questions' => ['vraag 1', 'vraag 2'],
+        ],
+        'reportQuestion_1' => 'Ja',
+        'reportQuestion_2' => 'Ja',
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [TypeAanvraagStep::make()]);
+
+    expect($sections[0]['entries'][0]['value'])->toBe('Melding');
+});
+
 test('Risicoscan: het seizoen-veld wordt bij een melding weggelaten uit samenvatting/PDF', function () {
     // Het seizoen-veld wordt automatisch afgeleid uit de startdatum, ook
     // wanneer de risicoscan-stap (bij een melding) nooit getoond wordt.

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -25,6 +25,7 @@ use App\EventForm\Schema\EventFormSchema;
 use App\EventForm\Schema\Steps\BijlagenStep;
 use App\EventForm\Schema\Steps\ContactgegevensStep;
 use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
+use App\EventForm\Schema\Steps\RisicoscanStep;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
@@ -189,6 +190,35 @@ test('Type-aanvraag-stap: meldingspad → Melding zonder aanvullende ontheffinge
     $sections = app(SubmissionReport::class)->build($state, [TypeAanvraagStep::make()]);
 
     expect($sections[0]['entries'][0]['value'])->toBe('Melding');
+});
+
+test('Risicoscan: het seizoen-veld wordt bij een melding weggelaten uit samenvatting/PDF', function () {
+    // Het seizoen-veld wordt automatisch afgeleid uit de startdatum, ook
+    // wanneer de risicoscan-stap (bij een melding) nooit getoond wordt.
+    // Het hoort dan niet in de samenvatting/PDF te verschijnen.
+    $state = new FormState(values: [
+        // Meldingspad (legacy): wegen niet afgesloten → Melding.
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Nee',
+        'inWelkSeizoenVindtHetEvenementPlaats' => '0.5',
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [RisicoscanStep::make()]);
+
+    $waarden = collect($sections)->flatMap(fn ($s) => collect($s['entries'])->pluck('value'))->all();
+    expect($waarden)->not->toContain('Zomer of winter');
+});
+
+test('Risicoscan: het seizoen-veld blijft bij een vergunning wel zichtbaar', function () {
+    $state = new FormState(values: [
+        // Vergunningpad (legacy): wegen afgesloten → Vergunning.
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+        'inWelkSeizoenVindtHetEvenementPlaats' => '0.5',
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [RisicoscanStep::make()]);
+
+    $waarden = collect($sections)->flatMap(fn ($s) => collect($s['entries'])->pluck('value'))->all();
+    expect($waarden)->toContain('Zomer of winter');
 });
 
 test('Bijlagen-stap: FileUpload-velden krijgen een `files`-array per bestandsvraag', function () {

--- a/tests/Feature/ReportQuestion/ReportQuestionTest.php
+++ b/tests/Feature/ReportQuestion/ReportQuestionTest.php
@@ -1,6 +1,9 @@
 <?php
 
 use App\Enums\Role;
+use App\Filament\Admin\Resources\MunicipalityResource\Pages\EditMunicipality;
+use App\Filament\Admin\Resources\MunicipalityResource\RelationManagers\ReportQuestionsRelationManager;
+use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages\EditReportQuestion;
 use App\Filament\Municipality\Clusters\Settings\Resources\ReportQuestions\Pages\ListReportQuestions;
 use App\Models\Municipality;
 use App\Models\ReportQuestion;
@@ -159,6 +162,65 @@ test('reordering does not affect report questions of other municipalities', func
     expect($q2->fresh()->order)->toBe(1);
     expect($q1->fresh()->order)->toBe(2);
     expect($other->fresh()->order)->toBe(1); // untouched
+});
+
+test('reordering via admin relation manager does not cause unique constraint violations', function () {
+    $admin = User::factory()->create(['role' => Role::Admin]);
+    $municipality = Municipality::factory()->create();
+    $municipality->reportQuestions()->delete();
+
+    $questions = collect(range(1, 5))->map(fn ($i) => ReportQuestion::factory()->create([
+        'municipality_id' => $municipality->id,
+        'order' => $i,
+        'question' => "Question $i?",
+    ]));
+
+    $this->actingAs($admin);
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    // Reverse the entire order (worst case for constraint violations)
+    $reversed = $questions->reverse()->pluck('id')->all();
+
+    livewire(ReportQuestionsRelationManager::class, [
+        'ownerRecord' => $municipality,
+        'pageClass' => EditMunicipality::class,
+    ])->call('reorderTable', $reversed);
+
+    foreach ($questions->reverse()->values() as $newPosition => $question) {
+        expect($question->fresh()->order)->toBe($newPosition + 1);
+    }
+});
+
+// ---------------------------------------------------------------------------
+// EditReportQuestion form validation
+// ---------------------------------------------------------------------------
+
+test('editing a report question with an empty question fails validation instead of writing null', function () {
+    $municipality = Municipality::factory()->create();
+    $municipality->reportQuestions()->delete();
+
+    $question = ReportQuestion::factory()->create([
+        'municipality_id' => $municipality->id,
+        'order' => 1,
+        'question' => 'Original question?',
+        'is_active' => true,
+    ]);
+
+    $user = User::factory()->create(['role' => Role::ReviewerMunicipalityAdmin]);
+    $user->municipalities()->attach($municipality);
+
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+    Filament::setTenant($municipality);
+
+    livewire(EditReportQuestion::class, ['record' => $question->id])
+        ->fillForm(['question' => '', 'is_active' => false])
+        ->call('save')
+        ->assertHasFormErrors(['question' => 'required']);
+
+    // The original value must be untouched (no NULL written to the NOT NULL column).
+    expect($question->fresh()->question)->toBe('Original question?');
+    expect($question->fresh()->is_active)->toBeTrue();
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Brings four fixes that were sitting on the long-lived `next/multi-zgw-connection` branch to `main`, so they no longer wait on that branch being approved. None of them are related to the multi-ZGW work.

Two commits were cherry-picked as-is; the two report commits were adapted because they relied on the `ZaaktypeRole` enum, which only exists on the ZGW branch. On `main` they use the existing `DetermineAanvraagType` string constants instead, which produce the same labels.

### Report questions (`ReportQuestion`)

- The shared report question form field is now required, so an empty question can no longer write `NULL` into a `NOT NULL` column.
- Reordering questions by dragging used Filament's default bulk `CASE WHEN` update, which violated the unique constraint on `(municipality_id, order)`. The safe two-pass reorder (shift every affected row to a temporary high value, then write the final positions) is extracted into a `SafelyReordersReportQuestions` trait and applied to both the municipality list page and the admin relation manager. The admin panel previously had no protection at all.

### Submission summary and PDF

- The season field (`inWelkSeizoenVindtHetEvenementPlaats`) is derived automatically from the start date, but the risicoscan step is never filled in for a melding, so the field appeared in the summary and PDF without the organiser ever answering it. It is now skipped for a melding.
- `TypeAanvraagOnderdelen::buildList` held a legacy-only copy of the melding/vergunning determination (the road-closure question alone). Municipalities on the new report question system saw "Evenementenvergunning" for a melding on the final step, in the summary and in the PDF. It now delegates to the canonical `DetermineAanvraagType`, the same logic that selects the zaaktype, so the UI, the summary and the zaaktype routing stay in sync. The empty state is guarded so the section stays hidden until a choice is made.

### Invite acceptance

- Narrows the authenticated user to `User` in `AbstractAcceptInvite`, a type fix without behavioural change.