### PR TITLE
Hide the derived season field for a vooraankondiging too

### DIFF
--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\EventForm\Reporting;
 
+use App\EventForm\Schema\Steps\RisicoscanStep;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
-use App\EventForm\Submit\DetermineAanvraagType;
 use Carbon\Carbon;
 use Closure;
 use Filament\Forms\Components\CheckboxList;
@@ -46,12 +46,12 @@ use ReflectionObject;
 final class SubmissionReport
 {
     /**
-     * Fields that are present in the state (usually derived automatically) but
-     * do not belong in the summary or PDF of a melding.
+     * Fields of the risicoscan step that are present in the state (derived
+     * automatically) even when the organiser never gets to see that step.
      *
      * @var list<string>
      */
-    private const HIDDEN_FOR_MELDING = [
+    private const RISICOSCAN_DERIVED_KEYS = [
         'inWelkSeizoenVindtHetEvenementPlaats',
     ];
 
@@ -275,13 +275,13 @@ final class SubmissionReport
     }
 
     /**
-     * Whether this submission is a melding (and therefore not a permit
-     * application or a vooraankondiging), using the same determination as the
-     * zaaktype routing.
+     * Whether the organiser actually walked through the risicoscan step. Both
+     * a melding and a vooraankondiging skip it, so anything derived there is
+     * an artefact rather than an answer.
      */
-    private function isMelding(FormState $state): bool
+    private function heeftRisicoscanDoorlopen(FormState $state): bool
     {
-        return app(DetermineAanvraagType::class)->forState($state) === DetermineAanvraagType::MELDING;
+        return $state->isStepApplicable(RisicoscanStep::UUID);
     }
 
     /**
@@ -296,10 +296,10 @@ final class SubmissionReport
             return null;
         }
 
-        // A melding never fills in the risicoscan step, but the season field is
-        // derived automatically from the start date and would otherwise still
-        // show up in the summary and the PDF.
-        if (in_array($key, self::HIDDEN_FOR_MELDING, true) && $this->isMelding($state)) {
+        // A melding and a vooraankondiging both skip the risicoscan step, but
+        // the season field is derived automatically from the start date and
+        // would otherwise still show up in the summary and the PDF.
+        if (in_array($key, self::RISICOSCAN_DERIVED_KEYS, true) && ! $this->heeftRisicoscanDoorlopen($state)) {
             return null;
         }
 

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -228,6 +228,20 @@ test('Risicoscan: het seizoen-veld wordt bij een melding weggelaten uit samenvat
     expect($waarden)->not->toContain('Zomer of winter');
 });
 
+test('Risicoscan: het seizoen-veld wordt ook bij een vooraankondiging weggelaten', function () {
+    // Een vooraankondiging slaat de risicoscan-stap net zo goed over als een
+    // melding, dus het afgeleide seizoen-veld hoort daar evenmin te staan.
+    $state = new FormState(values: [
+        'waarvoorWiltUEventloketGebruiken' => 'vooraankondiging',
+        'inWelkSeizoenVindtHetEvenementPlaats' => '0.5',
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [RisicoscanStep::make()]);
+
+    $waarden = collect($sections)->flatMap(fn ($s) => collect($s['entries'])->pluck('value'))->all();
+    expect($waarden)->not->toContain('Zomer of winter');
+});
+
 test('Risicoscan: het seizoen-veld blijft bij een vergunning wel zichtbaar', function () {
     $state = new FormState(values: [
         // Vergunningpad (legacy): wegen afgesloten → Vergunning.


### PR DESCRIPTION
The season field (`inWelkSeizoenVindtHetEvenementPlaats`) is derived automatically from the start date, so it ends up in the form state even when the organiser never sees the risicoscan step. #483 suppressed it in the summary and the PDF, but scoped that to a melding only.

A vooraankondiging skips the risicoscan step just as a melding does, so the field kept surfacing there. Because the step then holds exactly one filled "answer", it also survives the rule that drops steps without filled fields, which is why a Risicoscan section showed up containing a single question the organiser was never asked.

## Change

The suppression is now tied to whether the risicoscan step applies at all, rather than to the submission type:

```php
if (in_array($key, self::RISICOSCAN_DERIVED_KEYS, true) && ! $this->heeftRisicoscanDoorlopen($state)) {
    return null;
}
```

`FormStepApplicability` already marks the step as not applicable for both the melding path and the vooraankondiging path, so one condition covers both and cannot drift again if another path ever skips the step. The constant is renamed accordingly, since it is no longer about meldingen.

The existing melding and vergunning tests are unchanged; a vooraankondiging case is added alongside them.