### PR TITLE
Order thread messages chronologically

### DIFF
--- a/app/Models/Thread.php
+++ b/app/Models/Thread.php
@@ -62,9 +62,21 @@ class Thread extends Model
         return $this->belongsTo(User::class, 'created_by');
     }
 
+    /**
+     * Messages in the order they were written. The ordering is part of the
+     * relation on purpose: without an ORDER BY, PostgreSQL is free to return
+     * rows in physical heap order, which changes as soon as a row is updated
+     * (attaching documents to a message, for example). That put replies above
+     * the question they answered in the thread view.
+     *
+     * `created_at` is a `timestamp(0)` column, so two messages written within
+     * the same second would tie; `id` breaks that tie by insertion order.
+     */
     public function messages(): HasMany
     {
-        return $this->hasMany(Message::class, 'thread_id');
+        return $this->hasMany(Message::class, 'thread_id')
+            ->orderBy('created_at')
+            ->orderBy('id');
     }
 
     public function unreadMessages()

--- a/tests/Feature/Threads/ThreadMessageOrderTest.php
+++ b/tests/Feature/Threads/ThreadMessageOrderTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use App\Enums\AdviceStatus;
+use App\Enums\ThreadType;
+use App\Models\Message;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\Threads\AdviceThread;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+
+beforeEach(function () {
+    // Creating a message makes the observer read the zaak status from ZGW.
+    Http::fake([ZgwHttpFake::$baseUrl.'*' => Http::response([], 200)]);
+
+    // The message observer walks Zaak -> Zaaktype -> Municipality, so the
+    // zaaktype needs a municipality behind it.
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => Municipality::factory()->create()->id,
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => $zaaktype->id,
+    ]);
+
+    // Concept keeps the observer from notifying an advisory this test does
+    // not need; the ordering under test lives on the base Thread model.
+    $this->thread = AdviceThread::forceCreate([
+        'zaak_id' => $zaak->id,
+        'type' => ThreadType::Advice,
+        'advice_status' => AdviceStatus::Concept,
+        'title' => 'Test advice thread',
+    ]);
+});
+
+test('messages are returned in chronological order regardless of insertion order', function () {
+    Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Antwoord van de adviesdienst',
+        'created_at' => now()->subHour(),
+    ]);
+
+    Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Vraag van de behandelaar',
+        'created_at' => now()->subDay(),
+    ]);
+
+    expect($this->thread->messages()->pluck('body')->all())->toBe([
+        'Vraag van de behandelaar',
+        'Antwoord van de adviesdienst',
+    ]);
+});
+
+test('updating an earlier message does not move it to the end of the thread', function () {
+    // The reported bug: PostgreSQL rewrites an updated row at the end of the
+    // heap, so without an explicit ORDER BY the question ended up below the
+    // reply that answered it.
+    $vraag = Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Vraag van de behandelaar',
+        'created_at' => now()->subDay(),
+    ]);
+
+    Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Antwoord van de adviesdienst',
+        'created_at' => now()->subHour(),
+    ]);
+
+    $vraag->update(['documents' => [['url' => 'https://example.test/document/1', 'versie' => 1]]]);
+
+    expect($this->thread->fresh()->messages->pluck('body')->all())->toBe([
+        'Vraag van de behandelaar',
+        'Antwoord van de adviesdienst',
+    ]);
+});
+
+test('messages written within the same second keep their insertion order', function () {
+    // created_at is a timestamp(0) column, so messages posted in quick
+    // succession share a timestamp and need the id as tie-breaker.
+    $moment = now()->startOfSecond();
+
+    $first = Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Eerste',
+        'created_at' => $moment,
+    ]);
+
+    $second = Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Tweede',
+        'created_at' => $moment,
+    ]);
+
+    expect($first->id)->toBeLessThan($second->id)
+        ->and($this->thread->messages()->pluck('body')->all())->toBe(['Eerste', 'Tweede']);
+});
+
+test('the latest message of a thread is the most recent one', function () {
+    // The thread table column renders `$thread->messages->last()`, which only
+    // holds up while the relation is ordered.
+    Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Oudste',
+        'created_at' => now()->subDay(),
+    ]);
+
+    $newest = Message::factory()->create([
+        'thread_id' => $this->thread->id,
+        'body' => 'Nieuwste',
+        'created_at' => now(),
+    ]);
+
+    expect($this->thread->messages->last()->is($newest))->toBeTrue();
+});


### PR DESCRIPTION
Reported from production: in some zaken the messages in a thread are out of order, with an advisory's reply shown above the reviewer's question, and the list does not look sorted by date.

### Cause

`Thread::messages()` was a bare `hasMany` with no `ORDER BY`, and the thread view iterates that relation directly. Without an `ORDER BY`, PostgreSQL is free to return rows in physical heap order. That order matches insertion order right up until a row is updated: an update writes a new tuple at the end of the heap, so the updated message moves to the back of the list. Attaching documents to a message writes to the `documents` column and does exactly that.

This explains why the problem only shows up in some zaken. A thread where no message was ever updated still reads correctly.

### Fix

Order the relation on `created_at`, with `id` as tie-breaker. The tie-breaker matters because `messages.created_at` is a `timestamp(0)` column, so two messages posted within the same second carry the same value.

Putting the ordering on the relation rather than in the view also fixes `LatestMessageColumn`, which shows the most recent message in the threads table via `$thread->messages->last()`. That call only holds up while the relation is ordered.

### Tests

`tests/Feature/Threads/ThreadMessageOrderTest.php` covers four cases: chronological order regardless of insertion order, an updated earlier message staying in place (the reported scenario), the same-second tie-break, and `->last()` returning the newest message. The first two fail without the fix; the other two are guards against a future change ordering the relation the wrong way.

### Not included

The `messages` table has no index on `thread_id` (a foreign key does not create one in PostgreSQL), so every thread view does a sequential scan and now sorts on top of it. Worth a follow-up, but it is a migration and does not belong in this fix.