### PR TITLE
Open the zaak view modal when a row is clicked in the list view

### DIFF
--- a/app/Filament/Shared/Widgets/CalendarWidget.php
+++ b/app/Filament/Shared/Widgets/CalendarWidget.php
@@ -359,6 +359,8 @@ class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget implements 
                         $this->viewActionFooterAction(),
                     ]),
             ])
+            // Clicking anywhere in a row opens the same view modal as the row action.
+            ->recordAction('view')
             ->filtersLayout(FiltersLayout::AboveContent)
             ->filtersFormColumns(2)
             ->deferFilters(false)

--- a/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
+++ b/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
@@ -442,3 +442,39 @@ test('calendar widget shows cases without resultaat even when zaaktype has hidde
         ->assertSet('viewMode', 'table')
         ->assertCanSeeTableRecords([$zaakWithoutResultaat]);
 });
+
+test('calendar widget table view opens the view modal when a row is clicked', function () {
+    $user = User::factory()->create([
+        'email' => 'municipality-admin@example.com',
+        'role' => Role::MunicipalityAdmin,
+    ]);
+
+    $this->municipality->users()->attach($user);
+
+    // A local zaak keeps the modal from calling out to Open Zaak.
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => null,
+    ]);
+
+    $this->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+    Filament::setTenant($this->municipality);
+
+    $component = livewire(MunicipalityCalendarWidget::class)
+        ->callAction('toggleView')
+        ->assertSet('viewMode', 'table')
+        ->assertCanSeeTableRecords([$zaak]);
+
+    // A row click mounts the table record action, so it has to resolve to the view action.
+    expect($component->instance()->getTable()->getRecordAction($zaak))->toBe('view');
+
+    // And that action must open a modal rather than navigate away.
+    $viewAction = $component->instance()->getTable()->getAction('view')->record($zaak);
+    expect($viewAction->getUrl())->toBeNull();
+
+    $component->mountTableAction('view', $zaak)->assertOk();
+
+    expect($component->instance()->getMountedAction()?->getName())->toBe('view');
+});


### PR DESCRIPTION
The calendar widget's list view rendered a view action per row but had no record action on the table itself, so clicking anywhere else in the row did nothing. Setting the table's record action to the existing view action makes the whole row open the same modal.

This applies to all four panels (admin, municipality, advisor, organiser), which all inherit the shared calendar widget's table configuration.