### PR TITLE
Add per-day times for multi-day events, build-up and tear-down

### DIFF
--- a/app/Console/Commands/Zaak/RecoverOrphanedZaken.php
+++ b/app/Console/Commands/Zaak/RecoverOrphanedZaken.php
@@ -118,6 +118,11 @@ class RecoverOrphanedZaken extends Command
             return true;
         }
 
+        // Per-day times of a multi-day event live only locally, not as a
+        // zaakeigenschap in OpenZaak. If a local case already exists, recovery
+        // must not overwrite those with nothing.
+        $bestaand = Zaak::withTrashed()->firstWhere('zgw_zaak_url', $ozZaak->url);
+
         $zaak = Zaak::updateOrCreate(
             ['zgw_zaak_url' => $ozZaak->url],
             [
@@ -134,6 +139,9 @@ class RecoverOrphanedZaken extends Command
                             'status_name' => $ozZaak->status_name ?? '',
                             'statustype_url' => $ozZaak->statustype_url ?? '',
                             'organisator' => $organisator,
+                            'dagen_evenement' => $bestaand?->reference_data->dagen_evenement,
+                            'dagen_opbouw' => $bestaand?->reference_data->dagen_opbouw,
+                            'dagen_afbouw' => $bestaand?->reference_data->dagen_afbouw,
                         ]
                     )
                 ),

--- a/app/EventForm/Components/EventDagenRepeater.php
+++ b/app/EventForm/Components/EventDagenRepeater.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Components;
+
+use App\EventForm\Support\DagenRepeater;
+use App\EventForm\Support\EventDagen;
+use Closure;
+use Filament\Forms\Components\Hidden;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TimePicker;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
+use Illuminate\Support\Carbon;
+
+/**
+ * Per-day start and end times for a period that runs over several days.
+ *
+ * The two datetime pickers above the repeater stay authoritative: they decide
+ * which days exist and own the very first start and the very last end. The
+ * rows only add what those two moments cannot express, namely when each
+ * individual day starts and ends. Rows are therefore generated rather than
+ * added by hand, and the two mirrored times are shown but not editable.
+ *
+ * @see DagenRepeater for the state translation
+ * @see EventDagen for the night-boundary rule that decides what "multi-day" means
+ */
+final class EventDagenRepeater
+{
+    public static function make(string $key, string $startKey, string $eindKey, string $label): Repeater
+    {
+        return Repeater::make($key)
+            ->label($label)
+            ->addable(false)
+            ->deletable(false)
+            ->reorderable(false)
+            ->columns(2)
+            ->itemLabel(fn (array $state): ?string => self::dagLabel($state['datum'] ?? null))
+            // Drafts and copied applications from before this feature have a
+            // period but no day rows yet. Build them on open so the organiser
+            // still gets to fill them in.
+            ->afterStateHydrated(function (?array $state, Repeater $component, Get $get) use ($startKey, $eindKey): void {
+                if (is_array($state) && $state !== []) {
+                    return;
+                }
+
+                $rijen = DagenRepeater::sync($get($startKey), $get($eindKey));
+
+                if ($rijen !== []) {
+                    $component->state($rijen);
+                }
+            })
+            ->helperText('De eindtijd mag in de nacht liggen. Vult u een eindtijd in die niet later is dan de starttijd, dan loopt de dag door tot de volgende ochtend.')
+            ->schema([
+                Hidden::make('datum'),
+                TimePicker::make('startTijd')
+                    ->label('Starttijd')
+                    ->seconds(false)
+                    ->required()
+                    ->disabled(fn (Get $get): bool => DagenRepeater::isEersteDag($get('datum'), $get("../../{$startKey}")))
+                    ->dehydrated()
+                    ->helperText(fn (Get $get): ?string => DagenRepeater::isEersteDag($get('datum'), $get("../../{$startKey}"))
+                        ? 'Overgenomen uit de startdatum en -tijd hierboven.'
+                        : null),
+                TimePicker::make('eindTijd')
+                    ->label('Eindtijd')
+                    ->seconds(false)
+                    ->required()
+                    ->disabled(fn (Get $get): bool => DagenRepeater::isLaatsteDag($get('datum'), $get("../../{$startKey}"), $get("../../{$eindKey}")))
+                    ->dehydrated()
+                    ->helperText(fn (Get $get): ?string => DagenRepeater::isLaatsteDag($get('datum'), $get("../../{$startKey}"), $get("../../{$eindKey}"))
+                        ? 'Overgenomen uit de einddatum en -tijd hierboven.'
+                        : null)
+                    ->rule(static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get): void {
+                        if (! is_string($value) || $value === '') {
+                            return;
+                        }
+
+                        if (! EventDagen::rolloverBinnenNachtGrens($get('startTijd'), $value)) {
+                            $fail('Een dag die doorloopt tot na middernacht moet uiterlijk om 06:00 eindigen. Duurt de dag langer, pas dan de einddatum van de periode aan.');
+                        }
+                    }),
+            ])
+            ->rule(static fn (): Closure => static function (string $attribute, mixed $value, Closure $fail): void {
+                if (! is_array($value)) {
+                    return;
+                }
+
+                if (self::heeftOverlappendeDagen($value)) {
+                    $fail('De ingevulde dagen overlappen elkaar. Een dag die doorloopt tot na middernacht moet eindigen voordat de volgende dag begint.');
+                }
+            })
+            ->visible(fn (Get $get): bool => EventDagen::isMeerdaags($get($startKey), $get($eindKey)));
+    }
+
+    /**
+     * Regenerate the rows of a repeater from its envelope. Call this from the
+     * `afterStateUpdated()` of both datetime pickers that bound the period.
+     */
+    public static function sync(Get $get, Set $set, string $key, string $startKey, string $eindKey): void
+    {
+        $bestaand = $get($key);
+
+        $set($key, DagenRepeater::sync(
+            $get($startKey),
+            $get($eindKey),
+            is_array($bestaand) ? $bestaand : [],
+        ));
+    }
+
+    /**
+     * @param  array<array-key, mixed>  $rijen
+     */
+    private static function heeftOverlappendeDagen(array $rijen): bool
+    {
+        $blokken = DagenRepeater::naarReferenceData($rijen);
+
+        for ($i = 1; $i < count($blokken); $i++) {
+            $start = Carbon::parse($blokken[$i]['start']);
+            $vorigEind = Carbon::parse($blokken[$i - 1]['eind']);
+
+            if ($start->lessThan($vorigEind)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function dagLabel(mixed $datum): ?string
+    {
+        if (! is_string($datum) || $datum === '') {
+            return null;
+        }
+
+        try {
+            return ucfirst(Carbon::parse($datum)->translatedFormat('l j F Y'));
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/app/EventForm/Persistence/PrefillLoader.php
+++ b/app/EventForm/Persistence/PrefillLoader.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Persistence;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Support\DagenRepeater;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
@@ -118,6 +119,20 @@ class PrefillLoader
         foreach ($pairs as $key => $value) {
             if ($value !== null && $value !== '') {
                 $state->setField($key, $value);
+            }
+        }
+
+        // Per-day times of a multi-day period.
+        $dagen = [
+            'EvenementDagen' => $ref->dagen_evenement,
+            'OpbouwDagen' => $ref->dagen_opbouw,
+            'AfbouwDagen' => $ref->dagen_afbouw,
+        ];
+
+        foreach ($dagen as $key => $blokken) {
+            $rijen = DagenRepeater::uitReferenceData($blokken);
+            if ($rijen !== []) {
+                $state->setField($key, $rijen);
             }
         }
 

--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -8,6 +8,7 @@ use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\DetermineAanvraagType;
+use App\EventForm\Support\TijdenOverzicht;
 use Carbon\Carbon;
 use Closure;
 use Filament\Forms\Components\CheckboxList;
@@ -83,9 +84,9 @@ final class SubmissionReport
      * verwerkt worden — laten we niet ook nog als losse rijen tonen.
      */
     private const TIJDEN_TABEL_KEYS = [
-        'OpbouwStart', 'OpbouwEind',
-        'EvenementStart', 'EvenementEind',
-        'AfbouwStart', 'AfbouwEind',
+        'OpbouwStart', 'OpbouwEind', 'OpbouwDagen',
+        'EvenementStart', 'EvenementEind', 'EvenementDagen',
+        'AfbouwStart', 'AfbouwEind', 'AfbouwDagen',
     ];
 
     /**
@@ -137,6 +138,11 @@ final class SubmissionReport
                 if ($key === '') {
                     return;
                 }
+                if ($isTijdenStep && in_array($key, self::TIJDEN_TABEL_KEYS, true)) {
+                    // Already covered by the tijden table; the rows themselves
+                    // hold bare clock times, which would render as today's date.
+                    return;
+                }
                 $fullKey = $keyPrefix === null ? $key : "{$keyPrefix}.{$key}";
                 $rows = is_array($state->get($fullKey)) ? $state->get($fullKey) : [];
                 if ($rows === []) {
@@ -175,7 +181,7 @@ final class SubmissionReport
                 $key = $component->getName();
                 if ($key !== '') {
                     if ($isTijdenStep && in_array($key, self::TIJDEN_TABEL_KEYS, true)) {
-                        // Al in de tijden-tabel verwerkt; sla over.
+                        // Already covered by the tijden table; skip.
                         return;
                     }
                     $fullKey = $keyPrefix === null ? $key : "{$keyPrefix}.{$key}";
@@ -195,25 +201,16 @@ final class SubmissionReport
     }
 
     /**
-     * Bouw een 3×2-overzichts-tabel (Opbouw / Publiek / Afbouw × Start / Eind)
-     * voor de Tijden-stap. Lege rijen (geen opbouw of geen afbouw) laten we
-     * weg. Zijn alle rijen leeg, dan retourneren we null zodat de tabel
-     * helemaal niet in de PDF verschijnt.
+     * Build the summary table (Opbouw / Publiek / Afbouw × Start / Eind) for
+     * the Tijden step. A multi-day period gets a row per day. Empty rows (no
+     * build-up or no tear-down) are dropped, and when every row is empty we
+     * return null so the table does not appear in the PDF at all.
      *
      * @return array{label: string, value: string, table: array{header: list<string>, rows: list<list<string>>}}|null
      */
     private function buildTijdenTable(FormState $state): ?array
     {
-        $rijen = [
-            ['Opbouw', $this->humanDateTime($state->get('OpbouwStart')), $this->humanDateTime($state->get('OpbouwEind'))],
-            ['Publiek', $this->humanDateTime($state->get('EvenementStart')), $this->humanDateTime($state->get('EvenementEind'))],
-            ['Afbouw', $this->humanDateTime($state->get('AfbouwStart')), $this->humanDateTime($state->get('AfbouwEind'))],
-        ];
-
-        $rijenMetData = array_values(array_filter(
-            $rijen,
-            fn (array $rij) => $rij[1] !== '' || $rij[2] !== '',
-        ));
+        $rijenMetData = TijdenOverzicht::uitFormState($state);
 
         if ($rijenMetData === []) {
             return null;

--- a/app/EventForm/Schema/Steps/TijdenStep.php
+++ b/app/EventForm/Schema/Steps/TijdenStep.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\EventForm\Schema\Steps;
 
+use App\EventForm\Components\EventDagenRepeater;
 use App\EventForm\Components\EventDateTimePicker;
 use App\EventForm\Components\InfoText;
 use App\EventForm\Components\JaNeeOptions;
@@ -11,6 +12,7 @@ use App\EventForm\Schema\Hidden;
 use App\EventForm\Schema\Label;
 use App\EventForm\State\FormState;
 use App\EventForm\Support\SafeDateTime;
+use App\EventForm\Support\TijdenOverzicht;
 use App\EventForm\Template\LabelRenderer;
 use App\Filament\Organiser\Pages\Calendar;
 use App\Models\Organisation;
@@ -69,7 +71,9 @@ final class TijdenStep
                                 'after_or_equal' => 'De startdatum van het evenement moet vandaag of later zijn.',
                             ])
                             ->required()
-                            ->afterStateUpdated(function (?string $state, Set $set): void {
+                            ->afterStateUpdated(function (?string $state, Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'EvenementDagen', 'EvenementStart', 'EvenementEind');
+
                                 $parsed = SafeDateTime::parse($state);
                                 if (! $parsed) {
                                     return;
@@ -91,11 +95,20 @@ final class TijdenStep
                                 'after_or_equal' => 'De einddatum van het evenement moet op of na de startdatum liggen.',
                             ])
                             ->required()
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'EvenementDagen', 'EvenementStart', 'EvenementEind');
+                            })
                             ->belowContent([
                                 Icon::make(Heroicon::InformationCircle),
                                 'Dit is het eindmoment wanneer u bezoekers of deelnemers verwacht.',
                             ])
                             ->live(),
+                        EventDagenRepeater::make(
+                            'EvenementDagen',
+                            'EvenementStart',
+                            'EvenementEind',
+                            'Op welke tijden vindt uw evenement plaats per dag?',
+                        ),
                     ]),
                 InfoText::info('evenmentenInDeBuurtContent', function (FormState $state): string {
                     $html = app(LabelRenderer::class)->renderHtml(
@@ -138,6 +151,9 @@ final class TijdenStep
                                 'before_or_equal' => 'De starttijd van de opbouw moet op of voor de eindtijd opbouw liggen.',
                             ])
                             ->required()
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'OpbouwDagen', 'OpbouwStart', 'OpbouwEind');
+                            })
                             ->hidden(function (Get $get, $livewire): bool {
                                 $rule = $livewire->state()->isFieldHidden('OpbouwStart');
                                 if ($rule !== null) {
@@ -157,6 +173,9 @@ final class TijdenStep
                                 'before_or_equal' => 'De eindtijd van de opbouw moet op of voor de startdatum van het evenement liggen.',
                             ])
                             ->required()
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'OpbouwDagen', 'OpbouwStart', 'OpbouwEind');
+                            })
                             ->hidden(function (Get $get, $livewire): bool {
                                 $rule = $livewire->state()->isFieldHidden('OpbouwEind');
                                 if ($rule !== null) {
@@ -166,6 +185,20 @@ final class TijdenStep
                                 return ! ($get('zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten') === 'Ja');
                             })
                             ->live(),
+                        EventDagenRepeater::make(
+                            'OpbouwDagen',
+                            'OpbouwStart',
+                            'OpbouwEind',
+                            'Op welke tijden vindt de opbouw plaats per dag?',
+                        )
+                            ->hidden(function (Get $get, $livewire): bool {
+                                $rule = $livewire->state()->isFieldHidden('OpbouwStart');
+                                if ($rule !== null) {
+                                    return $rule;
+                                }
+
+                                return ! ($get('zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten') === 'Ja');
+                            }),
                     ]),
                 Radio::make('zijnErTijdensHetEvenementXOpbouwactiviteiten')
                     ->label(Label::render('Zijn er tijdens het evenement {{ watIsDeNaamVanHetEvenementVergunning }} opbouwactiviteiten?'))
@@ -188,6 +221,9 @@ final class TijdenStep
                                 'after_or_equal' => 'De starttijd van de afbouw moet op of na de einddatum van het evenement liggen.',
                             ])
                             ->required()
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'AfbouwDagen', 'AfbouwStart', 'AfbouwEind');
+                            })
                             ->hidden(function (Get $get, $livewire): bool {
                                 $rule = $livewire->state()->isFieldHidden('AfbouwStart');
                                 if ($rule !== null) {
@@ -206,6 +242,9 @@ final class TijdenStep
                                 'after_or_equal' => 'De eindtijd van de afbouw moet op of na de starttijd van de afbouw liggen.',
                             ])
                             ->required()
+                            ->afterStateUpdated(function (Get $get, Set $set): void {
+                                EventDagenRepeater::sync($get, $set, 'AfbouwDagen', 'AfbouwStart', 'AfbouwEind');
+                            })
                             ->hidden(function (Get $get, $livewire): bool {
                                 $rule = $livewire->state()->isFieldHidden('AfbouwEind');
                                 if ($rule !== null) {
@@ -215,6 +254,20 @@ final class TijdenStep
                                 return ! ($get('zijnErAansluitendAanHetEvenementAfbouwactiviteiten') === 'Ja');
                             })
                             ->live(),
+                        EventDagenRepeater::make(
+                            'AfbouwDagen',
+                            'AfbouwStart',
+                            'AfbouwEind',
+                            'Op welke tijden vindt de afbouw plaats per dag?',
+                        )
+                            ->hidden(function (Get $get, $livewire): bool {
+                                $rule = $livewire->state()->isFieldHidden('AfbouwStart');
+                                if ($rule !== null) {
+                                    return $rule;
+                                }
+
+                                return ! ($get('zijnErAansluitendAanHetEvenementAfbouwactiviteiten') === 'Ja');
+                            }),
                     ]),
                 Radio::make('zijnErTijdensHetEvenementXAfbouwactiviteiten3')
                     ->label(Label::render('Zijn er tijdens het evenement {{ watIsDeNaamVanHetEvenementVergunning }} afbouwactiviteiten?'))
@@ -222,12 +275,38 @@ final class TijdenStep
                     ->required(),
                 TextEntry::make('overzichtTijden')
                     ->hiddenLabel()
-                    // `renderHtml()` ipv `render()` — de output wordt rauw
-                    // in de DOM gezet via `HtmlString`. DateTimePicker-
-                    // waarden zijn ISO-strings (geen user-text-input),
-                    // dus self-XSS is in de praktijk niet mogelijk, maar
-                    // safe-by-default is het beleid.
-                    ->state(fn ($livewire) => new HtmlString(app(LabelRenderer::class)->renderHtml('<h2>Overzicht ingevulde tijden</h2><figure class="table"><table><thead><tr><th><strong>Activiteit</strong></th><th>&nbsp;</th><th><strong>Start</strong></th><th>&nbsp;</th><th><strong>Eind</strong></th></tr></thead><tbody><tr><th><strong>Opbouw</strong></th><td>&nbsp;</td><td>{{ OpbouwStart }}</td><td>&nbsp;</td><td>{{ OpbouwEind }}</td></tr><tr><th><strong>Publiek</strong></th><td>&nbsp;</td><td>{{ EvenementStart }}</td><td>&nbsp;</td><td>{{ EvenementEind }}</td></tr><tr><th><strong>Afbouw</strong></th><td>&nbsp;</td><td>{{ AfbouwStart }}</td><td>&nbsp;</td><td>{{ AfbouwEind }}</td></tr></tbody></table></figure><p><br>Wijzig de velden boven dit overzicht indien de tijden niet correct zijn.</p>', $livewire->state()))),
+                    // The table goes into the DOM raw through `HtmlString`, so
+                    // every cell is escaped. The values come from date and time
+                    // fields rather than free text, but safe-by-default is the
+                    // policy.
+                    ->state(fn ($livewire) => new HtmlString(self::overzichtHtml($livewire->state()))),
             ]);
+    }
+
+    /**
+     * The read-back table at the bottom of the step. Multi-day periods list a
+     * row per day; single-day periods keep the one-row-per-activity shape.
+     */
+    private static function overzichtHtml(FormState $state): string
+    {
+        $rijen = TijdenOverzicht::uitFormState($state);
+
+        if ($rijen === []) {
+            return '';
+        }
+
+        $body = '';
+        foreach ($rijen as [$activiteit, $start, $eind]) {
+            $body .= '<tr><th><strong>'.e($activiteit).'</strong></th><td>&nbsp;</td><td>'
+                .e($start).'</td><td>&nbsp;</td><td>'.e($eind).'</td></tr>';
+        }
+
+        return '<h2>Overzicht ingevulde tijden</h2>'
+            .'<figure class="table"><table><thead><tr>'
+            .'<th><strong>Activiteit</strong></th><th>&nbsp;</th>'
+            .'<th><strong>Start</strong></th><th>&nbsp;</th>'
+            .'<th><strong>Eind</strong></th></tr></thead>'
+            .'<tbody>'.$body.'</tbody></table></figure>'
+            .'<p><br>Wijzig de velden boven dit overzicht indien de tijden niet correct zijn.</p>';
     }
 }

--- a/app/EventForm/Services/EventsCheckService.php
+++ b/app/EventForm/Services/EventsCheckService.php
@@ -5,42 +5,99 @@ declare(strict_types=1);
 namespace App\EventForm\Services;
 
 use App\Models\Zaak;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Controleert of er andere evenementen gepland staan in dezelfde gemeente
- * binnen een tijdsperiode. Gebruikt om conflicten te signaleren.
+ * Checks whether other events are planned in the same municipality within a
+ * period. Used to flag conflicts to the organiser.
  *
- * Oorspronkelijk OF's `fetch-from-service` naar /api/events/check.
+ * Originally Open Forms' `fetch-from-service` call to /api/events/check.
  */
 class EventsCheckService
 {
     /**
+     * How many names we return at most. The count itself is unlimited, so the
+     * message "you have among others these events" names an honest total.
+     */
+    private const MAX_NAMEN = 10;
+
+    /**
+     * The dates in `reference_data` are ISO 8601 strings, but older cases can
+     * hold another format. Only values that look like ISO are cast to a
+     * timestamp; the rest falls outside the comparison instead of blowing up
+     * the query.
+     */
+    private const ISO_PATROON = '^\d{4}-\d{2}-\d{2}';
+
+    /**
      * @param  string  $startDate  ISO 8601 / date string
      * @param  string  $endDate  ISO 8601 / date string
-     * @param  string  $municipalityBrkId  bv. 'GM0882'
+     * @param  string  $municipalityBrkId  e.g. 'GM0882'
      * @return array{event_names: string, event_count: int}
      */
     public function check(string $startDate, string $endDate, string $municipalityBrkId): array
     {
-        $zaken = Zaak::query()
-            ->where(function ($query) use ($startDate, $endDate): void {
-                $query
-                    ->whereBetween('reference_data->start_evenement', [$startDate, $endDate])
-                    ->orWhereBetween('reference_data->eind_evenement', [$startDate, $endDate]);
-            })
-            ->whereHas('municipality', function ($query) use ($municipalityBrkId): void {
-                $query->where('brk_identification', $municipalityBrkId);
-            })
-            ->limit(10)
-            ->get();
+        $start = $this->parse($startDate);
+        $eind = $this->parse($endDate);
 
-        $names = $zaken->isNotEmpty()
-            ? $zaken->pluck('reference_data.naam_evenement')->filter()->join(', ')
-            : '';
+        if ($start === null || $eind === null) {
+            return ['event_names' => '', 'event_count' => 0];
+        }
+
+        if ($eind->lessThan($start)) {
+            [$start, $eind] = [$eind, $start];
+        }
+
+        $query = Zaak::query()
+            // Two periods overlap when one starts before the other ends, and
+            // vice versa. An event spanning the whole given period counts as
+            // an overlap too; the old whereBetween variant missed those,
+            // since it only checked whether either end fell inside the window.
+            ->whereRaw($this->moment('start_evenement').' <= ?', [$eind])
+            ->whereRaw($this->moment('eind_evenement').' >= ?', [$start])
+            ->whereHas('municipality', function (Builder $query) use ($municipalityBrkId): void {
+                $query->where('brk_identification', $municipalityBrkId);
+            });
+
+        $namen = (clone $query)
+            ->limit(self::MAX_NAMEN)
+            ->get()
+            ->pluck('reference_data.naam_evenement')
+            ->filter()
+            ->join(', ');
 
         return [
-            'event_names' => $names,
-            'event_count' => $zaken->count(),
+            'event_names' => $namen,
+            'event_count' => $query->count(),
         ];
+    }
+
+    /**
+     * A JSON date field as a timestamp, or NULL when the stored value does not
+     * look like ISO. The CASE keeps the cast from running in that branch, so
+     * legacy data cannot produce a database error.
+     */
+    private function moment(string $key): string
+    {
+        return sprintf(
+            "(CASE WHEN reference_data->>'%s' ~ '%s' THEN (reference_data->>'%s')::timestamptz END)",
+            $key,
+            self::ISO_PATROON,
+            $key,
+        );
+    }
+
+    private function parse(string $waarde): ?CarbonImmutable
+    {
+        if (trim($waarde) === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($waarde, 'Europe/Amsterdam');
+        } catch (\Throwable) {
+            return null;
+        }
     }
 }

--- a/app/EventForm/Services/EventsCheckService.php
+++ b/app/EventForm/Services/EventsCheckService.php
@@ -23,14 +23,6 @@ class EventsCheckService
     private const MAX_NAMEN = 10;
 
     /**
-     * The dates in `reference_data` are ISO 8601 strings, but older cases can
-     * hold another format. Only values that look like ISO are cast to a
-     * timestamp; the rest falls outside the comparison instead of blowing up
-     * the query.
-     */
-    private const ISO_PATROON = '^\d{4}-\d{2}-\d{2}';
-
-    /**
      * @param  string  $startDate  ISO 8601 / date string
      * @param  string  $endDate  ISO 8601 / date string
      * @param  string  $municipalityBrkId  e.g. 'GM0882'
@@ -39,7 +31,7 @@ class EventsCheckService
     public function check(string $startDate, string $endDate, string $municipalityBrkId): array
     {
         $start = $this->parse($startDate);
-        $eind = $this->parse($endDate);
+        $eind = $this->parse($endDate, eindeVanDagBijAlleenDatum: true);
 
         if ($start === null || $eind === null) {
             return ['event_names' => '', 'event_count' => 0];
@@ -51,11 +43,19 @@ class EventsCheckService
 
         $query = Zaak::query()
             // Two periods overlap when one starts before the other ends, and
-            // vice versa. An event spanning the whole given period counts as
-            // an overlap too; the old whereBetween variant missed those,
-            // since it only checked whether either end fell inside the window.
-            ->whereRaw($this->moment('start_evenement').' <= ?', [$eind])
-            ->whereRaw($this->moment('eind_evenement').' >= ?', [$start])
+            // vice versa. An event spanning the whole given period counts as an
+            // overlap too; the old whereBetween variant missed those, since it
+            // only checked whether either end fell inside the window.
+            //
+            // The dates live in a JSON column as ISO 8601 strings, so this is a
+            // text comparison. That is deliberate: it keeps the query portable
+            // across the database drivers we run on, and a fixed-width ISO 8601
+            // string sorts chronologically. The one imprecision is the timezone
+            // offset, which can put two moments within an hour of each other on
+            // the wrong side of a DST switch. For a "what else is planned around
+            // then" signal that is noise rather than a defect.
+            ->where('reference_data->start_evenement', '<=', $eind->toIso8601String())
+            ->where('reference_data->eind_evenement', '>=', $start->toIso8601String())
             ->whereHas('municipality', function (Builder $query) use ($municipalityBrkId): void {
                 $query->where('brk_identification', $municipalityBrkId);
             });
@@ -74,30 +74,27 @@ class EventsCheckService
     }
 
     /**
-     * A JSON date field as a timestamp, or NULL when the stored value does not
-     * look like ISO. The CASE keeps the cast from running in that branch, so
-     * legacy data cannot produce a database error.
+     * A bare date carries no time, so as the end of a window it means the whole
+     * of that day rather than the stroke of midnight.
      */
-    private function moment(string $key): string
+    private function parse(string $waarde, bool $eindeVanDagBijAlleenDatum = false): ?CarbonImmutable
     {
-        return sprintf(
-            "(CASE WHEN reference_data->>'%s' ~ '%s' THEN (reference_data->>'%s')::timestamptz END)",
-            $key,
-            self::ISO_PATROON,
-            $key,
-        );
-    }
+        $waarde = trim($waarde);
 
-    private function parse(string $waarde): ?CarbonImmutable
-    {
-        if (trim($waarde) === '') {
+        if ($waarde === '') {
             return null;
         }
 
         try {
-            return CarbonImmutable::parse($waarde, 'Europe/Amsterdam');
+            $moment = CarbonImmutable::parse($waarde, 'Europe/Amsterdam');
         } catch (\Throwable) {
             return null;
         }
+
+        if ($eindeVanDagBijAlleenDatum && preg_match('/\d{1,2}:\d{2}/', $waarde) !== 1) {
+            return $moment->endOfDay();
+        }
+
+        return $moment;
     }
 }

--- a/app/EventForm/Submit/MapFormStateToReferenceData.php
+++ b/app/EventForm/Submit/MapFormStateToReferenceData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Submit;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Support\DagenRepeater;
 use App\Models\Organisation;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Carbon\Carbon;
@@ -41,7 +42,29 @@ final class MapFormStateToReferenceData
             start_afbouw: $this->iso8601OrNull($state->get('AfbouwStart')),
             eind_afbouw: $this->iso8601OrNull($state->get('AfbouwEind')),
             locaties_evenement: $this->locatiesEvenement($state),
+            dagen_evenement: $this->dagen($state, 'EvenementDagen'),
+            dagen_opbouw: $this->dagen($state, 'OpbouwDagen'),
+            dagen_afbouw: $this->dagen($state, 'AfbouwDagen'),
         );
+    }
+
+    /**
+     * Per-day start and end times, filled in only when the period runs over
+     * several calendar days. Null keeps the envelope the whole story.
+     *
+     * @return list<array{datum: string, start: string, eind: string}>|null
+     */
+    private function dagen(FormState $state, string $key): ?array
+    {
+        $rijen = $state->get($key);
+
+        if (! is_array($rijen)) {
+            return null;
+        }
+
+        $blokken = DagenRepeater::naarReferenceData($rijen);
+
+        return $blokken !== [] ? $blokken : null;
     }
 
     private function iso8601(mixed $value): string

--- a/app/EventForm/Support/DagenRepeater.php
+++ b/app/EventForm/Support/DagenRepeater.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Support;
+
+use Carbon\CarbonImmutable;
+
+/**
+ * Translates between the two datetime pickers that bound a period (the
+ * envelope) and the per-day rows an organiser fills in for a multi-day period.
+ *
+ * The envelope stays authoritative: it drives which days exist, and its own
+ * start and end time are mirrored onto the first and last row. The rows only
+ * add the detail the envelope cannot express, namely when each individual day
+ * starts and ends.
+ *
+ * Row keys are the ISO date of the day, which keeps the sync idempotent: a day
+ * that survives a date change keeps the times already filled in for it.
+ */
+final class DagenRepeater
+{
+    /**
+     * Rebuild the per-day rows for an envelope, preserving times already
+     * entered for days that still exist. Returns an empty array for a
+     * single-day period, so the repeater simply has nothing to show.
+     *
+     * @param  array<array-key, mixed>  $bestaand
+     * @return array<string, array{datum: string, startTijd: ?string, eindTijd: ?string}>
+     */
+    public static function sync(mixed $start, mixed $eind, array $bestaand = []): array
+    {
+        $dagen = EventDagen::dagen($start, $eind);
+
+        if (count($dagen) < 2) {
+            return [];
+        }
+
+        $bestaandOpDatum = self::indexeerOpDatum($bestaand);
+
+        $startMoment = SafeDateTime::parse($start);
+        $eindMoment = SafeDateTime::parse($eind);
+
+        $eersteDatum = $dagen[0]->toDateString();
+        $laatsteDatum = $dagen[count($dagen) - 1]->toDateString();
+
+        $rijen = [];
+
+        foreach ($dagen as $dag) {
+            $datum = $dag->toDateString();
+            $rij = $bestaandOpDatum[$datum] ?? [];
+
+            $startTijd = self::tijdOfNull($rij['startTijd'] ?? null);
+            $eindTijd = self::tijdOfNull($rij['eindTijd'] ?? null);
+
+            // The envelope owns the very first start and the very last end;
+            // the organiser changes those in the pickers above the repeater.
+            if ($datum === $eersteDatum && $startMoment !== null) {
+                $startTijd = $startMoment->format('H:i');
+            }
+
+            if ($datum === $laatsteDatum && $eindMoment !== null) {
+                $eindTijd = $eindMoment->format('H:i');
+            }
+
+            $rijen[$datum] = [
+                'datum' => $datum,
+                'startTijd' => $startTijd,
+                'eindTijd' => $eindTijd,
+            ];
+        }
+
+        return $rijen;
+    }
+
+    /**
+     * Whether a given row holds the first day of the envelope, whose start
+     * time is mirrored from the envelope and therefore not editable.
+     */
+    public static function isEersteDag(mixed $datum, mixed $start): bool
+    {
+        $dag = SafeDateTime::parse($datum);
+        $startMoment = SafeDateTime::parse($start);
+
+        if ($dag === null || $startMoment === null) {
+            return false;
+        }
+
+        return $dag->toDateString() === $startMoment->toDateString();
+    }
+
+    /**
+     * Whether a given row holds the last day of the envelope, whose end time
+     * is mirrored from the envelope and therefore not editable.
+     */
+    public static function isLaatsteDag(mixed $datum, mixed $start, mixed $eind): bool
+    {
+        $dag = SafeDateTime::parse($datum);
+        $laatste = EventDagen::effectieveEinddatum($start, $eind);
+
+        if ($dag === null || $laatste === null) {
+            return false;
+        }
+
+        return $dag->toDateString() === $laatste->toDateString();
+    }
+
+    /**
+     * Flatten the repeater rows into the list of resolved day blocks we store
+     * on the zaak. Rows without both times are skipped, and an end time at or
+     * before the start time rolls over into the next morning.
+     *
+     * @param  array<array-key, mixed>  $rijen
+     * @return list<array{datum: string, start: string, eind: string}>
+     */
+    public static function naarReferenceData(array $rijen): array
+    {
+        $blokken = [];
+
+        foreach (self::indexeerOpDatum($rijen) as $datum => $rij) {
+            $startTijd = self::tijdOfNull($rij['startTijd'] ?? null);
+            $eindTijd = self::tijdOfNull($rij['eindTijd'] ?? null);
+
+            $start = EventDagen::blokStart($datum, $startTijd);
+            $eind = EventDagen::blokEinde($datum, $startTijd, $eindTijd);
+
+            if ($start === null || $eind === null) {
+                continue;
+            }
+
+            $blokken[] = [
+                'datum' => $datum,
+                'start' => $start->toIso8601String(),
+                'eind' => $eind->toIso8601String(),
+            ];
+        }
+
+        usort($blokken, fn (array $a, array $b): int => $a['start'] <=> $b['start']);
+
+        return $blokken;
+    }
+
+    /**
+     * Rebuild repeater rows from stored day blocks, for prefilling a copy of
+     * an earlier application.
+     *
+     * @param  mixed  $blokken  the stored `dagen_*` value
+     * @return array<string, array{datum: string, startTijd: string, eindTijd: string}>
+     */
+    public static function uitReferenceData(mixed $blokken): array
+    {
+        if (! is_array($blokken)) {
+            return [];
+        }
+
+        $rijen = [];
+
+        foreach ($blokken as $blok) {
+            if (! is_array($blok)) {
+                continue;
+            }
+
+            $start = self::parseOpgeslagen($blok['start'] ?? null);
+            $eind = self::parseOpgeslagen($blok['eind'] ?? null);
+
+            if ($start === null || $eind === null) {
+                continue;
+            }
+
+            $datum = is_string($blok['datum'] ?? null)
+                ? $blok['datum']
+                : $start->toDateString();
+
+            $rijen[$datum] = [
+                'datum' => $datum,
+                'startTijd' => $start->format('H:i'),
+                'eindTijd' => $eind->format('H:i'),
+            ];
+        }
+
+        return $rijen;
+    }
+
+    /**
+     * Render the stored day blocks as table rows for the summary, the PDF and
+     * the case infolist.
+     *
+     * @param  mixed  $blokken  the stored `dagen_*` value
+     * @return list<array{datum: string, start: string, eind: string}>
+     */
+    public static function alsTabelRijen(mixed $blokken, string $datumFormat = 'l j F Y', string $tijdFormat = 'H:i'): array
+    {
+        if (! is_array($blokken)) {
+            return [];
+        }
+
+        $rijen = [];
+
+        foreach ($blokken as $blok) {
+            if (! is_array($blok)) {
+                continue;
+            }
+
+            $start = self::parseOpgeslagen($blok['start'] ?? null);
+            $eind = self::parseOpgeslagen($blok['eind'] ?? null);
+
+            if ($start === null || $eind === null) {
+                continue;
+            }
+
+            $eindLabel = $eind->format($tijdFormat);
+
+            // Make a roll-over into the small hours explicit, otherwise a row
+            // reading "16:00 – 02:00" is ambiguous about which night it ends.
+            if ($eind->toDateString() !== $start->toDateString()) {
+                $eindLabel .= ' ('.$eind->translatedFormat('j F').')';
+            }
+
+            $rijen[] = [
+                'datum' => $start->translatedFormat($datumFormat),
+                'start' => $start->format($tijdFormat),
+                'eind' => $eindLabel,
+            ];
+        }
+
+        return $rijen;
+    }
+
+    /**
+     * Repeater state arrives keyed by row identifier, which is the ISO date
+     * for rows we generated but a UUID for anything Filament created itself.
+     * Re-key on the row's own `datum` so both shapes line up.
+     *
+     * @param  array<array-key, mixed>  $rijen
+     * @return array<string, array<string, mixed>>
+     */
+    private static function indexeerOpDatum(array $rijen): array
+    {
+        $opDatum = [];
+
+        foreach ($rijen as $sleutel => $rij) {
+            if (! is_array($rij)) {
+                continue;
+            }
+
+            $datum = SafeDateTime::parse($rij['datum'] ?? $sleutel)?->toDateString();
+
+            if ($datum === null) {
+                continue;
+            }
+
+            $opDatum[$datum] = $rij;
+        }
+
+        ksort($opDatum);
+
+        return $opDatum;
+    }
+
+    /**
+     * Stored day blocks hold full ISO 8601 strings including a timezone
+     * offset, which the stricter form-input parser deliberately rejects.
+     */
+    private static function parseOpgeslagen(mixed $waarde): ?CarbonImmutable
+    {
+        if (! is_string($waarde) || trim($waarde) === '') {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($waarde, 'Europe/Amsterdam');
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function tijdOfNull(mixed $waarde): ?string
+    {
+        if (! is_string($waarde) || trim($waarde) === '') {
+            return null;
+        }
+
+        return trim($waarde);
+    }
+}

--- a/app/EventForm/Support/EventDagen.php
+++ b/app/EventForm/Support/EventDagen.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Support;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+
+/**
+ * Determines the calendar days an event (or its build-up / tear-down) spans.
+ *
+ * An end time that falls in the small hours belongs to the evening before it,
+ * not to a new day: an event running 16:00–02:00 is a single-day event with a
+ * late finish. Only when the end moment passes the night boundary of the
+ * following morning does the event become genuinely multi-day.
+ *
+ * The boundary is 06:00. Anything at or before 06:00 counts towards the
+ * previous day; anything after it starts a new day of its own.
+ */
+final class EventDagen
+{
+    /**
+     * Everything up to and including this clock time counts towards the
+     * previous calendar day.
+     */
+    public const NACHT_GRENS = '06:00:00';
+
+    /**
+     * The calendar day an end moment belongs to. An end at or before the night
+     * boundary is attributed to the day before.
+     *
+     * Never returns a date before the given start date, so a malformed pair
+     * (end before start) still yields at least one day.
+     */
+    public static function effectieveEinddatum(mixed $start, mixed $eind): ?CarbonImmutable
+    {
+        $startMoment = self::parse($start);
+        $eindMoment = self::parse($eind);
+
+        if ($startMoment === null || $eindMoment === null) {
+            return null;
+        }
+
+        $datum = CarbonImmutable::parse($eindMoment->toDateTimeString())->startOfDay();
+
+        if (self::valtInDeNacht($eindMoment)) {
+            $datum = $datum->subDay();
+        }
+
+        $startDatum = CarbonImmutable::parse($startMoment->toDateTimeString())->startOfDay();
+
+        return $datum->lessThan($startDatum) ? $startDatum : $datum;
+    }
+
+    /**
+     * Whether the period covers more than one calendar day under the night-
+     * boundary rule.
+     */
+    public static function isMeerdaags(mixed $start, mixed $eind): bool
+    {
+        return count(self::dagen($start, $eind)) > 1;
+    }
+
+    /**
+     * The calendar days the period covers, from the start date up to and
+     * including the effective end date. Returns an empty list when either
+     * moment is missing or unparseable.
+     *
+     * @return list<CarbonImmutable>
+     */
+    public static function dagen(mixed $start, mixed $eind): array
+    {
+        $startMoment = self::parse($start);
+        $eindDatum = self::effectieveEinddatum($start, $eind);
+
+        if ($startMoment === null || $eindDatum === null) {
+            return [];
+        }
+
+        $dag = CarbonImmutable::parse($startMoment->toDateTimeString())->startOfDay();
+
+        $dagen = [];
+        while ($dag->lessThanOrEqualTo($eindDatum)) {
+            $dagen[] = $dag;
+            $dag = $dag->addDay();
+        }
+
+        return $dagen;
+    }
+
+    /**
+     * The moment a day block ends. An end time at or before the start time
+     * rolls over to the next morning, so 16:00–02:00 ends the following night.
+     */
+    public static function blokEinde(mixed $datum, ?string $startTijd, ?string $eindTijd): ?CarbonImmutable
+    {
+        $dag = self::parse($datum)?->startOfDay();
+
+        if ($dag === null || $startTijd === null || $eindTijd === null) {
+            return null;
+        }
+
+        $eind = self::opDag($dag, $eindTijd);
+        $start = self::opDag($dag, $startTijd);
+
+        if ($eind === null || $start === null) {
+            return null;
+        }
+
+        return $eind->lessThanOrEqualTo($start) ? $eind->addDay() : $eind;
+    }
+
+    /**
+     * The moment a day block starts.
+     */
+    public static function blokStart(mixed $datum, ?string $startTijd): ?CarbonImmutable
+    {
+        $dag = self::parse($datum)?->startOfDay();
+
+        if ($dag === null || $startTijd === null) {
+            return null;
+        }
+
+        return self::opDag($dag, $startTijd);
+    }
+
+    /**
+     * Whether an end time that rolls over to the next day stays within the
+     * night boundary. A block may run into the small hours, but not through
+     * the whole of the next day.
+     */
+    public static function rolloverBinnenNachtGrens(?string $startTijd, ?string $eindTijd): bool
+    {
+        if ($startTijd === null || $eindTijd === null) {
+            return true;
+        }
+
+        $start = self::normaliseerTijd($startTijd);
+        $eind = self::normaliseerTijd($eindTijd);
+
+        if ($start === null || $eind === null) {
+            return true;
+        }
+
+        if ($eind > $start) {
+            return true;
+        }
+
+        return $eind <= self::NACHT_GRENS;
+    }
+
+    private static function valtInDeNacht(CarbonInterface $moment): bool
+    {
+        return $moment->format('H:i:s') <= self::NACHT_GRENS;
+    }
+
+    private static function opDag(CarbonImmutable $dag, string $tijd): ?CarbonImmutable
+    {
+        $genormaliseerd = self::normaliseerTijd($tijd);
+
+        if ($genormaliseerd === null) {
+            return null;
+        }
+
+        [$uur, $minuut, $seconde] = array_map(intval(...), explode(':', $genormaliseerd));
+
+        return $dag->setTime($uur, $minuut, $seconde);
+    }
+
+    /**
+     * Accepts `H:i` and `H:i:s` and returns a comparable `H:i:s` string.
+     */
+    private static function normaliseerTijd(string $tijd): ?string
+    {
+        if (preg_match('/^(\d{1,2}):(\d{2})(?::(\d{2}))?$/', trim($tijd), $delen) !== 1) {
+            return null;
+        }
+
+        $uur = (int) $delen[1];
+        $minuut = (int) $delen[2];
+        $seconde = (int) ($delen[3] ?? 0);
+
+        if ($uur > 23 || $minuut > 59 || $seconde > 59) {
+            return null;
+        }
+
+        return sprintf('%02d:%02d:%02d', $uur, $minuut, $seconde);
+    }
+
+    private static function parse(mixed $value): ?CarbonImmutable
+    {
+        $parsed = SafeDateTime::parse($value);
+
+        if ($parsed === null) {
+            return null;
+        }
+
+        return CarbonImmutable::parse($parsed->toDateTimeString());
+    }
+}

--- a/app/EventForm/Support/TijdenOverzicht.php
+++ b/app/EventForm/Support/TijdenOverzicht.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Support;
+
+use App\EventForm\State\FormState;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Carbon\CarbonImmutable;
+
+/**
+ * The single source for the "Overzicht ingevulde tijden" table, shared by the
+ * wizard summary, the submission PDF and the case infolist so all three tell
+ * the same story.
+ *
+ * A single-day period stays one row holding two full moments. A multi-day
+ * period expands into one row per day holding only clock times, since the day
+ * itself is already in the row label.
+ */
+final class TijdenOverzicht
+{
+    /**
+     * Activity label, envelope start key, envelope end key, per-day repeater key.
+     *
+     * @var list<array{0: string, 1: string, 2: string, 3: string}>
+     */
+    private const BLOKKEN = [
+        ['Opbouw', 'OpbouwStart', 'OpbouwEind', 'OpbouwDagen'],
+        ['Publiek', 'EvenementStart', 'EvenementEind', 'EvenementDagen'],
+        ['Afbouw', 'AfbouwStart', 'AfbouwEind', 'AfbouwDagen'],
+    ];
+
+    /**
+     * Activity label, envelope start key, envelope end key, stored day blocks key.
+     *
+     * @var list<array{0: string, 1: string, 2: string, 3: string}>
+     */
+    private const REFERENCE_BLOKKEN = [
+        ['Opbouw', 'start_opbouw', 'eind_opbouw', 'dagen_opbouw'],
+        ['Publiek', 'start_evenement', 'eind_evenement', 'dagen_evenement'],
+        ['Afbouw', 'start_afbouw', 'eind_afbouw', 'dagen_afbouw'],
+    ];
+
+    /**
+     * @return list<list<string>> rows of [activiteit, start, eind]
+     */
+    public static function uitFormState(FormState $state): array
+    {
+        $rijen = [];
+
+        foreach (self::BLOKKEN as [$label, $startKey, $eindKey, $dagenKey]) {
+            $dagBlokken = DagenRepeater::naarReferenceData(
+                is_array($dagen = $state->get($dagenKey)) ? $dagen : [],
+            );
+
+            $rijen = [...$rijen, ...self::rijenVoorBlok(
+                $label,
+                $state->get($startKey),
+                $state->get($eindKey),
+                $dagBlokken,
+            )];
+        }
+
+        return $rijen;
+    }
+
+    /**
+     * @return list<list<string>> rows of [activiteit, start, eind]
+     */
+    public static function uitReferenceData(ZaakReferenceData $reference): array
+    {
+        $rijen = [];
+
+        foreach (self::REFERENCE_BLOKKEN as [$label, $startKey, $eindKey, $dagenKey]) {
+            $rijen = [...$rijen, ...self::rijenVoorBlok(
+                $label,
+                $reference->{$startKey},
+                $reference->{$eindKey},
+                $reference->{$dagenKey} ?? [],
+            )];
+        }
+
+        return $rijen;
+    }
+
+    /**
+     * @param  mixed  $dagBlokken  stored day blocks, if the period runs over several days
+     * @return list<list<string>>
+     */
+    private static function rijenVoorBlok(string $label, mixed $start, mixed $eind, mixed $dagBlokken): array
+    {
+        $dagRijen = DagenRepeater::alsTabelRijen($dagBlokken);
+
+        if ($dagRijen !== []) {
+            return array_map(
+                fn (array $rij): array => [$label.' — '.$rij['datum'], $rij['start'], $rij['eind']],
+                $dagRijen,
+            );
+        }
+
+        $startLabel = self::moment($start);
+        $eindLabel = self::moment($eind);
+
+        if ($startLabel === '' && $eindLabel === '') {
+            return [];
+        }
+
+        return [[$label, $startLabel, $eindLabel]];
+    }
+
+    private static function moment(mixed $waarde): string
+    {
+        if (! is_string($waarde) || trim($waarde) === '') {
+            return '';
+        }
+
+        try {
+            return CarbonImmutable::parse($waarde, 'Europe/Amsterdam')->translatedFormat('j F Y · H:i');
+        } catch (\Throwable) {
+            return '';
+        }
+    }
+}

--- a/app/EventForm/Validation/TijdenFieldRules.php
+++ b/app/EventForm/Validation/TijdenFieldRules.php
@@ -5,30 +5,34 @@ declare(strict_types=1);
 namespace App\EventForm\Validation;
 
 /**
- * Cross-field datumconstraints op de tijden-stap. Geen eigen logica —
- * we leunen op Filament's eigen `->after()/->before()/->afterOrEqual()/
- * ->beforeOrEqual()` die intern Laravel-rules `after`/`before`/etc.
- * gebruiken (vendor/filament/forms/src/Components/Concerns/CanBeValidated.php).
+ * Cross-field date constraints on the Tijden step. No logic of our own — we
+ * lean on Filament's `->after()/->before()/->afterOrEqual()/->beforeOrEqual()`,
+ * which internally use the Laravel rules `after`/`before`/etc.
+ * (vendor/filament/forms/src/Components/Concerns/CanBeValidated.php).
  *
- * De waarden zijn ruwe modifier-statements die de transpiler ongewijzigd
- * achter de DateTimePicker emit. We doen het via een constant zodat de
- * regels op één plek staan en bij re-transpile niet kwijt zijn.
+ * The values are raw modifier statements that the transpiler emits unchanged
+ * after the DateTimePicker. Keeping them in a constant puts the rules in one
+ * place and stops them getting lost on a re-transpile.
  *
- * Samenhang van de tijden:
+ * How the moments relate:
  *
  *     OpbouwStart ≤ OpbouwEind ≤ EvenementStart ≤ EvenementEind ≤ AfbouwStart ≤ AfbouwEind
  *
- * EvenementStart moet bovendien minimaal vandaag zijn — voorkomt dat een
- * organisator een aanvraag voor een evenement in het verleden indient.
+ * EvenementStart must also be today at the earliest, which stops an organiser
+ * applying for an event in the past.
+ *
+ * These constraints bound the whole period. The rules for the per-day rows
+ * inside such a period live on the repeater itself.
+ *
+ * @see \App\EventForm\Components\EventDagenRepeater
  */
 final class TijdenFieldRules
 {
     /**
-     * @var array<string, list<string>> Veld-key → list van modifier-statements
-     *                                  die de transpiler na de basis-make()
-     *                                  emit. Statements moeten zonder leading
-     *                                  spaties zijn — de transpiler zorgt
-     *                                  voor de juiste indent.
+     * @var array<string, list<string>> Field key → list of modifier statements
+     *                                  the transpiler emits after the base
+     *                                  make(). Statements must carry no leading
+     *                                  spaces; the transpiler handles indent.
      */
     public const PER_FIELD = [
         'EvenementStart' => [

--- a/app/EventForm/Validation/TijdenFieldRules.php
+++ b/app/EventForm/Validation/TijdenFieldRules.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\EventForm\Validation;
 
+use App\EventForm\Components\EventDagenRepeater;
+
 /**
  * Cross-field date constraints on the Tijden step. No logic of our own — we
  * lean on Filament's `->after()/->before()/->afterOrEqual()/->beforeOrEqual()`,
@@ -24,7 +26,7 @@ namespace App\EventForm\Validation;
  * These constraints bound the whole period. The rules for the per-day rows
  * inside such a period live on the repeater itself.
  *
- * @see \App\EventForm\Components\EventDagenRepeater
+ * @see EventDagenRepeater
  */
 final class TijdenFieldRules
 {

--- a/app/Filament/Shared/Resources/Zaken/Schemas/ZaakInfolist.php
+++ b/app/Filament/Shared/Resources/Zaken/Schemas/ZaakInfolist.php
@@ -4,6 +4,7 @@ namespace App\Filament\Shared\Resources\Zaken\Schemas;
 
 use App\Enums\AdviceStatus;
 use App\Enums\Role;
+use App\EventForm\Support\DagenRepeater;
 use App\Filament\Shared\Resources\Zaken\Pages\ViewZaak;
 use App\Filament\Shared\Resources\Zaken\Schemas\Components\LocationsTab;
 use App\Filament\Shared\Resources\Zaken\ZaakResource\RelationManagers\AdviceThreadRelationManager;
@@ -78,6 +79,7 @@ class ZaakInfolist
             TextEntry::make('reference_data.eind_evenement_datetime')
                 ->dateTime(config('app.datetime_format'))
                 ->label(__('resources/zaak.columns.eind_evenement.label')),
+            self::dagenEntry('dagen_evenement', __('resources/zaak.columns.dagen_evenement.label')),
             TextEntry::make('reference_data.start_opbouw')
                 ->dateTime(config('app.datetime_format'))
                 ->label(__('resources/zaak.columns.start_opbouw.label'))
@@ -86,6 +88,7 @@ class ZaakInfolist
                 ->dateTime(config('app.datetime_format'))
                 ->label(__('resources/zaak.columns.eind_opbouw.label'))
                 ->visible(fn ($state) => ! empty($state)),
+            self::dagenEntry('dagen_opbouw', __('resources/zaak.columns.dagen_opbouw.label')),
             TextEntry::make('reference_data.start_afbouw')
                 ->dateTime(config('app.datetime_format'))
                 ->label(__('resources/zaak.columns.start_afbouw.label'))
@@ -94,6 +97,7 @@ class ZaakInfolist
                 ->dateTime(config('app.datetime_format'))
                 ->label(__('resources/zaak.columns.eind_afbouw.label'))
                 ->visible(fn ($state) => ! empty($state)),
+            self::dagenEntry('dagen_afbouw', __('resources/zaak.columns.dagen_afbouw.label')),
             TextEntry::make('reference_data.locaties_evenement')
                 ->label(__('resources/zaak.columns.locaties_evenement.label'))
                 ->visible(fn ($state) => ! empty($state)),
@@ -133,6 +137,25 @@ class ZaakInfolist
                     return in_array($user->role, [Role::MunicipalityAdmin, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::Reviewer, Role::Advisor, Role::Admin]);
                 }),
         ];
+    }
+
+    /**
+     * Per-day start and end times of a multi-day period. Only shown when the
+     * organiser actually supplied them; a single-day event keeps telling its
+     * story through the start and end entries above.
+     */
+    private static function dagenEntry(string $key, string $label): TextEntry
+    {
+        return TextEntry::make("reference_data.{$key}")
+            ->label($label)
+            ->listWithLineBreaks()
+            ->state(function (Zaak $record) use ($key): array {
+                return array_map(
+                    fn (array $rij): string => sprintf('%s · %s – %s', $rij['datum'], $rij['start'], $rij['eind']),
+                    DagenRepeater::alsTabelRijen($record->reference_data->{$key}),
+                );
+            })
+            ->visible(fn ($state): bool => is_array($state) && $state !== []);
     }
 
     public static function resultaatSection(): Section

--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -177,6 +177,12 @@ class CreateDoorkomstZaken implements ShouldQueue
                             'status_name' => $newOzZaak->status_name ?? '',
                             'statustype_url' => $newOzZaak->statustype_url ?? '',
                             'organisator' => $organisator,
+                            // Per-day times of a multi-day event do not exist
+                            // as a zaakeigenschap, so carry them over from the
+                            // parent case directly.
+                            'dagen_evenement' => $this->zaak->reference_data->dagen_evenement,
+                            'dagen_opbouw' => $this->zaak->reference_data->dagen_opbouw,
+                            'dagen_afbouw' => $this->zaak->reference_data->dagen_afbouw,
                         ]
                     )
                 ),

--- a/app/ValueObjects/ModelAttributes/ZaakReferenceData.php
+++ b/app/ValueObjects/ModelAttributes/ZaakReferenceData.php
@@ -43,6 +43,12 @@ final readonly class ZaakReferenceData implements Arrayable, Castable
         public ?string $eind_afbouw = null,
         public ?string $locaties_evenement = null,
         public ?string $intern_zaaknummer = null,
+        /** @var list<array{datum: string, start: string, eind: string}>|null */
+        public ?array $dagen_evenement = null,
+        /** @var list<array{datum: string, start: string, eind: string}>|null */
+        public ?array $dagen_opbouw = null,
+        /** @var list<array{datum: string, start: string, eind: string}>|null */
+        public ?array $dagen_afbouw = null,
         ...$otherParams
     ) {
         $this->start_evenement_datetime = $this->parseDateTime($this->start_evenement);
@@ -102,6 +108,9 @@ final readonly class ZaakReferenceData implements Arrayable, Castable
             'eind_afbouw' => $this->eind_afbouw,
             'locaties_evenement' => $this->locaties_evenement,
             'intern_zaaknummer' => $this->intern_zaaknummer,
+            'dagen_evenement' => $this->dagen_evenement,
+            'dagen_opbouw' => $this->dagen_opbouw,
+            'dagen_afbouw' => $this->dagen_afbouw,
         ];
     }
 

--- a/lang/nl/resources/zaak.php
+++ b/lang/nl/resources/zaak.php
@@ -35,6 +35,15 @@ return [
         'eind_evenement' => [
             'label' => 'Eind evenement',
         ],
+        'dagen_evenement' => [
+            'label' => 'Evenement per dag',
+        ],
+        'dagen_opbouw' => [
+            'label' => 'Opbouw per dag',
+        ],
+        'dagen_afbouw' => [
+            'label' => 'Afbouw per dag',
+        ],
         'telefoon' => [
             'label' => 'Telefoonnummer organisatie',
         ],

--- a/tests/Feature/EventForm/Pages/EventFormDagenTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormDagenTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #24, in the real form: as soon as the given period covers more than
+ * one calendar day, day rows appear in which the organiser fills in a start
+ * and end time per day. A single-day event with an end time in the small
+ * hours stays single-day and therefore gets no day rows.
+ */
+
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Organisation;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->user = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach($this->organisation->id, ['role' => 'admin']);
+
+    $this->actingAs($this->user);
+    Filament\Facades\Filament::setCurrentPanel(Filament\Facades\Filament::getPanel('organiser'));
+    Filament\Facades\Filament::setTenant($this->organisation);
+
+    $this->draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [], 'system' => []],
+        'current_step_key' => null,
+    ]);
+});
+
+test('een meerdaagse periode levert een dagregel per evenementdag op', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    $component->set('data.EvenementStart', '2026-07-04 16:00:00');
+    $component->set('data.EvenementEind', '2026-07-07 02:00:00');
+
+    $dagen = $component->get('data.EvenementDagen');
+
+    // The last block ends on 7 July at 02:00, but 7 July is not itself an
+    // event day: that night belongs to 6 July.
+    expect(array_keys($dagen))->toBe(['2026-07-04', '2026-07-05', '2026-07-06']);
+
+    // The envelope supplies the first start time and the last end time.
+    expect($dagen['2026-07-04']['startTijd'])->toBe('16:00');
+    expect($dagen['2026-07-06']['eindTijd'])->toBe('02:00');
+});
+
+test('een eendaags evenement met een eindtijd in de nacht krijgt geen dagregels', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    $component->set('data.EvenementStart', '2026-07-04 16:00:00');
+    $component->set('data.EvenementEind', '2026-07-05 02:00:00');
+
+    expect($component->get('data.EvenementDagen'))->toBe([]);
+});
+
+test('een ingevulde dagtijd blijft staan als de periode langer wordt', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    $component->set('data.EvenementStart', '2026-07-04 16:00:00');
+    $component->set('data.EvenementEind', '2026-07-06 23:00:00');
+    $component->set('data.EvenementDagen.2026-07-05.startTijd', '14:00');
+    $component->set('data.EvenementDagen.2026-07-05.eindTijd', '23:00');
+
+    $component->set('data.EvenementEind', '2026-07-08 23:00:00');
+
+    $dagen = $component->get('data.EvenementDagen');
+
+    expect(array_keys($dagen))->toBe(['2026-07-04', '2026-07-05', '2026-07-06', '2026-07-07', '2026-07-08']);
+    expect($dagen['2026-07-05']['startTijd'])->toBe('14:00');
+    expect($dagen['2026-07-05']['eindTijd'])->toBe('23:00');
+});
+
+test('een bestaand concept met alleen een periode krijgt bij openen alsnog dagregels', function () {
+    // Drafts from before this feature, and copies of older cases, do have a
+    // start and end but no day rows yet.
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [
+            'EvenementStart' => '2026-07-04 16:00:00',
+            'EvenementEind' => '2026-07-06 23:00:00',
+        ], 'system' => []],
+        'current_step_key' => null,
+    ]);
+
+    $dagen = Livewire::test(EventFormPage::class, ['draft' => $draft->id])
+        ->get('data.EvenementDagen');
+
+    expect(array_keys($dagen))->toBe(['2026-07-04', '2026-07-05', '2026-07-06']);
+    expect($dagen['2026-07-04']['startTijd'])->toBe('16:00');
+});
+
+test('opbouw over meerdere dagen krijgt zijn eigen dagregels', function () {
+    $component = Livewire::test(EventFormPage::class, ['draft' => $this->draft->id]);
+
+    $component->set('data.zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten', 'Ja');
+    $component->set('data.OpbouwStart', '2026-07-01 08:00:00');
+    $component->set('data.OpbouwEind', '2026-07-03 18:00:00');
+
+    expect(array_keys($component->get('data.OpbouwDagen')))
+        ->toBe(['2026-07-01', '2026-07-02', '2026-07-03']);
+    // The event itself is not filled in yet and therefore has no day rows.
+    expect($component->get('data.EvenementDagen'))->toBeEmpty();
+});

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -114,6 +114,40 @@ test('Tijden-stap: alle drie de blokken ingevuld → tabel met 3 rijen in volgor
     ]);
 });
 
+test('Tijden-stap: meerdaags evenement → een tabelrij per dag met alleen kloktijden', function () {
+    // Issue #24. De datum staat al in het rij-label, dus de kolommen Start en
+    // Eind tonen alleen de tijd. Loopt een dag door tot na middernacht, dan
+    // maakt de eindkolom zichtbaar op welke dag die eindigt.
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-07-04T16:00',
+        'EvenementEind' => '2026-07-06T23:00',
+        'EvenementDagen' => [
+            '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-06' => ['datum' => '2026-07-06', 'startTijd' => '16:00', 'eindTijd' => '23:00'],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [TijdenStep::make()]);
+    $tabelEntry = collect($sections[0]['entries'])->first(fn ($e) => ! empty($e['table']));
+
+    expect($tabelEntry['table']['rows'])->toBe([
+        ['Publiek — zaterdag 4 juli 2026', '16:00', '02:00 (5 juli)'],
+        ['Publiek — zondag 5 juli 2026', '16:00', '02:00 (6 juli)'],
+        ['Publiek — maandag 6 juli 2026', '16:00', '23:00'],
+    ]);
+
+    // De dagregels mogen niet óók nog als losse repeater-rijen ("— rij 1")
+    // in de PDF verschijnen. Dat stond niet alleen dubbel, de rijen bevatten
+    // kale kloktijden die als de datum van vandaag gerenderd werden.
+    $labels = collect($sections[0]['entries'])->pluck('label')->all();
+    expect(collect($labels)->filter(fn (string $label) => str_contains($label, 'per dag')))
+        ->toBeEmpty();
+    $subLabels = collect($sections[0]['entries'])->pluck('sub')->filter()->flatten(1)->pluck('label')->all();
+    expect($subLabels)->not->toContain('Starttijd')
+        ->and($subLabels)->not->toContain('Eindtijd');
+});
+
 test('Tijden-stap: geen enkele datetime ingevuld → geen tabel-entry', function () {
     // Andere velden in TijdenStep (de Radio-vragen) kunnen wel ingevuld
     // zijn; de tabel zelf moet bij ontbrekende datums niet als een

--- a/tests/Feature/EventForm/Schema/TijdenDagenTest.php
+++ b/tests/Feature/EventForm/Schema/TijdenDagenTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #24: for a multi-day event the organiser must be able to give a start
+ * and end time per day, for the build-up and tear-down as well.
+ *
+ * This test guards that the three day repeaters are present in the rendered
+ * step and carry the right fields. The rules themselves (what "multi-day"
+ * means, how a night rolls over) live in the unit tests of EventDagen and
+ * DagenRepeater.
+ */
+
+use App\EventForm\Schema\Steps\TijdenStep;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\TimePicker;
+use Filament\Schemas\Components\Wizard\Step;
+
+function findRepeaters(Step $step): array
+{
+    $found = [];
+    $walk = function (object $component) use (&$walk, &$found): void {
+        if ($component instanceof Repeater) {
+            $found[$component->getName()] = $component;
+        }
+
+        if (! property_exists($component, 'childComponents')) {
+            return;
+        }
+
+        $reflection = new ReflectionObject($component);
+        $childProp = $reflection->getProperty('childComponents');
+        $childProp->setAccessible(true);
+
+        foreach ($childProp->getValue($component) as $componentList) {
+            if (! is_array($componentList)) {
+                continue;
+            }
+            foreach ($componentList as $child) {
+                if (is_object($child)) {
+                    $walk($child);
+                }
+            }
+        }
+    };
+    $walk($step);
+
+    return $found;
+}
+
+test('de tijden-stap heeft een dag-repeater voor evenement, opbouw en afbouw', function () {
+    $repeaters = findRepeaters(TijdenStep::make());
+
+    expect($repeaters)->toHaveKeys(['EvenementDagen', 'OpbouwDagen', 'AfbouwDagen']);
+});
+
+test('elke dag-repeater vraagt een start- en een eindtijd', function (string $key) {
+    $repeater = findRepeaters(TijdenStep::make())[$key];
+
+    $reflection = new ReflectionObject($repeater);
+    $childProp = $reflection->getProperty('childComponents');
+    $childProp->setAccessible(true);
+
+    $tijdVelden = [];
+    foreach ($childProp->getValue($repeater) as $componentList) {
+        foreach ((array) $componentList as $child) {
+            if ($child instanceof TimePicker) {
+                $tijdVelden[] = $child->getName();
+            }
+        }
+    }
+
+    expect($tijdVelden)->toBe(['startTijd', 'eindTijd']);
+})->with(['EvenementDagen', 'OpbouwDagen', 'AfbouwDagen']);
+
+test('dagregels kunnen niet met de hand toegevoegd of verwijderd worden', function (string $key) {
+    // Rows follow the date span of the two pickers above; adding rows by hand
+    // would produce a day outside that period.
+    $repeater = findRepeaters(TijdenStep::make())[$key];
+
+    // The public isAddable()/isDeletable() need a container that an isolated
+    // step does not have, so read the flags directly.
+    $reflection = new ReflectionObject($repeater);
+    $lees = function (string $property) use ($reflection, $repeater) {
+        $prop = $reflection->getProperty($property);
+        $prop->setAccessible(true);
+
+        return $prop->getValue($repeater);
+    };
+
+    expect($lees('isAddable'))->toBeFalse();
+    expect($lees('isDeletable'))->toBeFalse();
+    expect($lees('isReorderable'))->toBeFalse();
+})->with(['EvenementDagen', 'OpbouwDagen', 'AfbouwDagen']);

--- a/tests/Feature/EventForm/Services/EventsCheckServiceTest.php
+++ b/tests/Feature/EventForm/Services/EventsCheckServiceTest.php
@@ -45,6 +45,119 @@ test('returns empty when no matches', function () {
     ]);
 });
 
+test('finds an event that spans the whole date range', function () {
+    // Een meerdaags evenement dat begint vóór en eindigt ná het opgegeven
+    // venster overlapt wel degelijk, maar viel voorheen buiten de boot omdat
+    // geen van beide uiteinden binnen het venster lag.
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '2026-05-01T10:00:00+02:00',
+            eind_evenement: '2026-05-20T18:00:00+02:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ontvangen',
+            statustype_url: '',
+            naam_evenement: 'Meerdaagse kermis',
+        ),
+    ]);
+
+    $result = $this->service->check('2026-05-05', '2026-05-06', 'GM0882');
+
+    expect($result)->toBe([
+        'event_names' => 'Meerdaagse kermis',
+        'event_count' => 1,
+    ]);
+});
+
+test('ignores events that end before or start after the date range', function () {
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '2026-04-01T10:00:00+02:00',
+            eind_evenement: '2026-04-02T18:00:00+02:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ontvangen',
+            statustype_url: '',
+            naam_evenement: 'Ervoor',
+        ),
+    ]);
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '2026-06-01T10:00:00+02:00',
+            eind_evenement: '2026-06-02T18:00:00+02:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ontvangen',
+            statustype_url: '',
+            naam_evenement: 'Erna',
+        ),
+    ]);
+
+    expect($this->service->check('2026-05-01', '2026-05-10', 'GM0882')['event_count'])->toBe(0);
+});
+
+test('een zaak met een niet-ISO datum laat de query niet klappen', function () {
+    // Oudere zaken kunnen een Nederlandse datumnotatie bevatten. Die mag geen
+    // databasefout opleveren; de zaak valt simpelweg buiten de vergelijking.
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '5 mei 2026 10:00',
+            eind_evenement: '6 mei 2026 18:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ontvangen',
+            statustype_url: '',
+            naam_evenement: 'Oud formaat',
+        ),
+    ]);
+
+    expect($this->service->check('2026-05-01', '2026-05-10', 'GM0882')['event_count'])->toBe(0);
+});
+
+test('telt alle overlappende evenementen ook als er meer dan tien namen zijn', function () {
+    foreach (range(1, 12) as $nummer) {
+        Zaak::factory()->create([
+            'zaaktype_id' => $this->zaaktype->id,
+            'reference_data' => new ZaakReferenceData(
+                start_evenement: '2026-05-05T10:00:00+02:00',
+                eind_evenement: '2026-05-05T18:00:00+02:00',
+                registratiedatum: now()->toIso8601String(),
+                status_name: 'Ontvangen',
+                statustype_url: '',
+                naam_evenement: "Evenement {$nummer}",
+            ),
+        ]);
+    }
+
+    $result = $this->service->check('2026-05-01', '2026-05-10', 'GM0882');
+
+    expect($result['event_count'])->toBe(12);
+    expect(explode(', ', $result['event_names']))->toHaveCount(10);
+});
+
+test('een omgekeerd opgegeven venster levert hetzelfde resultaat op', function () {
+    Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: '2026-05-05T10:00:00+02:00',
+            eind_evenement: '2026-05-06T18:00:00+02:00',
+            registratiedatum: now()->toIso8601String(),
+            status_name: 'Ontvangen',
+            statustype_url: '',
+            naam_evenement: 'Bevrijdingsfestival',
+        ),
+    ]);
+
+    expect($this->service->check('2026-05-10', '2026-05-01', 'GM0882')['event_count'])->toBe(1);
+});
+
+test('een leeg of onleesbaar venster levert geen resultaten op', function () {
+    expect($this->service->check('', '2026-05-10', 'GM0882'))->toBe([
+        'event_names' => '',
+        'event_count' => 0,
+    ]);
+});
+
 test('filters by municipality', function () {
     $other = Municipality::factory()->create(['brk_identification' => 'GM0999']);
     $otherZt = Zaaktype::factory()->create(['municipality_id' => $other->id]);

--- a/tests/Feature/EventForm/Services/EventsCheckServiceTest.php
+++ b/tests/Feature/EventForm/Services/EventsCheckServiceTest.php
@@ -96,9 +96,10 @@ test('ignores events that end before or start after the date range', function ()
     expect($this->service->check('2026-05-01', '2026-05-10', 'GM0882')['event_count'])->toBe(0);
 });
 
-test('een zaak met een niet-ISO datum laat de query niet klappen', function () {
-    // Oudere zaken kunnen een Nederlandse datumnotatie bevatten. Die mag geen
-    // databasefout opleveren; de zaak valt simpelweg buiten de vergelijking.
+test('een zaak met een niet-ISO datum valt buiten de vergelijking', function () {
+    // Oudere zaken kunnen een Nederlandse datumnotatie bevatten. Die sorteert
+    // niet mee met de ISO-waarden en valt daardoor buiten het venster, zonder
+    // de query te verstoren.
     Zaak::factory()->create([
         'zaaktype_id' => $this->zaaktype->id,
         'reference_data' => new ZaakReferenceData(

--- a/tests/Feature/EventForm/Submit/MeerdaagseTijdenTest.php
+++ b/tests/Feature/EventForm/Submit/MeerdaagseTijdenTest.php
@@ -15,6 +15,7 @@ use App\EventForm\State\FormState;
 use App\EventForm\Submit\MapFormStateToReferenceData;
 use App\Models\Zaak;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Carbon\CarbonImmutable;
 
 function meerdaagseState(): FormState
 {
@@ -38,13 +39,13 @@ test('de dagtijden van een meerdaags evenement landen in de reference_data', fun
     expect($reference->dagen_evenement[0]['datum'])->toBe('2026-07-04');
 
     // The 02:00 end time belongs to the night after the first day.
-    expect(Carbon\CarbonImmutable::parse($reference->dagen_evenement[0]['eind'])->toDateTimeString())
+    expect(CarbonImmutable::parse($reference->dagen_evenement[0]['eind'])->toDateTimeString())
         ->toBe('2026-07-05 02:00:00');
 
     // The envelope stays the head and tail of the whole period.
-    expect(Carbon\CarbonImmutable::parse($reference->start_evenement)->toDateTimeString())
+    expect(CarbonImmutable::parse($reference->start_evenement)->toDateTimeString())
         ->toBe('2026-07-04 16:00:00');
-    expect(Carbon\CarbonImmutable::parse($reference->eind_evenement)->toDateTimeString())
+    expect(CarbonImmutable::parse($reference->eind_evenement)->toDateTimeString())
         ->toBe('2026-07-07 02:00:00');
 });
 

--- a/tests/Feature/EventForm/Submit/MeerdaagseTijdenTest.php
+++ b/tests/Feature/EventForm/Submit/MeerdaagseTijdenTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Per-day times of a multi-day event must survive the whole trip: from the
+ * FormState into the case reference_data, and stay there when a single other
+ * field on the case is updated.
+ *
+ * That last part is not theoretical: `ZaakReferenceData::toArray()` is a hard
+ * whitelist, so a key missing from it disappears silently on every save.
+ */
+
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\MapFormStateToReferenceData;
+use App\Models\Zaak;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+
+function meerdaagseState(): FormState
+{
+    return new FormState(values: [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Driedaags festival',
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-07 02:00',
+        'EvenementDagen' => [
+            '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-06' => ['datum' => '2026-07-06', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+        ],
+    ]);
+}
+
+test('de dagtijden van een meerdaags evenement landen in de reference_data', function () {
+    $reference = app(MapFormStateToReferenceData::class)
+        ->build(meerdaagseState(), 'Ingediend', 'https://example.test/statustypen/1');
+
+    expect($reference->dagen_evenement)->toHaveCount(3);
+    expect($reference->dagen_evenement[0]['datum'])->toBe('2026-07-04');
+
+    // The 02:00 end time belongs to the night after the first day.
+    expect(Carbon\CarbonImmutable::parse($reference->dagen_evenement[0]['eind'])->toDateTimeString())
+        ->toBe('2026-07-05 02:00:00');
+
+    // The envelope stays the head and tail of the whole period.
+    expect(Carbon\CarbonImmutable::parse($reference->start_evenement)->toDateTimeString())
+        ->toBe('2026-07-04 16:00:00');
+    expect(Carbon\CarbonImmutable::parse($reference->eind_evenement)->toDateTimeString())
+        ->toBe('2026-07-07 02:00:00');
+});
+
+test('een eendaags evenement krijgt geen dagtijden', function () {
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-05 02:00',
+    ]);
+
+    $reference = app(MapFormStateToReferenceData::class)
+        ->build($state, 'Ingediend', 'https://example.test/statustypen/1');
+
+    expect($reference->dagen_evenement)->toBeNull();
+    expect($reference->dagen_opbouw)->toBeNull();
+    expect($reference->dagen_afbouw)->toBeNull();
+});
+
+test('opbouw en afbouw krijgen hun eigen dagtijden', function () {
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-04 23:00',
+        'OpbouwStart' => '2026-07-02 08:00',
+        'OpbouwEind' => '2026-07-03 18:00',
+        'OpbouwDagen' => [
+            '2026-07-02' => ['datum' => '2026-07-02', 'startTijd' => '08:00', 'eindTijd' => '17:00'],
+            '2026-07-03' => ['datum' => '2026-07-03', 'startTijd' => '08:00', 'eindTijd' => '18:00'],
+        ],
+        'AfbouwStart' => '2026-07-05 08:00',
+        'AfbouwEind' => '2026-07-06 16:00',
+        'AfbouwDagen' => [
+            '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '08:00', 'eindTijd' => '17:00'],
+            '2026-07-06' => ['datum' => '2026-07-06', 'startTijd' => '08:00', 'eindTijd' => '16:00'],
+        ],
+    ]);
+
+    $reference = app(MapFormStateToReferenceData::class)
+        ->build($state, 'Ingediend', 'https://example.test/statustypen/1');
+
+    expect($reference->dagen_opbouw)->toHaveCount(2);
+    expect($reference->dagen_afbouw)->toHaveCount(2);
+    expect($reference->dagen_evenement)->toBeNull();
+});
+
+test('de dagtijden overleven een gedeeltelijke update van de zaak', function () {
+    $reference = app(MapFormStateToReferenceData::class)
+        ->build(meerdaagseState(), 'Ingediend', 'https://example.test/statustypen/1');
+
+    $zaak = Zaak::factory()->create(['reference_data' => $reference]);
+
+    // This is the shape the individual case actions use: spread the existing
+    // reference_data and overwrite a single key.
+    $zaak->reference_data = new ZaakReferenceData(
+        ...array_merge($zaak->reference_data->toArray(), ['intern_zaaknummer' => 'INT-42'])
+    );
+    $zaak->save();
+
+    $opnieuw = $zaak->fresh();
+
+    expect($opnieuw->reference_data->intern_zaaknummer)->toBe('INT-42');
+    expect($opnieuw->reference_data->dagen_evenement)->toHaveCount(3);
+});

--- a/tests/Feature/Filament/Shared/Resources/ZaakDagtijdenTest.php
+++ b/tests/Feature/Filament/Shared/Resources/ZaakDagtijdenTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Issue #24: the per-day times of a multi-day event must be visible to the
+ * case handler on the case itself, not only in the submission PDF.
+ */
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\Filament\Organiser\Resources\Zaken\Pages\ViewZaak;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Config;
+use Tests\Fakes\ZgwHttpFake;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('organiser'));
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+    ZgwHttpFake::wildcardFake();
+
+    $municipality = Municipality::factory()->create();
+    $this->zaaktype = Zaaktype::factory()->create(['municipality_id' => $municipality->id]);
+    $this->organisation = Organisation::factory()->create(['type' => 'business']);
+    $this->user = User::factory()->create(['role' => Role::Organiser]);
+    $this->organisation->users()->attach($this->user, ['role' => OrganisationRole::Admin]);
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->organisation);
+});
+
+function zaakMetDagtijden(array $overrides = []): Zaak
+{
+    return Zaak::factory()->create([
+        'zaaktype_id' => test()->zaaktype->id,
+        'organisation_id' => test()->organisation->id,
+        'zgw_zaak_url' => null,
+        'imported_data' => ['some' => 'data'],
+        'reference_data' => new ZaakReferenceData(...array_merge([
+            'start_evenement' => '2026-07-04T16:00:00+02:00',
+            'eind_evenement' => '2026-07-07T02:00:00+02:00',
+            'registratiedatum' => '2026-06-01T10:00:00+02:00',
+            'status_name' => 'Ingediend',
+            'statustype_url' => 'https://example.com/statustype/1',
+            'naam_evenement' => 'Driedaags festival',
+        ], $overrides)),
+    ]);
+}
+
+test('de dagtijden van een meerdaags evenement staan op de zaak', function () {
+    $zaak = zaakMetDagtijden([
+        'dagen_evenement' => [
+            ['datum' => '2026-07-04', 'start' => '2026-07-04T16:00:00+02:00', 'eind' => '2026-07-05T02:00:00+02:00'],
+            ['datum' => '2026-07-05', 'start' => '2026-07-05T16:00:00+02:00', 'eind' => '2026-07-06T02:00:00+02:00'],
+        ],
+    ]);
+
+    livewire(ViewZaak::class, ['record' => $zaak->id])
+        ->assertOk()
+        ->assertSee('Evenement per dag')
+        ->assertSee('zaterdag 4 juli 2026 · 16:00 – 02:00 (5 juli)');
+});
+
+test('een zaak zonder dagtijden toont het kopje niet', function () {
+    $zaak = zaakMetDagtijden();
+
+    livewire(ViewZaak::class, ['record' => $zaak->id])
+        ->assertOk()
+        ->assertDontSee('Evenement per dag')
+        ->assertDontSee('Opbouw per dag');
+});

--- a/tests/Unit/EventForm/Support/DagenRepeaterTest.php
+++ b/tests/Unit/EventForm/Support/DagenRepeaterTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  */
 
 use App\EventForm\Support\DagenRepeater;
+use Carbon\CarbonImmutable;
 
 test('een eendaagse periode levert geen dagregels op', function () {
     expect(DagenRepeater::sync('2026-07-04 10:00', '2026-07-04 18:00'))->toBe([]);
@@ -64,9 +65,9 @@ test('dagregels worden omgezet naar dagblokken met doorrollende eindtijden', fun
 
     expect($blokken)->toHaveCount(2);
     expect($blokken[0]['datum'])->toBe('2026-07-04');
-    expect(Carbon\CarbonImmutable::parse($blokken[0]['eind'])->toDateTimeString())
+    expect(CarbonImmutable::parse($blokken[0]['eind'])->toDateTimeString())
         ->toBe('2026-07-05 02:00:00');
-    expect(Carbon\CarbonImmutable::parse($blokken[1]['eind'])->toDateTimeString())
+    expect(CarbonImmutable::parse($blokken[1]['eind'])->toDateTimeString())
         ->toBe('2026-07-05 23:00:00');
 });
 

--- a/tests/Unit/EventForm/Support/DagenRepeaterTest.php
+++ b/tests/Unit/EventForm/Support/DagenRepeaterTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The per-day rows an organiser fills in for a multi-day period, and the way
+ * they travel to and from the stored day blocks on the zaak.
+ */
+
+use App\EventForm\Support\DagenRepeater;
+
+test('een eendaagse periode levert geen dagregels op', function () {
+    expect(DagenRepeater::sync('2026-07-04 10:00', '2026-07-04 18:00'))->toBe([]);
+    // Not even when the end time falls in the small hours.
+    expect(DagenRepeater::sync('2026-07-04 16:00', '2026-07-05 02:00'))->toBe([]);
+});
+
+test('een meerdaagse periode levert één regel per evenementdag op', function () {
+    $rijen = DagenRepeater::sync('2026-07-04 16:00', '2026-07-07 02:00');
+
+    expect(array_keys($rijen))->toBe(['2026-07-04', '2026-07-05', '2026-07-06']);
+});
+
+test('de eerste starttijd en de laatste eindtijd spiegelen de envelope', function () {
+    $rijen = DagenRepeater::sync('2026-07-04 16:00', '2026-07-06 23:30');
+
+    expect($rijen['2026-07-04']['startTijd'])->toBe('16:00');
+    expect($rijen['2026-07-06']['eindTijd'])->toBe('23:30');
+    // The remaining times stay empty until the organiser fills them in.
+    expect($rijen['2026-07-04']['eindTijd'])->toBeNull();
+    expect($rijen['2026-07-05']['startTijd'])->toBeNull();
+});
+
+test('bestaande tijden blijven behouden als de datumspan verandert', function () {
+    $bestaand = DagenRepeater::sync('2026-07-04 16:00', '2026-07-06 23:00');
+    $bestaand['2026-07-05']['startTijd'] = '14:00';
+    $bestaand['2026-07-05']['eindTijd'] = '23:00';
+
+    // A day is added at the end.
+    $nieuw = DagenRepeater::sync('2026-07-04 16:00', '2026-07-07 23:00', $bestaand);
+
+    expect(array_keys($nieuw))->toBe(['2026-07-04', '2026-07-05', '2026-07-06', '2026-07-07']);
+    expect($nieuw['2026-07-05']['startTijd'])->toBe('14:00');
+    expect($nieuw['2026-07-05']['eindTijd'])->toBe('23:00');
+    // The last day has shifted, so that one now mirrors the envelope.
+    expect($nieuw['2026-07-07']['eindTijd'])->toBe('23:00');
+});
+
+test('rijen met een uuid-sleutel worden herkend aan hun eigen datum', function () {
+    $bestaand = [
+        '0198-abcd' => ['datum' => '2026-07-05', 'startTijd' => '14:00', 'eindTijd' => '23:00'],
+    ];
+
+    $rijen = DagenRepeater::sync('2026-07-04 16:00', '2026-07-06 23:00', $bestaand);
+
+    expect($rijen['2026-07-05']['startTijd'])->toBe('14:00');
+});
+
+test('dagregels worden omgezet naar dagblokken met doorrollende eindtijden', function () {
+    $blokken = DagenRepeater::naarReferenceData([
+        '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+        '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '16:00', 'eindTijd' => '23:00'],
+    ]);
+
+    expect($blokken)->toHaveCount(2);
+    expect($blokken[0]['datum'])->toBe('2026-07-04');
+    expect(Carbon\CarbonImmutable::parse($blokken[0]['eind'])->toDateTimeString())
+        ->toBe('2026-07-05 02:00:00');
+    expect(Carbon\CarbonImmutable::parse($blokken[1]['eind'])->toDateTimeString())
+        ->toBe('2026-07-05 23:00:00');
+});
+
+test('onvolledige dagregels leveren geen half dagblok op', function () {
+    $blokken = DagenRepeater::naarReferenceData([
+        '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => null],
+        '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '16:00', 'eindTijd' => '23:00'],
+    ]);
+
+    expect($blokken)->toHaveCount(1);
+    expect($blokken[0]['datum'])->toBe('2026-07-05');
+});
+
+test('opgeslagen dagblokken zijn terug te lezen als dagregels voor een kopie', function () {
+    $blokken = DagenRepeater::naarReferenceData([
+        '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+    ]);
+
+    $rijen = DagenRepeater::uitReferenceData($blokken);
+
+    expect($rijen['2026-07-04'])->toBe([
+        'datum' => '2026-07-04',
+        'startTijd' => '16:00',
+        'eindTijd' => '02:00',
+    ]);
+});
+
+test('dagblokken renderen als leesbare tabelrijen met een nachtmarkering', function () {
+    $blokken = DagenRepeater::naarReferenceData([
+        '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+        '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '10:00', 'eindTijd' => '18:00'],
+    ]);
+
+    $rijen = DagenRepeater::alsTabelRijen($blokken);
+
+    expect($rijen[0]['start'])->toBe('16:00');
+    // A roll-over into the next morning is made explicit.
+    expect($rijen[0]['eind'])->toContain('02:00');
+    expect($rijen[0]['eind'])->toContain('5');
+    // A block inside a single day gets no marker.
+    expect($rijen[1]['eind'])->toBe('18:00');
+});
+
+test('ontbrekende of onbruikbare dagdata levert lege lijsten op', function () {
+    expect(DagenRepeater::uitReferenceData(null))->toBe([]);
+    expect(DagenRepeater::alsTabelRijen(null))->toBe([]);
+    expect(DagenRepeater::alsTabelRijen(['onzin']))->toBe([]);
+});
+
+test('de eerste en laatste dag van de envelope zijn herkenbaar', function () {
+    expect(DagenRepeater::isEersteDag('2026-07-04', '2026-07-04 16:00'))->toBeTrue();
+    expect(DagenRepeater::isEersteDag('2026-07-05', '2026-07-04 16:00'))->toBeFalse();
+
+    // The last day is the effective end day, not the calendar day of the end moment.
+    expect(DagenRepeater::isLaatsteDag('2026-07-06', '2026-07-04 16:00', '2026-07-07 02:00'))->toBeTrue();
+    expect(DagenRepeater::isLaatsteDag('2026-07-07', '2026-07-04 16:00', '2026-07-07 02:00'))->toBeFalse();
+});

--- a/tests/Unit/EventForm/Support/EventDagenTest.php
+++ b/tests/Unit/EventForm/Support/EventDagenTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The night-boundary rule from issue #24: an event that finishes in the small
+ * hours is still a single-day event. Only when the end moment passes 06:00 of
+ * the following morning do we consider it multi-day and ask for times per day.
+ */
+
+use App\EventForm\Support\EventDagen;
+
+test('een evenement binnen één kalenderdag is niet meerdaags', function () {
+    expect(EventDagen::isMeerdaags('2026-07-04 10:00', '2026-07-04 18:00'))->toBeFalse();
+    expect(EventDagen::dagen('2026-07-04 10:00', '2026-07-04 18:00'))->toHaveCount(1);
+});
+
+test('een eindtijd in de nacht maakt een eendaags evenement niet meerdaags', function () {
+    // 16:00 until 02:00 the next morning: one day with a late finish.
+    expect(EventDagen::isMeerdaags('2026-07-04 16:00', '2026-07-05 02:00'))->toBeFalse();
+
+    $dagen = EventDagen::dagen('2026-07-04 16:00', '2026-07-05 02:00');
+    expect($dagen)->toHaveCount(1);
+    expect($dagen[0]->toDateString())->toBe('2026-07-04');
+});
+
+test('de nachtgrens ligt op 06:00 en telt die grens zelf nog bij de vorige dag', function () {
+    expect(EventDagen::isMeerdaags('2026-07-04 16:00', '2026-07-05 06:00'))->toBeFalse();
+    expect(EventDagen::isMeerdaags('2026-07-04 16:00', '2026-07-05 06:01'))->toBeTrue();
+});
+
+test('een meerdaags evenement met nachtelijke eindtijden telt alleen de evenementdagen', function () {
+    // Three days of 16:00-02:00: the last block ends on 7 July at 02:00,
+    // but 7 July is not itself an event day.
+    $dagen = EventDagen::dagen('2026-07-04 16:00', '2026-07-07 02:00');
+
+    expect($dagen)->toHaveCount(3);
+    expect(array_map(fn ($dag) => $dag->toDateString(), $dagen))
+        ->toBe(['2026-07-04', '2026-07-05', '2026-07-06']);
+});
+
+test('een meerdaags evenement dat overdag eindigt telt de einddag mee', function () {
+    $dagen = EventDagen::dagen('2026-07-04 10:00', '2026-07-06 18:00');
+
+    expect(array_map(fn ($dag) => $dag->toDateString(), $dagen))
+        ->toBe(['2026-07-04', '2026-07-05', '2026-07-06']);
+});
+
+test('ontbrekende of onleesbare momenten leveren geen dagen op', function () {
+    expect(EventDagen::dagen(null, '2026-07-04 18:00'))->toBe([]);
+    expect(EventDagen::dagen('2026-07-04 10:00', null))->toBe([]);
+    expect(EventDagen::dagen('2026-07-04 10:00', '20267-07-04 18:00'))->toBe([]);
+    expect(EventDagen::isMeerdaags(null, null))->toBeFalse();
+});
+
+test('een eind vóór de start levert nog steeds één dag op in plaats van een lege lijst', function () {
+    expect(EventDagen::dagen('2026-07-04 10:00', '2026-07-02 18:00'))->toHaveCount(1);
+});
+
+test('blokEinde rolt door naar de volgende dag als de eindtijd niet later is dan de starttijd', function () {
+    expect(EventDagen::blokEinde('2026-07-04', '16:00', '02:00')?->toDateTimeString())
+        ->toBe('2026-07-05 02:00:00');
+    expect(EventDagen::blokEinde('2026-07-04', '10:00', '18:00')?->toDateTimeString())
+        ->toBe('2026-07-04 18:00:00');
+    // Equal times read as a 24-hour block, not as an empty one.
+    expect(EventDagen::blokEinde('2026-07-04', '16:00', '16:00')?->toDateTimeString())
+        ->toBe('2026-07-05 16:00:00');
+});
+
+test('blokStart combineert de dag met de opgegeven tijd', function () {
+    expect(EventDagen::blokStart('2026-07-04', '16:00')?->toDateTimeString())
+        ->toBe('2026-07-04 16:00:00');
+    expect(EventDagen::blokStart('2026-07-04', null))->toBeNull();
+    expect(EventDagen::blokStart(null, '16:00'))->toBeNull();
+});
+
+test('een doorlopend blok mag niet voorbij de nachtgrens eindigen', function () {
+    expect(EventDagen::rolloverBinnenNachtGrens('16:00', '02:00'))->toBeTrue();
+    expect(EventDagen::rolloverBinnenNachtGrens('16:00', '06:00'))->toBeTrue();
+    expect(EventDagen::rolloverBinnenNachtGrens('16:00', '07:00'))->toBeFalse();
+    // Blocks that stay within the same day never touch the night boundary.
+    expect(EventDagen::rolloverBinnenNachtGrens('10:00', '18:00'))->toBeTrue();
+});

--- a/tests/Unit/EventForm/Support/TijdenOverzichtTest.php
+++ b/tests/Unit/EventForm/Support/TijdenOverzichtTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * The "Overzicht ingevulde tijden" table is shown in three places: at the
+ * bottom of the Tijden step, in the submission PDF and on the case. All three
+ * read from this one source so they cannot drift apart.
+ */
+
+use App\EventForm\State\FormState;
+use App\EventForm\Support\TijdenOverzicht;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+
+test('een eendaags evenement blijft één regel per activiteit', function () {
+    $rijen = TijdenOverzicht::uitFormState(new FormState(values: [
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-05 02:00',
+    ]));
+
+    expect($rijen)->toHaveCount(1);
+    expect($rijen[0][0])->toBe('Publiek');
+    expect($rijen[0][1])->toContain('16:00');
+});
+
+test('een meerdaags evenement krijgt een regel per dag', function () {
+    $rijen = TijdenOverzicht::uitFormState(new FormState(values: [
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-06 23:00',
+        'EvenementDagen' => [
+            '2026-07-04' => ['datum' => '2026-07-04', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-05' => ['datum' => '2026-07-05', 'startTijd' => '16:00', 'eindTijd' => '02:00'],
+            '2026-07-06' => ['datum' => '2026-07-06', 'startTijd' => '16:00', 'eindTijd' => '23:00'],
+        ],
+    ]));
+
+    expect($rijen)->toHaveCount(3);
+    expect($rijen[0][0])->toContain('Publiek');
+    expect($rijen[0][0])->toContain('4 juli 2026');
+    expect($rijen[0][1])->toBe('16:00');
+});
+
+test('opbouw, publiek en afbouw staan in die volgorde onder elkaar', function () {
+    $rijen = TijdenOverzicht::uitFormState(new FormState(values: [
+        'OpbouwStart' => '2026-07-03 08:00',
+        'OpbouwEind' => '2026-07-04 12:00',
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-04 23:00',
+        'AfbouwStart' => '2026-07-05 08:00',
+        'AfbouwEind' => '2026-07-05 12:00',
+    ]));
+
+    expect(array_column($rijen, 0))->toBe(['Opbouw', 'Publiek', 'Afbouw']);
+});
+
+test('activiteiten zonder ingevulde tijden krijgen geen regel', function () {
+    $rijen = TijdenOverzicht::uitFormState(new FormState(values: [
+        'EvenementStart' => '2026-07-04 16:00',
+        'EvenementEind' => '2026-07-04 23:00',
+    ]));
+
+    expect(array_column($rijen, 0))->toBe(['Publiek']);
+});
+
+test('de zaakweergave leest dezelfde tabel uit de opgeslagen dagtijden', function () {
+    $reference = new ZaakReferenceData(
+        start_evenement: '2026-07-04T16:00:00+02:00',
+        eind_evenement: '2026-07-07T02:00:00+02:00',
+        registratiedatum: '2026-06-01T10:00:00+02:00',
+        status_name: 'Ingediend',
+        statustype_url: '',
+        dagen_evenement: [
+            ['datum' => '2026-07-04', 'start' => '2026-07-04T16:00:00+02:00', 'eind' => '2026-07-05T02:00:00+02:00'],
+            ['datum' => '2026-07-05', 'start' => '2026-07-05T16:00:00+02:00', 'eind' => '2026-07-06T02:00:00+02:00'],
+        ],
+    );
+
+    $rijen = TijdenOverzicht::uitReferenceData($reference);
+
+    expect($rijen)->toHaveCount(2);
+    expect($rijen[0][0])->toContain('4 juli 2026');
+    expect($rijen[0][1])->toBe('16:00');
+    // A roll-over into the next morning stays visible.
+    expect($rijen[0][2])->toContain('5 juli');
+});
+
+test('een zaak zonder dagtijden valt terug op de start- en eindmomenten', function () {
+    $reference = new ZaakReferenceData(
+        start_evenement: '2026-07-04T16:00:00+02:00',
+        eind_evenement: '2026-07-04T23:00:00+02:00',
+        registratiedatum: '2026-06-01T10:00:00+02:00',
+        status_name: 'Ingediend',
+        statustype_url: '',
+    );
+
+    $rijen = TijdenOverzicht::uitReferenceData($reference);
+
+    expect($rijen)->toHaveCount(1);
+    expect($rijen[0][0])->toBe('Publiek');
+});


### PR DESCRIPTION
Closes WowebNL/eventloket-fase-2#24

An event carried a single start and end moment, so a multi-day event could not express when each individual day starts and ends. The same gap applied to the build-up (opbouw) and tear-down (afbouw) periods.

## What counts as multi-day

An end time in the small hours belongs to the evening before it, so an event running 16:00 to 02:00 stays a single-day event with a late finish. Only when the end moment passes 06:00 of the following morning does a period become genuinely multi-day. That rule lives in `EventDagen` and drives the form, the storage and every display.

A three-day event running 16:00 to 02:00 therefore yields three day rows, even though its end moment falls on the fourth calendar day.

## Approach

The two datetime pickers stay authoritative and unchanged. They remain the envelope that feeds the calendar, the case table, exports and the ZGW zaakeigenschappen, so nothing downstream had to move.

Below each pair a repeater now appears when the period is multi-day, with one generated row per day. Rows cannot be added or removed by hand, since they follow the date span above them. The first start time and the last end time mirror the envelope and are not separately editable, so a single moment can never have two conflicting sources. A day may run past midnight but must end by 06:00 and may not overlap the next day.

## Storage

Day times are stored as `dagen_evenement`, `dagen_opbouw` and `dagen_afbouw` on the reference data, including in the `toArray()` whitelist so a partial update of the case cannot silently drop them.

They are deliberately not synced to ZGW: the catalogus defines the six date eigenschappen as `datum_tijd` with kardinaliteit 1, which cannot hold a list. The detail still reaches the case through the submission PDF, which is stored as an informatieobject.

Cases without day times fall back to the existing pair everywhere, so no migration or backfill is needed. Existing drafts and copied applications get their day rows built when the form is opened.

## Display

The summary step, the submission PDF and the case infolist now read the times table from one shared source so they cannot drift apart. A roll-over into the next morning is spelled out ("02:00 (5 juli)") rather than left ambiguous. The day rows are suppressed as individual repeater entries in the summary and the PDF, since the table already covers them and the bare clock times would otherwise render as today's date.

## Also in this PR

The conflict check, which this feature makes more relevant, had three problems:

- it missed events that spanned the whole given window, because it only checked whether either end fell inside it;
- it compared ISO 8601 strings carrying a timezone offset as plain text on a JSON path;
- it capped the total at ten while showing that total to the organiser.

It now does a real overlap test on timestamps, returns an honest total alongside at most ten names, and leaves legacy rows with a non-ISO date out of the comparison instead of letting the cast fail.

## Not included

Splitting a multi-day event into one calendar entry per day is a follow-up. The calendar keeps showing a single block spanning the envelope, as agreed.