### PR TITLE
Convert a vooraankondiging into a definitive aanvraag

### DIFF
--- a/app/Enums/ZaakRelatieType.php
+++ b/app/Enums/ZaakRelatieType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Types a row in `zaak_relaties`. Every type fixes its own reading
+ * direction as a sentence: `zaak_id` (subject) performs the type (verb)
+ * on `gerelateerde_zaak_id` (object). A new type must document that
+ * direction (or explicit symmetry), its write location and its read
+ * location in the UI before it is introduced — otherwise this generic
+ * table grows the exact wild growth it is meant to prevent.
+ */
+enum ZaakRelatieType: string
+{
+    /**
+     * The definitive aanvraag (`zaak_id`) replaces the vooraankondiging
+     * (`gerelateerde_zaak_id`). Written on submit of an aanvraag that
+     * was linked to a vooraankondiging; read on both zaak screens and
+     * by the calendar filter that hides the replaced vooraankondiging.
+     */
+    case VervangtVooraankondiging = 'vervangt_vooraankondiging';
+}

--- a/app/EventForm/Persistence/Draft.php
+++ b/app/EventForm/Persistence/Draft.php
@@ -6,6 +6,7 @@ namespace App\EventForm\Persistence;
 
 use App\Models\Organisation;
 use App\Models\User;
+use App\Models\Zaak;
 use Illuminate\Database\Eloquent\Attributes\Scope;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -27,6 +28,7 @@ class Draft extends Model
     protected $fillable = [
         'user_id',
         'organisation_id',
+        'source_zaak_id',
         'state',
         'name',
         'current_step_key',
@@ -75,5 +77,16 @@ class Draft extends Model
     public function organisation(): BelongsTo
     {
         return $this->belongsTo(Organisation::class);
+    }
+
+    /**
+     * The zaak this concept was prefilled from ("Nieuwe aanvraag met deze
+     * gegevens" / "Definitieve aanvraag indienen"), null for a blank
+     * concept. The FK is nullOnDelete: a hard-deleted source zaak leaves
+     * the concept itself intact.
+     */
+    public function sourceZaak(): BelongsTo
+    {
+        return $this->belongsTo(Zaak::class, 'source_zaak_id');
     }
 }

--- a/app/EventForm/Persistence/DraftStore.php
+++ b/app/EventForm/Persistence/DraftStore.php
@@ -68,18 +68,23 @@ class DraftStore
     }
 
     /**
-     * Maak een nieuw concept aan. Een bestaand concept zonder ingevulde
-     * velden wordt hergebruikt zodat herhaald "Start nieuwe aanvraag"
-     * geen lege junk-rijen stapelt — behalve wanneer de nieuwe state
-     * zelf al gevuld is (prefill), dan is een eigen rij gewenst.
+     * Create a new concept. An existing concept without filled fields is
+     * reused so repeated "Start nieuwe aanvraag" clicks do not stack empty
+     * junk rows — except when the new state itself is already filled
+     * (prefill), in which case a dedicated row is wanted.
      *
-     * @throws DraftLimitReached wanneer MAX_DRAFTS is bereikt
+     * `$sourceZaakId` records which zaak the concept was prefilled from;
+     * callers must only pass an id whose ownership has been verified
+     * (PrefillLoader enforces the organisation guard).
+     *
+     * @throws DraftLimitReached when MAX_DRAFTS has been reached
      */
     public function create(
         User $user,
         Organisation $organisation,
         FormState $state,
         ?string $currentStepKey = null,
+        ?string $sourceZaakId = null,
     ): Draft {
         if ($state->fields() === []) {
             // In PHP filteren i.p.v. een JSON-query: een lege values-bag
@@ -103,6 +108,7 @@ class DraftStore
         return Draft::create([
             'user_id' => $user->id,
             'organisation_id' => $organisation->id,
+            'source_zaak_id' => $sourceZaakId,
             'state' => $state->toSnapshot(),
             'name' => $this->deriveName($state),
             'current_step_key' => $currentStepKey,

--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -7,6 +7,7 @@ namespace App\EventForm\Reporting;
 use App\EventForm\Schema\Steps\RisicoscanStep;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
 use App\EventForm\State\FormState;
 use Carbon\Carbon;
 use Closure;
@@ -77,6 +78,17 @@ final class SubmissionReport
 
         return $sections;
     }
+
+    /**
+     * Display-only fields that duplicate another entry in the report.
+     * The locked zaaknummer field mirrors the vooraankondiging select
+     * right above it, so the report keeps only the select entry.
+     *
+     * @var list<string>
+     */
+    private const DISPLAY_ONLY_KEYS = [
+        Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD,
+    ];
 
     /**
      * Velden die voor de TijdenStep al in de overzichts-tabel
@@ -176,6 +188,9 @@ final class SubmissionReport
                 if ($key !== '') {
                     if ($isTijdenStep && in_array($key, self::TIJDEN_TABEL_KEYS, true)) {
                         // Al in de tijden-tabel verwerkt; sla over.
+                        return;
+                    }
+                    if (in_array($key, self::DISPLAY_ONLY_KEYS, true)) {
                         return;
                     }
                     $fullKey = $keyPrefix === null ? $key : "{$keyPrefix}.{$key}";

--- a/app/EventForm/Schema/Steps/Vragenboom2Step.php
+++ b/app/EventForm/Schema/Steps/Vragenboom2Step.php
@@ -6,15 +6,19 @@ namespace App\EventForm\Schema\Steps;
 
 use App\EventForm\Components\JaNeeOptions;
 use App\EventForm\Schema\Label;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use Carbon\Carbon;
 use Closure;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\Radio;
+use Filament\Forms\Components\Select;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
-use Filament\Schemas\Components\Icon;
 use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Components\Wizard\Step;
-use Filament\Support\Icons\Heroicon;
 
 /**
  * @openforms-step-uuid ae44ab5b-c068-4ceb-b121-6e6907f78ef9
@@ -25,19 +29,67 @@ final class Vragenboom2Step
 {
     public const UUID = 'ae44ab5b-c068-4ceb-b121-6e6907f78ef9';
 
+    /** Existing Ja/Nee question "did you submit a vooraankondiging earlier?". */
+    public const HEEFT_VOORAANKONDIGING_FIELD = 'voordatUVerderGaatMetHetBeantwoordenVanDeVragenVoorUwEvenementWillenWeGraagWetenOfUEerderEenVooraankondigingHeeftIngevuldVoorDitEvenement';
+
+    /** Zaak UUID of the vooraankondiging the organiser links to this aanvraag. */
+    public const VOORAANKONDIGING_ZAAK_FIELD = 'welkeVooraankondigingHoortBijDezeAanvraag';
+
+    /** Locked display field carrying the public zaaknummer of that vooraankondiging. */
+    public const VOORAANKONDIGING_ZAAKNUMMER_FIELD = 'zaaknummerVanDeVooraankondiging';
+
     public static function make(): Step
     {
         return Step::make('Vergunningsaanvraag: soort')
             ->key(self::UUID)
             ->schema([
-                Radio::make('voordatUVerderGaatMetHetBeantwoordenVanDeVragenVoorUwEvenementWillenWeGraagWetenOfUEerderEenVooraankondigingHeeftIngevuldVoorDitEvenement')
+                // The whole vooraankondiging question is only shown when the
+                // organisation actually has a submitted vooraankondiging;
+                // without one there is nothing to link (issue #10, answer 7).
+                Radio::make(self::HEEFT_VOORAANKONDIGING_FIELD)
                     ->label('Voordat u verder gaat met het beantwoorden van de vragen voor uw evenement willen we graag weten of u eerder een vooraankondiging heeft ingevuld voor dit evenement?')
                     ->options(JaNeeOptions::OPTIONS)
                     ->required()
-                    ->belowContent([
-                        Icon::make(Heroicon::InformationCircle),
-                        'Op dit moment is het nog niet mogelijk om de gegevens uit de vooraankondiging over te nemen in de definitieve aanvraag. Deze functionaliteit wordt in 2026 gebouwd.',
-                    ]),
+                    ->live()
+                    ->visible(fn (): bool => self::organisationHasVooraankondiging())
+                    ->afterStateUpdated(function (Set $set, ?string $state): void {
+                        // "Nee" after an earlier "Ja" must also drop the
+                        // selection, otherwise the hidden values would still
+                        // link the vooraankondiging on submit.
+                        if ($state !== 'Ja') {
+                            $set(self::VOORAANKONDIGING_ZAAK_FIELD, null);
+                            $set(self::VOORAANKONDIGING_ZAAKNUMMER_FIELD, null);
+                        }
+                    }),
+                Select::make(self::VOORAANKONDIGING_ZAAK_FIELD)
+                    ->label('Welke vooraankondiging hoort bij dit evenement?')
+                    ->belowContent('Controleer of dit de juiste vooraankondiging is. Bij het indienen wordt uw aanvraag hieraan gekoppeld en vervangt de aanvraag de vooraankondiging in de evenementenagenda.')
+                    ->options(fn ($livewire): array => self::vooraankondigingOptions($livewire))
+                    ->required()
+                    ->live()
+                    ->visible(fn (Get $get): bool => $get(self::HEEFT_VOORAANKONDIGING_FIELD) === 'Ja' && self::organisationHasVooraankondiging())
+                    ->afterStateUpdated(fn (Set $set, ?string $state) => $set(self::VOORAANKONDIGING_ZAAKNUMMER_FIELD, self::zaaknummerFor($state)))
+                    ->afterStateHydrated(function (Select $component, Set $set, mixed $state, $livewire): void {
+                        // Date-based suggestion: with the event date filled and
+                        // exactly one vooraankondiging on that date, preselect
+                        // it. The organiser still confirms explicitly — the
+                        // field stays editable and the zaaknummer is shown.
+                        if (filled($state)) {
+                            return;
+                        }
+                        $suggestion = self::suggestedVooraankondiging($livewire);
+                        if ($suggestion instanceof Zaak) {
+                            $set(self::VOORAANKONDIGING_ZAAK_FIELD, $suggestion->id);
+                            $set(self::VOORAANKONDIGING_ZAAKNUMMER_FIELD, $suggestion->public_id);
+                        }
+                    }),
+                TextInput::make(self::VOORAANKONDIGING_ZAAKNUMMER_FIELD)
+                    ->label('Zaaknummer van de vooraankondiging')
+                    // disabled() makes it read-only for the organiser;
+                    // dehydrated() keeps the value in the submitted state.
+                    ->disabled()
+                    ->dehydrated()
+                    ->visible(fn (Get $get): bool => $get(self::HEEFT_VOORAANKONDIGING_FIELD) === 'Ja' && filled($get(self::VOORAANKONDIGING_ZAAK_FIELD)) && self::organisationHasVooraankondiging()),
                 TextInput::make('watIsTijdensDeHeleDuurVanUwEvenementWatIsDeNaamVanHetEvenementVergunningHetTotaalAantalAanwezigePersonenVanAlleDagenBijElkaarOpgeteld')
                     ->label(Label::render('Wat is tijdens de hele duur van uw evenement {{ watIsDeNaamVanHetEvenementVergunning }} het totaal aantal aanwezige personen van alle dagen bij elkaar opgeteld?'))
                     ->numeric()
@@ -223,5 +275,159 @@ final class Vragenboom2Step
                         return ! ($get('isUwEvenementToegankelijkVoorMensenMetEenBeperking') === 'Ja');
                     }),
             ]);
+    }
+
+    /**
+     * Whether the current organisation has at least one submitted
+     * vooraankondiging to link. Closed vooraankondigingen count too: in
+     * practice a vooraankondiging is usually already finished by the time
+     * the definitive aanvraag arrives (issue #10, answer 6), so filtering
+     * on an open status would hide exactly the normal case. One that
+     * already has a definitive aanvraag no longer counts, though — it
+     * cannot be linked a second time.
+     */
+    private static function organisationHasVooraankondiging(): bool
+    {
+        $tenant = Filament::getTenant();
+        if (! $tenant instanceof Organisation) {
+            return false;
+        }
+
+        return Zaak::query()
+            ->vooraankondigingen()
+            ->nogNietOpgevolgd()
+            ->where('organisation_id', $tenant->getKey())
+            ->exists();
+    }
+
+    /**
+     * Options for the vooraankondiging select, scoped to the current
+     * organisation and without any status filter (see above), excluding
+     * vooraankondigingen that already have a definitive aanvraag. Sorted
+     * with the best date match on top: vooraankondigingen on the entered
+     * event date first, then most recent first.
+     *
+     * @return array<string, string>
+     */
+    private static function vooraankondigingOptions($livewire): array
+    {
+        $eventDate = self::enteredEventDate($livewire);
+
+        $options = self::vooraankondigingenForTenant()
+            ->sortBy([
+                fn (Zaak $a, Zaak $b): int => (int) self::isOnDate($b, $eventDate) <=> (int) self::isOnDate($a, $eventDate),
+                fn (Zaak $a, Zaak $b): int => $b->created_at <=> $a->created_at,
+            ])
+            ->mapWithKeys(fn (Zaak $zaak): array => [$zaak->id => self::optionLabel($zaak, $eventDate)])
+            ->all();
+
+        // Outside a panel request there is no tenant — that is the report
+        // render (samenvatting/PDF via SubmissionReport's stub livewire)
+        // resolving this closure after submit, when the linked
+        // vooraankondiging is also already excluded by nogNietOpgevolgd().
+        // Resolve the selected value directly so the report shows its
+        // label instead of the raw UUID. Display-only: the selection
+        // itself is re-validated server-side at submit.
+        $selected = method_exists($livewire, 'state')
+            ? $livewire->state()->get(self::VOORAANKONDIGING_ZAAK_FIELD)
+            : null;
+        if (is_string($selected) && $selected !== '' && ! isset($options[$selected]) && Filament::getTenant() === null) {
+            $zaak = Zaak::query()->whereKey($selected)->first();
+            if ($zaak instanceof Zaak) {
+                $options[$selected] = self::optionLabel($zaak, $eventDate);
+            }
+        }
+
+        return $options;
+    }
+
+    private static function optionLabel(Zaak $zaak, ?Carbon $eventDate): string
+    {
+        $label = sprintf(
+            '%s — %s (%s)',
+            $zaak->public_id,
+            $zaak->reference_data->naam_evenement ?? 'evenement zonder naam',
+            $zaak->reference_data->start_evenement_datetime->format('d-m-Y'),
+        );
+        if (self::isOnDate($zaak, $eventDate)) {
+            $label .= ' — zelfde datum als deze aanvraag';
+        }
+
+        return $label;
+    }
+
+    /**
+     * The vooraankondiging to preselect: only when the event date is
+     * filled and exactly one vooraankondiging of the organisation starts
+     * on that date. Anything more ambiguous stays a manual choice.
+     */
+    private static function suggestedVooraankondiging($livewire): ?Zaak
+    {
+        $eventDate = self::enteredEventDate($livewire);
+        if ($eventDate === null) {
+            return null;
+        }
+
+        $matches = self::vooraankondigingenForTenant()
+            ->filter(fn (Zaak $zaak): bool => self::isOnDate($zaak, $eventDate));
+
+        return $matches->count() === 1 ? $matches->first() : null;
+    }
+
+    /** @return \Illuminate\Database\Eloquent\Collection<int, Zaak> */
+    private static function vooraankondigingenForTenant(): \Illuminate\Database\Eloquent\Collection
+    {
+        $tenant = Filament::getTenant();
+        if (! $tenant instanceof Organisation) {
+            return new \Illuminate\Database\Eloquent\Collection;
+        }
+
+        return Zaak::query()
+            ->vooraankondigingen()
+            ->nogNietOpgevolgd()
+            ->where('organisation_id', $tenant->getKey())
+            ->get();
+    }
+
+    /** The event start date the organiser entered earlier in the wizard, date-only. */
+    private static function enteredEventDate($livewire): ?Carbon
+    {
+        $raw = method_exists($livewire, 'state') ? $livewire->state()->get('EvenementStart') : null;
+        if (! is_string($raw) || $raw === '') {
+            return null;
+        }
+
+        try {
+            return Carbon::parse($raw)->startOfDay();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private static function isOnDate(Zaak $zaak, ?Carbon $date): bool
+    {
+        if ($date === null) {
+            return false;
+        }
+
+        return $zaak->reference_data->start_evenement_datetime->isSameDay($date);
+    }
+
+    /** Public zaaknummer for a selected vooraankondiging, ownership-scoped to the tenant. */
+    private static function zaaknummerFor(?string $zaakId): ?string
+    {
+        if (! is_string($zaakId) || $zaakId === '') {
+            return null;
+        }
+
+        $tenant = Filament::getTenant();
+        if (! $tenant instanceof Organisation) {
+            return null;
+        }
+
+        return Zaak::query()
+            ->whereKey($zaakId)
+            ->where('organisation_id', $tenant->getKey())
+            ->value('public_id');
     }
 }

--- a/app/EventForm/Schema/Steps/Vragenboom2Step.php
+++ b/app/EventForm/Schema/Steps/Vragenboom2Step.php
@@ -19,6 +19,7 @@ use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Components\Wizard\Step;
+use Illuminate\Database\Eloquent\Collection;
 
 /**
  * @openforms-step-uuid ae44ab5b-c068-4ceb-b121-6e6907f78ef9
@@ -374,12 +375,12 @@ final class Vragenboom2Step
         return $matches->count() === 1 ? $matches->first() : null;
     }
 
-    /** @return \Illuminate\Database\Eloquent\Collection<int, Zaak> */
-    private static function vooraankondigingenForTenant(): \Illuminate\Database\Eloquent\Collection
+    /** @return Collection<int, Zaak> */
+    private static function vooraankondigingenForTenant(): Collection
     {
         $tenant = Filament::getTenant();
         if (! $tenant instanceof Organisation) {
-            return new \Illuminate\Database\Eloquent\Collection;
+            return new Collection;
         }
 
         return Zaak::query()

--- a/app/EventForm/Submit/Steps/KoppelVooraankondiging.php
+++ b/app/EventForm/Submit/Steps/KoppelVooraankondiging.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Submit\Steps;
+
+use App\Enums\ZaakRelatieType;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\DetermineAanvraagType;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use App\Models\ZaakRelatie;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Synchronous submit step for issue #10: when the organiser linked a
+ * vooraankondiging to this aanvraag, write the typed relation row
+ * ("this aanvraag replaces that vooraankondiging").
+ *
+ * The form values come from the client, so everything is re-checked
+ * server-side: the link only applies on the vergunning path (answer 8),
+ * the source must belong to the same organisation and must actually be
+ * a vooraankondiging. A failing guard skips the link with a warning
+ * instead of failing the submit — the zaak already exists in ZGW at
+ * this point and a missing link is repairable, a lost aanvraag is not.
+ */
+final class KoppelVooraankondiging
+{
+    public function __construct(private readonly DetermineAanvraagType $determineAanvraagType) {}
+
+    public function execute(FormState $state, Zaak $zaak, Organisation $organisation): void
+    {
+        if ($state->get(Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD) !== 'Ja') {
+            return;
+        }
+
+        $bronId = $state->get(Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD);
+        if (! is_string($bronId) || $bronId === '') {
+            return;
+        }
+
+        // Only a vergunningaanvraag replaces a vooraankondiging; a melding
+        // or another vooraankondiging never gets the link (answer 8).
+        if ($this->determineAanvraagType->forState($state) !== DetermineAanvraagType::VERGUNNING) {
+            return;
+        }
+
+        if ($bronId === $zaak->id) {
+            return;
+        }
+
+        $bron = Zaak::query()
+            ->whereKey($bronId)
+            ->where('organisation_id', $organisation->id)
+            ->first();
+
+        if (! $bron instanceof Zaak) {
+            Log::warning('KoppelVooraankondiging: bron-zaak niet gevonden of niet van deze organisatie', [
+                'zaak_id' => $zaak->id,
+                'bron_zaak_id' => $bronId,
+                'organisation_id' => $organisation->id,
+            ]);
+
+            return;
+        }
+
+        if (! $bron->isVooraankondiging()) {
+            Log::warning('KoppelVooraankondiging: bron-zaak is geen vooraankondiging', [
+                'zaak_id' => $zaak->id,
+                'bron_zaak_id' => $bron->id,
+                'bron_zaaktype' => $bron->zaaktype?->name,
+            ]);
+
+            return;
+        }
+
+        // A vooraankondiging is replaced at most once. The form already
+        // excludes linked ones from the select; this catches a stale
+        // draft or a manipulated value racing a concurrent submit.
+        if ($bron->opgevolgdDoor()->exists()) {
+            Log::warning('KoppelVooraankondiging: vooraankondiging heeft al een definitieve aanvraag', [
+                'zaak_id' => $zaak->id,
+                'bron_zaak_id' => $bron->id,
+            ]);
+
+            return;
+        }
+
+        ZaakRelatie::query()->firstOrCreate([
+            'zaak_id' => $zaak->id,
+            'gerelateerde_zaak_id' => $bron->id,
+            'type' => ZaakRelatieType::VervangtVooraankondiging->value,
+        ]);
+    }
+}

--- a/app/EventForm/Submit/SubmitEventForm.php
+++ b/app/EventForm/Submit/SubmitEventForm.php
@@ -9,6 +9,7 @@ use App\EventForm\Persistence\DraftStore;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\Steps\CreateLocalZaak;
 use App\EventForm\Submit\Steps\CreateZaakInZGW;
+use App\EventForm\Submit\Steps\KoppelVooraankondiging;
 use App\Jobs\Submit\GenerateSubmissionPdf;
 use App\Jobs\Submit\HashIdentifyingAttributes;
 use App\Jobs\Submit\UploadFormBijlagenToZGW;
@@ -56,6 +57,7 @@ final class SubmitEventForm
         private readonly ResolveZaaktype $resolveZaaktype,
         private readonly CreateZaakInZGW $createZaakInZGW,
         private readonly CreateLocalZaak $createLocalZaak,
+        private readonly KoppelVooraankondiging $koppelVooraankondiging,
         private readonly DraftStore $draftStore,
     ) {}
 
@@ -80,6 +82,11 @@ final class SubmitEventForm
                 organisation: $organisation,
             );
         });
+
+        // 3b. Vooraankondiging linked in the form? Write the typed
+        //     zaak-relation (issue #10), with server-side re-checks on
+        //     ownership and aard inside the step itself.
+        $this->koppelVooraankondiging->execute($state, $zaak, $organisation);
 
         // 4. Het ingediende concept verwijderen; andere concepten van de
         //    gebruiker (parallelle aanvragen) blijven staan.

--- a/app/Filament/Organiser/Pages/EventFormDraftsPage.php
+++ b/app/Filament/Organiser/Pages/EventFormDraftsPage.php
@@ -9,9 +9,11 @@ use App\EventForm\Persistence\DraftLimitReached;
 use App\EventForm\Persistence\DraftStore;
 use App\EventForm\Persistence\PrefillLoader;
 use App\EventForm\Schema\EventFormSchema;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
 use App\EventForm\State\FormState;
 use App\Models\Organisation;
 use App\Models\User;
+use App\Models\Zaak;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
@@ -52,15 +54,31 @@ class EventFormDraftsPage extends Page implements HasTable
         $tenant = $this->tenant();
         $store = app(DraftStore::class);
 
+        $sourceZaakId = request()->query('prefill_from_zaak');
+
         $prefill = app(PrefillLoader::class)->load(
-            request()->query('prefill_from_zaak'),
+            $sourceZaakId,
             $user,
             $tenant,
         );
 
         if ($prefill instanceof FormState) {
+            // Same ownership guard as PrefillLoader: never trust the raw
+            // query param beyond the organisation of the current tenant.
+            $sourceZaak = Zaak::query()
+                ->where('id', $sourceZaakId)
+                ->where('organisation_id', $tenant->id)
+                ->first();
+
+            // No conversion presets for a vooraankondiging that already
+            // has a definitive aanvraag (the convert action is hidden
+            // then, but the URL can be crafted); plain prefill still works.
+            if ($sourceZaak?->isVooraankondiging() && $sourceZaak->opgevolgdDoor()->doesntExist()) {
+                $this->applyVooraankondigingConversion($prefill, $sourceZaak);
+            }
+
             try {
-                $draft = $store->create($user, $tenant, $prefill);
+                $draft = $store->create($user, $tenant, $prefill, sourceZaakId: $sourceZaak?->id);
             } catch (DraftLimitReached) {
                 $this->notifyLimitReachedForHergebruik();
 
@@ -172,6 +190,22 @@ class EventFormDraftsPage extends Page implements HasTable
     public static function getNavigationGroup(): ?string
     {
         return null;
+    }
+
+    /**
+     * "Definitieve aanvraag indienen" on a vooraankondiging: the copied
+     * snapshot still says the organiser wants a vooraankondiging, which
+     * would route the new aanvraag straight into the vooraankondiging
+     * path again. Flip that choice to a regular aanvraag and preset the
+     * link fields in Vragenboom2Step so the vooraankondiging is coupled
+     * and its zaaknummer shows up locked in the form.
+     */
+    private function applyVooraankondigingConversion(FormState $prefill, Zaak $vooraankondiging): void
+    {
+        $prefill->setVariable('waarvoorWiltUEventloketGebruiken', 'evenement');
+        $prefill->setVariable(Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD, 'Ja');
+        $prefill->setVariable(Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD, $vooraankondiging->id);
+        $prefill->setVariable(Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD, $vooraankondiging->public_id);
     }
 
     /** 1-based positie van een step-UUID in de wizard; onbekend/leeg = stap 1. */

--- a/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
+++ b/app/Filament/Organiser/Resources/Zaken/Pages/ViewZaak.php
@@ -25,16 +25,36 @@ class ViewZaak extends ViewRecord
     protected function getHeaderActions(): array
     {
         return [
-            // "Herhaal aanvraag" — start een nieuwe aanvraag voorgevuld met de
-            // gegevens van deze zaak. Landt op het concepten-overzicht, dat
-            // de prefill in een nieuw concept zet (bestaande concepten worden
-            // dus nooit overschreven). PrefillLoader valt stil terug op lege
-            // waarden voor velden die inmiddels uit het schema zijn.
+            // "Repeat aanvraag" — start a new aanvraag prefilled with the
+            // data of this zaak. Lands on the concepts overview, which puts
+            // the prefill in a new concept (existing concepts are never
+            // overwritten). PrefillLoader falls back silently to empty
+            // values for fields that have since left the schema.
+            // On a vooraankondiging the dedicated convert action below
+            // replaces this one.
             Action::make('prefil_new_request')
                 ->label('Nieuwe aanvraag met deze gegevens')
                 ->icon('heroicon-o-arrow-path-rounded-square')
                 ->tooltip('Start een nieuwe aanvraag waarbij de ingevulde gegevens uit deze zaak vooraf zijn ingevuld. U kunt alles aanpassen voordat u opnieuw indient.')
-                ->visible(fn (Zaak $record): bool => $record->form_state_snapshot !== null)
+                ->visible(fn (Zaak $record): bool => $record->form_state_snapshot !== null && ! $record->isVooraankondiging())
+                ->action(function (Zaak $record) {
+                    $this->redirect(EventFormDraftsPage::getUrl([
+                        'tenant' => Filament::getTenant(),
+                        'prefill_from_zaak' => $record->id,
+                    ]));
+                }),
+            // Convert a vooraankondiging into the definitive aanvraag
+            // (issue #10). Same prefill path; EventFormDraftsPage detects
+            // that the source is a vooraankondiging, flips the form to the
+            // regular aanvraag flow and presets the link fields so the
+            // zaaknummer is carried over into a locked field. Disappears
+            // once a definitive aanvraag is linked — a vooraankondiging
+            // is converted at most once.
+            Action::make('convert_vooraankondiging')
+                ->label('Definitieve aanvraag indienen')
+                ->icon('heroicon-o-arrow-right-circle')
+                ->tooltip('Start de definitieve aanvraag voor dit evenement. De gegevens uit uw vooraankondiging zijn vooraf ingevuld en het zaaknummer van de vooraankondiging wordt automatisch meegenomen.')
+                ->visible(fn (Zaak $record): bool => $record->form_state_snapshot !== null && $record->isVooraankondiging() && $record->opgevolgdDoor()->doesntExist())
                 ->action(function (Zaak $record) {
                     $this->redirect(EventFormDraftsPage::getUrl([
                         'tenant' => Filament::getTenant(),

--- a/app/Filament/Shared/Resources/Zaken/Schemas/ZaakInfolist.php
+++ b/app/Filament/Shared/Resources/Zaken/Schemas/ZaakInfolist.php
@@ -52,6 +52,25 @@ class ZaakInfolist
                 ->label(__('resources/zaak.columns.public_id.label')),
             TextEntry::make('zaaktype.name')
                 ->label(__('resources/zaak.columns.zaaktype.label')),
+            // Issue #10: show the vooraankondiging link in both directions.
+            // On the definitive aanvraag: which vooraankondiging it replaces;
+            // on the vooraankondiging: which aanvraag replaced it. Rendered
+            // in every panel that uses this schema (municipality, advisor,
+            // admin and, via the organiser infolist, the organiser).
+            TextEntry::make('vervangt_vooraankondiging')
+                ->label(__('resources/zaak.columns.vervangt_vooraankondiging.label'))
+                ->state(fn (Zaak $record): ?string => $record->vervangtVooraankondiging->first()?->public_id)
+                ->url(fn (Zaak $record): ?string => self::zaakViewUrl($record->vervangtVooraankondiging->first()))
+                ->color('primary')
+                ->icon('heroicon-o-link')
+                ->visible(fn (Zaak $record): bool => $record->vervangtVooraankondiging->isNotEmpty()),
+            TextEntry::make('opgevolgd_door')
+                ->label(__('resources/zaak.columns.opgevolgd_door.label'))
+                ->state(fn (Zaak $record): ?string => $record->opgevolgdDoor->first()?->public_id)
+                ->url(fn (Zaak $record): ?string => self::zaakViewUrl($record->opgevolgdDoor->first()))
+                ->color('primary')
+                ->icon('heroicon-o-link')
+                ->visible(fn (Zaak $record): bool => $record->opgevolgdDoor->isNotEmpty()),
             TextEntry::make('reference_data.risico_classificatie')
                 ->label(__('resources/zaak.columns.risico_classificatie.label'))
                 ->visible(fn ($state) => ! empty($state)),
@@ -549,5 +568,19 @@ class ZaakInfolist
 
                     ]),
             ]));
+    }
+
+    /**
+     * View URL for a related zaak, resolved via the current panel so the
+     * link stays inside the panel of the viewer (municipality, advisor,
+     * admin or organiser).
+     */
+    private static function zaakViewUrl(?Zaak $zaak): ?string
+    {
+        if (! $zaak instanceof Zaak) {
+            return null;
+        }
+
+        return Filament::getResourceUrl($zaak, 'view');
     }
 }

--- a/app/Filament/Shared/Widgets/CalendarWidget.php
+++ b/app/Filament/Shared/Widgets/CalendarWidget.php
@@ -3,6 +3,7 @@
 namespace App\Filament\Shared\Widgets;
 
 use App\Enums\Role;
+use App\Enums\ZaakRelatieType;
 use App\Filament\Shared\Exports\AdvisorEventExporter;
 use App\Filament\Shared\Exports\BaseEventExporter;
 use App\Filament\Shared\Exports\ExtendedEventExporter;
@@ -432,7 +433,34 @@ class CalendarWidget extends \Guava\Calendar\Filament\CalendarWidget implements 
 
         $this->applyHiddenResultaatTypesFilter($query);
 
+        $this->applyOmgezetteVooraankondigingenFilter($query);
+
         return $query;
+    }
+
+    /**
+     * Hide vooraankondigingen that have been replaced by a definitive
+     * aanvraag (issue #10): the aanvraag takes their place on the
+     * calendar. Deliberately a hard exclusion here and not a user filter
+     * in $this->filters — "Filters resetten" must never bring them back.
+     *
+     * The join re-checks `deleted_at` of the successor because `Zaak`
+     * soft-deletes: the FK cascade only fires on hard deletes, so without
+     * this check a soft-deleted aanvraag would keep its vooraankondiging
+     * hidden behind a zaak that no longer exists. The status or resultaat
+     * of either zaak is irrelevant on purpose: a closed vooraankondiging
+     * is the normal case, only the existence of the relation counts.
+     */
+    protected function applyOmgezetteVooraankondigingenFilter(Builder $query): void
+    {
+        $query->whereNotExists(function ($subQuery) {
+            $subQuery->select(DB::raw(1))
+                ->from('zaak_relaties')
+                ->join('zaken as opvolgers', 'opvolgers.id', '=', 'zaak_relaties.zaak_id')
+                ->whereColumn('zaak_relaties.gerelateerde_zaak_id', 'zaken.id')
+                ->where('zaak_relaties.type', ZaakRelatieType::VervangtVooraankondiging->value)
+                ->whereNull('opvolgers.deleted_at');
+        });
     }
 
     protected function applyHiddenResultaatTypesFilter(Builder $query)

--- a/app/Jobs/Submit/GenerateSubmissionPdf.php
+++ b/app/Jobs/Submit/GenerateSubmissionPdf.php
@@ -53,6 +53,12 @@ final class GenerateSubmissionPdf implements ShouldQueue
 
         $this->zaak->loadMissing(['zaaktype', 'organisation', 'organiserUser']);
 
+        // Issue #10: when this aanvraag replaces a vooraankondiging, the
+        // link is shown in the PDF header right below the zaaknummer. The
+        // relation is written synchronously during submit, before this
+        // job is dispatched, so it is available here.
+        $vervangtVooraankondiging = $this->zaak->vervangtVooraankondiging()->first()?->public_id;
+
         // Een aanvraag op persoonlijke titel hangt aan een organisatie met
         // de placeholder-naam "Mijn omgeving". Er is dan geen organisator
         // om te tonen — de aanvrager staat al op de regel eronder — dus
@@ -64,6 +70,7 @@ final class GenerateSubmissionPdf implements ShouldQueue
 
         $pdf = Pdf::loadView('pdf.submission-report', [
             'zaak' => $this->zaak,
+            'vervangtVooraankondiging' => $vervangtVooraankondiging,
             'organisatorNaam' => $organisatorNaam,
             'state' => $state,
             'sections' => $sections,

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Enums\AdviceStatus;
 use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\ZaakRelatieType;
 use App\Models\Threads\AdviceThread;
 use App\Models\Threads\OrganiserThread;
 use App\Models\Users\MunicipalityUser;
@@ -18,11 +19,14 @@ use App\ValueObjects\ZGW\Informatieobject;
 use Guava\Calendar\Contracts\Eventable;
 use Guava\Calendar\ValueObjects\CalendarEvent;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -119,6 +123,90 @@ class Zaak extends Model implements Eventable
             'zaaktype_id',
             'municipality_id'
         );
+    }
+
+    /**
+     * Generic typed relations where this zaak is the subject. Code outside
+     * the datamodel should use the named helpers per type (see
+     * vervangtVooraankondiging() / opgevolgdDoor()) instead of these.
+     *
+     * @return HasMany<ZaakRelatie, $this>
+     */
+    public function relaties(): HasMany
+    {
+        return $this->hasMany(ZaakRelatie::class, 'zaak_id');
+    }
+
+    /**
+     * Generic typed relations where this zaak is the object.
+     *
+     * @return HasMany<ZaakRelatie, $this>
+     */
+    public function inverseRelaties(): HasMany
+    {
+        return $this->hasMany(ZaakRelatie::class, 'gerelateerde_zaak_id');
+    }
+
+    /**
+     * The vooraankondiging(en) this zaak replaces: read on the definitive
+     * aanvraag. Functionally one-to-one, modelled through the generic
+     * relation table.
+     *
+     * @return BelongsToMany<Zaak, $this>
+     */
+    public function vervangtVooraankondiging(): BelongsToMany
+    {
+        return $this->belongsToMany(Zaak::class, 'zaak_relaties', 'zaak_id', 'gerelateerde_zaak_id')
+            ->wherePivot('type', ZaakRelatieType::VervangtVooraankondiging->value);
+    }
+
+    /**
+     * The definitive aanvraag that replaced this vooraankondiging. The
+     * related model carries SoftDeletes, so a soft-deleted successor is
+     * excluded automatically.
+     *
+     * @return BelongsToMany<Zaak, $this>
+     */
+    public function opgevolgdDoor(): BelongsToMany
+    {
+        return $this->belongsToMany(Zaak::class, 'zaak_relaties', 'gerelateerde_zaak_id', 'zaak_id')
+            ->wherePivot('type', ZaakRelatieType::VervangtVooraankondiging->value);
+    }
+
+    /**
+     * Whether this zaak is a vooraankondiging. Delegates to the zaaktype
+     * naming convention; single seam to swap for `zaaktypen.role` after
+     * the multi-ZGW branch (PR #482) is merged.
+     */
+    public function isVooraankondiging(): bool
+    {
+        return $this->zaaktype?->isVooraankondiging() ?? false;
+    }
+
+    /**
+     * @param  Builder<Zaak>  $query
+     * @return Builder<Zaak>
+     */
+    #[Scope]
+    protected function vooraankondigingen(Builder $query): Builder
+    {
+        return $query->whereHas('zaaktype', fn (Builder $q): Builder => $q->where('name', 'like', Zaaktype::VOORAANKONDIGING_NAME_PREFIX.'%'));
+    }
+
+    /**
+     * Only zaken without a (non-soft-deleted) replacing aanvraag. A
+     * vooraankondiging that already has a definitive aanvraag cannot be
+     * linked a second time; when that aanvraag is soft-deleted the
+     * vooraankondiging becomes linkable again, consistent with the
+     * calendar filter.
+     *
+     * @param  Builder<Zaak>  $query
+     * @return Builder<Zaak>
+     */
+    #[Scope]
+    protected function nogNietOpgevolgd(Builder $query): Builder
+    {
+        return $query->whereDoesntHave('opgevolgdDoor');
     }
 
     /**

--- a/app/Models/ZaakRelatie.php
+++ b/app/Models/ZaakRelatie.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use App\Enums\ZaakRelatieType;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use InvalidArgumentException;
+
+/**
+ * A typed, directed relation between two zaken. The direction is fixed
+ * per type (see ZaakRelatieType): `zaak_id` is the subject that performs
+ * the type on `gerelateerde_zaak_id`. Code outside the datamodel should
+ * talk to the named helpers on `Zaak` (vervangtVooraankondiging(),
+ * opgevolgdDoor()) instead of querying this model directly.
+ *
+ * @property ZaakRelatieType $type
+ */
+class ZaakRelatie extends Model
+{
+    use HasFactory;
+
+    protected $table = 'zaak_relaties';
+
+    protected $fillable = [
+        'zaak_id',
+        'gerelateerde_zaak_id',
+        'type',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'type' => ZaakRelatieType::class,
+        ];
+    }
+
+    protected static function booted(): void
+    {
+        // Mirrors the database CHECK constraint, but fails with a clear
+        // message before a query is attempted.
+        static::saving(function (ZaakRelatie $relatie): void {
+            if ($relatie->zaak_id === $relatie->gerelateerde_zaak_id) {
+                throw new InvalidArgumentException('Een zaak kan geen relatie met zichzelf hebben.');
+            }
+        });
+    }
+
+    /** @return BelongsTo<Zaak, $this> */
+    public function zaak(): BelongsTo
+    {
+        return $this->belongsTo(Zaak::class, 'zaak_id');
+    }
+
+    /** @return BelongsTo<Zaak, $this> */
+    public function gerelateerdeZaak(): BelongsTo
+    {
+        return $this->belongsTo(Zaak::class, 'gerelateerde_zaak_id');
+    }
+}

--- a/app/Models/Zaaktype.php
+++ b/app/Models/Zaaktype.php
@@ -18,6 +18,15 @@ class Zaaktype extends Model
 {
     use HasFactory, HasUuids;
 
+    /**
+     * Name prefix that identifies a vooraankondiging zaaktype. The "aard"
+     * of a zaaktype is a naming convention on `main` (same convention as
+     * ResolveZaaktype); keep every aard check behind isVooraankondiging()
+     * so it can be replaced in one place by the `zaaktypen.role` column
+     * once the multi-ZGW branch (PR #482) lands.
+     */
+    public const VOORAANKONDIGING_NAME_PREFIX = 'Vooraankondiging';
+
     protected $table = 'zaaktypen';
 
     protected $fillable = [
@@ -39,6 +48,11 @@ class Zaaktype extends Model
     public function zaken(): HasMany
     {
         return $this->hasMany(Zaak::class);
+    }
+
+    public function isVooraankondiging(): bool
+    {
+        return str_starts_with($this->name ?? '', self::VOORAANKONDIGING_NAME_PREFIX);
     }
 
     /** @return BelongsTo<Municipality, $this> */

--- a/database/factories/ZaakRelatieFactory.php
+++ b/database/factories/ZaakRelatieFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ZaakRelatieType;
+use App\Models\Zaak;
+use App\Models\ZaakRelatie;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ZaakRelatie>
+ */
+class ZaakRelatieFactory extends Factory
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'zaak_id' => Zaak::factory(),
+            'gerelateerde_zaak_id' => Zaak::factory(),
+            'type' => ZaakRelatieType::VervangtVooraankondiging,
+        ];
+    }
+}

--- a/database/migrations/2026_08_14_144454_create_zaak_relaties_table.php
+++ b/database/migrations/2026_08_14_144454_create_zaak_relaties_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Generic, typed relation table between two zaken. The reading
+     * direction is fixed per type (see ZaakRelatieType): `zaak_id` is the
+     * subject, `gerelateerde_zaak_id` the object. First consumer is the
+     * "vervangt_vooraankondiging" relation of issue #10.
+     *
+     * `cascadeOnDelete` only fires on hard deletes; `Zaak` uses soft
+     * deletes, so readers that must ignore relations to a soft-deleted
+     * zaak (e.g. the calendar filter) have to check `deleted_at` of the
+     * related zaak themselves.
+     */
+    public function up(): void
+    {
+        Schema::create('zaak_relaties', function (Blueprint $table) {
+            $table->id();
+            $table->foreignUuid('zaak_id')->constrained('zaken')->cascadeOnDelete();
+            $table->foreignUuid('gerelateerde_zaak_id')->constrained('zaken')->cascadeOnDelete();
+            $table->string('type');
+            $table->timestamps();
+
+            $table->unique(['zaak_id', 'gerelateerde_zaak_id', 'type']);
+            $table->index(['gerelateerde_zaak_id', 'type']);
+        });
+
+        // Self-reference guard at the database level; the model repeats
+        // this check so a violation fails early with a clear message.
+        DB::statement('ALTER TABLE zaak_relaties ADD CONSTRAINT zaak_relaties_no_self_reference CHECK (zaak_id <> gerelateerde_zaak_id)');
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('zaak_relaties');
+    }
+};

--- a/database/migrations/2026_08_14_144456_add_source_zaak_id_to_event_form_drafts_table.php
+++ b/database/migrations/2026_08_14_144456_add_source_zaak_id_to_event_form_drafts_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Persist the origin of a prefilled concept ("Nieuwe aanvraag met
+     * deze gegevens" / "Definitieve aanvraag indienen"). Before this the
+     * only trace of the source zaak was the transient `?bron=hergebruik`
+     * query param, so at submit time nobody could tell which zaak a
+     * concept was created from.
+     */
+    public function up(): void
+    {
+        Schema::table('event_form_drafts', function (Blueprint $table) {
+            $table->foreignUuid('source_zaak_id')->nullable()->after('organisation_id')->constrained('zaken')->nullOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('event_form_drafts', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('source_zaak_id');
+        });
+    }
+};

--- a/lang/nl/resources/zaak.php
+++ b/lang/nl/resources/zaak.php
@@ -89,6 +89,12 @@ return [
         'eind_afbouw' => [
             'label' => 'Eind afbouw',
         ],
+        'vervangt_vooraankondiging' => [
+            'label' => 'Vervangt vooraankondiging',
+        ],
+        'opgevolgd_door' => [
+            'label' => 'Opgevolgd door',
+        ],
     ],
     'filters' => [
         'workingstock' => [

--- a/resources/views/pdf/submission-report.blade.php
+++ b/resources/views/pdf/submission-report.blade.php
@@ -35,6 +35,9 @@
     <h1>Aanvraagformulier {{ $naamEvenement }}</h1>
     <div class="meta">
         <div><strong>Zaaknummer:</strong> {{ $zaak->public_id }}</div>
+        @if (! empty($vervangtVooraankondiging))
+            <div><strong>Vervangt vooraankondiging:</strong> {{ $vervangtVooraankondiging }}</div>
+        @endif
         @if (! empty($risicoClassificatie))
             <div><strong>Risicoclassificatie:</strong> {{ $risicoClassificatie }}</div>
         @endif

--- a/tests/Feature/EventForm/Pages/EventFormDraftsPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormDraftsPageTest.php
@@ -170,3 +170,74 @@ test('prefill_from_zaak blokkeert met een melding wanneer het maximum is bereikt
 
     expect(Draft::ownedBy($this->user, $this->organisation)->count())->toBe(DraftStore::MAX_DRAFTS);
 });
+
+/**
+ * Issue #10: "Definitieve aanvraag indienen" on a vooraankondiging. The
+ * prefill flow detects that the source zaak is a vooraankondiging, flips
+ * the form to the regular aanvraag flow, presets the link fields and
+ * records the origin on the concept.
+ */
+function vooraankondigingMetSnapshotVoor(User $user, Organisation $organisation, array $values): Zaak
+{
+    $municipality = Municipality::factory()->create();
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $municipality->id,
+        'name' => 'Vooraankondiging gemeente Test',
+        'is_active' => true,
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => $organisation->id,
+        'organiser_user_id' => $user->id,
+        'form_state_snapshot' => ['values' => $values, 'system' => []],
+    ]);
+}
+
+test('prefill_from_zaak legt de bron-zaak vast op het nieuwe concept', function () {
+    $zaak = zaakMetSnapshotVoor($this->user, $this->organisation, [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest 2027',
+    ]);
+
+    Livewire::withQueryParams(['prefill_from_zaak' => $zaak->id])
+        ->test(EventFormDraftsPage::class);
+
+    expect(Draft::ownedBy($this->user, $this->organisation)->sole()->source_zaak_id)->toBe($zaak->id);
+});
+
+test('prefill vanaf een vooraankondiging zet de omzettings-presets in het concept', function () {
+    $vooraankondiging = vooraankondigingMetSnapshotVoor($this->user, $this->organisation, [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Kermis 2027',
+        'waarvoorWiltUEventloketGebruiken' => 'vooraankondiging',
+    ]);
+
+    Livewire::withQueryParams(['prefill_from_zaak' => $vooraankondiging->id])
+        ->test(EventFormDraftsPage::class);
+
+    $draft = Draft::ownedBy($this->user, $this->organisation)->sole();
+    $state = FormState::fromSnapshot($draft->state);
+
+    expect($draft->source_zaak_id)->toBe($vooraankondiging->id)
+        // The copied snapshot said "vooraankondiging"; without this flip
+        // the organiser would file a second vooraankondiging instead of
+        // the definitive aanvraag.
+        ->and($state->get('waarvoorWiltUEventloketGebruiken'))->toBe('evenement')
+        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBe('Ja')
+        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBe($vooraankondiging->id)
+        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD))->toBe($vooraankondiging->public_id);
+});
+
+test('prefill vanaf een gewone zaak zet geen omzettings-presets', function () {
+    $zaak = zaakMetSnapshotVoor($this->user, $this->organisation, [
+        'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest 2027',
+        'waarvoorWiltUEventloketGebruiken' => 'evenement',
+    ]);
+
+    Livewire::withQueryParams(['prefill_from_zaak' => $zaak->id])
+        ->test(EventFormDraftsPage::class);
+
+    $state = FormState::fromSnapshot(Draft::ownedBy($this->user, $this->organisation)->sole()->state);
+
+    expect($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBeNull()
+        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBeNull();
+});

--- a/tests/Feature/EventForm/Pages/EventFormDraftsPageTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormDraftsPageTest.php
@@ -7,6 +7,7 @@ use App\EventForm\Persistence\Draft;
 use App\EventForm\Persistence\DraftStore;
 use App\EventForm\Schema\EventFormSchema;
 use App\EventForm\Schema\Steps\TijdenStep;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
 use App\EventForm\State\FormState;
 use App\Filament\Organiser\Pages\EventFormDraftsPage;
 use App\Filament\Organiser\Pages\EventFormPage;
@@ -222,9 +223,9 @@ test('prefill vanaf een vooraankondiging zet de omzettings-presets in het concep
         // the organiser would file a second vooraankondiging instead of
         // the definitive aanvraag.
         ->and($state->get('waarvoorWiltUEventloketGebruiken'))->toBe('evenement')
-        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBe('Ja')
-        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBe($vooraankondiging->id)
-        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD))->toBe($vooraankondiging->public_id);
+        ->and($state->get(Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBe('Ja')
+        ->and($state->get(Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBe($vooraankondiging->id)
+        ->and($state->get(Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD))->toBe($vooraankondiging->public_id);
 });
 
 test('prefill vanaf een gewone zaak zet geen omzettings-presets', function () {
@@ -238,6 +239,6 @@ test('prefill vanaf een gewone zaak zet geen omzettings-presets', function () {
 
     $state = FormState::fromSnapshot(Draft::ownedBy($this->user, $this->organisation)->sole()->state);
 
-    expect($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBeNull()
-        ->and($state->get(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBeNull();
+    expect($state->get(Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD))->toBeNull()
+        ->and($state->get(Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD))->toBeNull();
 });

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -28,7 +28,12 @@ use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
 use App\EventForm\Schema\Steps\RisicoscanStep;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
 use App\EventForm\State\FormState;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
 use Filament\Forms\Components\Radio;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\TextInput;
@@ -581,26 +586,26 @@ test('the internal brkGemeente of an address does not leak into the report', fun
 });
 
 test('vooraankondiging-koppeling: alleen de select-regel, met opgelost label, zonder zaaknummer-duplicaat', function () {
-    $municipality = \App\Models\Municipality::factory()->create();
-    $vooraankondiging = \App\Models\Zaak::factory()->create([
+    $municipality = Municipality::factory()->create();
+    $vooraankondiging = Zaak::factory()->create([
         'public_id' => 'ZAAK-VA-9',
-        'zaaktype_id' => \App\Models\Zaaktype::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->create([
             'name' => 'Vooraankondiging gemeente Test',
             'municipality_id' => $municipality->id,
         ])->id,
-        'organisation_id' => \App\Models\Organisation::factory()->create()->id,
+        'organisation_id' => Organisation::factory()->create()->id,
     ]);
 
     $state = new FormState(values: [
-        \App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD => 'Ja',
-        \App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD => $vooraankondiging->id,
-        \App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD => 'ZAAK-VA-9',
+        Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD => 'Ja',
+        Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD => $vooraankondiging->id,
+        Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD => 'ZAAK-VA-9',
     ]);
 
     // No Filament panel/tenant here — exactly the context of the PDF
     // render in the queue, where the options closure must fall back to
     // the selected zaak itself.
-    $sections = app(SubmissionReport::class)->build($state, [\App\EventForm\Schema\Steps\Vragenboom2Step::make()]);
+    $sections = app(SubmissionReport::class)->build($state, [Vragenboom2Step::make()]);
 
     expect($sections)->toHaveCount(1);
 

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -579,3 +579,38 @@ test('the internal brkGemeente of an address does not leak into the report', fun
         ->and($flat)->not->toContain('GM0882')
         ->and($flat)->not->toContain('brkGemeente');
 });
+
+test('vooraankondiging-koppeling: alleen de select-regel, met opgelost label, zonder zaaknummer-duplicaat', function () {
+    $municipality = \App\Models\Municipality::factory()->create();
+    $vooraankondiging = \App\Models\Zaak::factory()->create([
+        'public_id' => 'ZAAK-VA-9',
+        'zaaktype_id' => \App\Models\Zaaktype::factory()->create([
+            'name' => 'Vooraankondiging gemeente Test',
+            'municipality_id' => $municipality->id,
+        ])->id,
+        'organisation_id' => \App\Models\Organisation::factory()->create()->id,
+    ]);
+
+    $state = new FormState(values: [
+        \App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD => 'Ja',
+        \App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD => $vooraankondiging->id,
+        \App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAKNUMMER_FIELD => 'ZAAK-VA-9',
+    ]);
+
+    // No Filament panel/tenant here — exactly the context of the PDF
+    // render in the queue, where the options closure must fall back to
+    // the selected zaak itself.
+    $sections = app(SubmissionReport::class)->build($state, [\App\EventForm\Schema\Steps\Vragenboom2Step::make()]);
+
+    expect($sections)->toHaveCount(1);
+
+    $labels = array_column($sections[0]['entries'], 'label');
+    $values = array_column($sections[0]['entries'], 'value');
+
+    // The locked zaaknummer field duplicates the select entry and stays
+    // out of the report; the select entry shows the resolved label, not
+    // the raw UUID.
+    expect($labels)->not->toContain('Zaaknummer van de vooraankondiging')
+        ->and(implode(' ', $values))->toContain('ZAAK-VA-9')
+        ->and(implode(' ', $values))->not->toContain($vooraankondiging->id);
+});

--- a/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
+++ b/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
@@ -231,3 +231,53 @@ test('toont de organisatienaam als organisator bij een zakelijke aanvraag', func
     expect($tekst)->toContain('Organisator:')
         ->and($tekst)->toContain('Media Tuin');
 });
+
+test('toont de vervangen vooraankondiging in de header onder het zaaknummer (issue #10)', function () {
+    $municipality = \App\Models\Municipality::factory()->create();
+    $organisation = Organisation::factory()->create(['type' => OrganisationType::Business, 'name' => 'Media Tuin']);
+
+    $vooraankondiging = Zaak::factory()->create([
+        'public_id' => 'ZAAK-VA-1',
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'name' => 'Vooraankondiging gemeente Test',
+            'municipality_id' => $municipality->id,
+        ])->id,
+        'organisation_id' => $organisation->id,
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'public_id' => 'ZAAK-DEF-1',
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'name' => 'Evenementenvergunning gemeente Test',
+            'municipality_id' => $municipality->id,
+        ])->id,
+        'organisation_id' => $organisation->id,
+        'form_state_snapshot' => (new FormState(values: [
+            'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest Testlaan',
+        ]))->toSnapshot(),
+    ]);
+
+    \App\Models\ZaakRelatie::create([
+        'zaak_id' => $zaak->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => \App\Enums\ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    Queue::fake();
+
+    (new GenerateSubmissionPdf($zaak))->handle();
+
+    $tekst = tekstUitPdf(Storage::disk('local')->get("zaken/{$zaak->id}/aanvraagformulier.pdf"));
+
+    expect($tekst)->toContain('Vervangt vooraankondiging:')
+        ->and($tekst)->toContain('ZAAK-VA-1');
+});
+
+test('laat de vooraankondiging-regel weg zonder gekoppelde vooraankondiging', function () {
+    $tekst = pdfVoorOrganisatie([
+        'type' => OrganisationType::Business,
+        'name' => 'Media Tuin',
+    ], 'Noah', 'Vermeulen');
+
+    expect($tekst)->not->toContain('Vervangt vooraankondiging:');
+});

--- a/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
+++ b/tests/Feature/EventForm/Submit/GenerateSubmissionPdfTest.php
@@ -19,12 +19,15 @@
 
 use App\Enums\OrganisationType;
 use App\Enums\Role;
+use App\Enums\ZaakRelatieType;
 use App\EventForm\State\FormState;
 use App\Jobs\Submit\GenerateSubmissionPdf;
 use App\Jobs\Submit\SendSubmissionConfirmationEmail;
+use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
+use App\Models\ZaakRelatie;
 use App\Models\Zaaktype;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Illuminate\Support\Facades\Queue;
@@ -233,7 +236,7 @@ test('toont de organisatienaam als organisator bij een zakelijke aanvraag', func
 });
 
 test('toont de vervangen vooraankondiging in de header onder het zaaknummer (issue #10)', function () {
-    $municipality = \App\Models\Municipality::factory()->create();
+    $municipality = Municipality::factory()->create();
     $organisation = Organisation::factory()->create(['type' => OrganisationType::Business, 'name' => 'Media Tuin']);
 
     $vooraankondiging = Zaak::factory()->create([
@@ -257,10 +260,10 @@ test('toont de vervangen vooraankondiging in de header onder het zaaknummer (iss
         ]))->toSnapshot(),
     ]);
 
-    \App\Models\ZaakRelatie::create([
+    ZaakRelatie::create([
         'zaak_id' => $zaak->id,
         'gerelateerde_zaak_id' => $vooraankondiging->id,
-        'type' => \App\Enums\ZaakRelatieType::VervangtVooraankondiging,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
     ]);
 
     Queue::fake();

--- a/tests/Feature/EventForm/Submit/KoppelVooraankondigingTest.php
+++ b/tests/Feature/EventForm/Submit/KoppelVooraankondigingTest.php
@@ -1,0 +1,216 @@
+<?php
+
+/**
+ * Server-side re-checks of the vooraankondiging link on submit
+ * (issue #10). The form values come from the client, so the step must
+ * only write the relation when:
+ *   - the organiser answered "Ja" and selected a vooraankondiging,
+ *   - the aanvraag resolves to the vergunning path (answer 8),
+ *   - the source belongs to the same organisation,
+ *   - the source actually is a vooraankondiging.
+ * A failing guard skips the link without failing the submit.
+ */
+
+use App\Enums\ZaakRelatieType;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\Steps\KoppelVooraankondiging;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use App\Models\ZaakRelatie;
+use App\Models\Zaaktype;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function koppelScenario(string $bronZaaktypeNaam = 'Vooraankondiging gemeente Heerlen', ?Organisation $bronOrganisation = null): array
+{
+    $organisation = Organisation::factory()->create();
+    $municipality = Municipality::factory()->create();
+
+    $bron = Zaak::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'municipality_id' => $municipality->id,
+            'name' => $bronZaaktypeNaam,
+            'is_active' => true,
+        ])->id,
+        'organisation_id' => ($bronOrganisation ?? $organisation)->id,
+    ]);
+
+    $aanvraag = Zaak::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'municipality_id' => $municipality->id,
+            'name' => 'Evenementenvergunning gemeente Heerlen',
+            'is_active' => true,
+        ])->id,
+        'organisation_id' => $organisation->id,
+    ]);
+
+    return compact('organisation', 'bron', 'aanvraag');
+}
+
+function vergunningStateMetKoppeling(?string $bronId, string $heeftVooraankondiging = 'Ja'): FormState
+{
+    return new FormState(values: [
+        // Legacy path resolving to a vergunningaanvraag.
+        'waarvoorWiltUEventloketGebruiken' => 'evenement',
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+        Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD => $heeftVooraankondiging,
+        Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD => $bronId,
+    ]);
+}
+
+test('schrijft de relatie bij een gekoppelde vooraankondiging op het vergunningpad', function () {
+    $sc = koppelScenario();
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    $relatie = ZaakRelatie::sole();
+    expect($relatie->zaak_id)->toBe($sc['aanvraag']->id)
+        ->and($relatie->gerelateerde_zaak_id)->toBe($sc['bron']->id)
+        ->and($relatie->type)->toBe(ZaakRelatieType::VervangtVooraankondiging);
+});
+
+test('is idempotent bij een tweede aanroep', function () {
+    $sc = koppelScenario();
+    $state = vergunningStateMetKoppeling($sc['bron']->id);
+
+    app(KoppelVooraankondiging::class)->execute($state, $sc['aanvraag'], $sc['organisation']);
+    app(KoppelVooraankondiging::class)->execute($state, $sc['aanvraag'], $sc['organisation']);
+
+    expect(ZaakRelatie::count())->toBe(1);
+});
+
+test('koppelt ook wanneer de vooraankondiging al is afgesloten', function () {
+    // Answer 6: in practice the vooraankondiging is usually already
+    // finished by the time the definitive aanvraag arrives; a resultaat
+    // must not block the link.
+    $sc = koppelScenario();
+    $referenceData = $sc['bron']->reference_data->toArray();
+    $referenceData['resultaat'] = 'Afgehandeld';
+    $sc['bron']->update(['reference_data' => new App\ValueObjects\ModelAttributes\ZaakReferenceData(...$referenceData)]);
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(1);
+});
+
+test('koppelt niet wanneer de organisator "Nee" heeft geantwoord', function () {
+    $sc = koppelScenario();
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id, heeftVooraankondiging: 'Nee'),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('koppelt niet op het meldingpad', function () {
+    // Answer 8: only a vergunningaanvraag replaces a vooraankondiging.
+    $sc = koppelScenario();
+
+    $state = new FormState(values: [
+        'waarvoorWiltUEventloketGebruiken' => 'evenement',
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Nee', // melding
+        Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD => 'Ja',
+        Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD => $sc['bron']->id,
+    ]);
+
+    app(KoppelVooraankondiging::class)->execute($state, $sc['aanvraag'], $sc['organisation']);
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('koppelt niet aan een zaak van een andere organisatie', function () {
+    $sc = koppelScenario(bronOrganisation: Organisation::factory()->create());
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('koppelt niet aan een bron die geen vooraankondiging is', function () {
+    $sc = koppelScenario(bronZaaktypeNaam: 'Melding evenement gemeente Heerlen');
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('koppelt niet zonder geselecteerde vooraankondiging', function () {
+    $sc = koppelScenario();
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling(null),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('koppelt niet aan een vooraankondiging die al een definitieve aanvraag heeft', function () {
+    $sc = koppelScenario();
+
+    // An earlier definitive aanvraag already replaced this vooraankondiging.
+    $eerdereAanvraag = Zaak::factory()->create([
+        'zaaktype_id' => $sc['aanvraag']->zaaktype_id,
+        'organisation_id' => $sc['organisation']->id,
+    ]);
+    ZaakRelatie::create([
+        'zaak_id' => $eerdereAanvraag->id,
+        'gerelateerde_zaak_id' => $sc['bron']->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::count())->toBe(1)
+        ->and(ZaakRelatie::sole()->zaak_id)->toBe($eerdereAanvraag->id);
+});
+
+test('koppelt wél opnieuw wanneer de eerdere opvolger soft-deleted is', function () {
+    $sc = koppelScenario();
+
+    $eerdereAanvraag = Zaak::factory()->create([
+        'zaaktype_id' => $sc['aanvraag']->zaaktype_id,
+        'organisation_id' => $sc['organisation']->id,
+    ]);
+    ZaakRelatie::create([
+        'zaak_id' => $eerdereAanvraag->id,
+        'gerelateerde_zaak_id' => $sc['bron']->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+    $eerdereAanvraag->delete();
+
+    app(KoppelVooraankondiging::class)->execute(
+        vergunningStateMetKoppeling($sc['bron']->id),
+        $sc['aanvraag'],
+        $sc['organisation'],
+    );
+
+    expect(ZaakRelatie::where('zaak_id', $sc['aanvraag']->id)->count())->toBe(1);
+});

--- a/tests/Feature/EventForm/Submit/KoppelVooraankondigingTest.php
+++ b/tests/Feature/EventForm/Submit/KoppelVooraankondigingTest.php
@@ -20,6 +20,7 @@ use App\Models\Organisation;
 use App\Models\Zaak;
 use App\Models\ZaakRelatie;
 use App\Models\Zaaktype;
+use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 uses(RefreshDatabase::class);
@@ -93,7 +94,7 @@ test('koppelt ook wanneer de vooraankondiging al is afgesloten', function () {
     $sc = koppelScenario();
     $referenceData = $sc['bron']->reference_data->toArray();
     $referenceData['resultaat'] = 'Afgehandeld';
-    $sc['bron']->update(['reference_data' => new App\ValueObjects\ModelAttributes\ZaakReferenceData(...$referenceData)]);
+    $sc['bron']->update(['reference_data' => new ZaakReferenceData(...$referenceData)]);
 
     app(KoppelVooraankondiging::class)->execute(
         vergunningStateMetKoppeling($sc['bron']->id),

--- a/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
+++ b/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
@@ -24,7 +24,9 @@
 
 use App\Enums\OrganisationRole;
 use App\Enums\Role;
+use App\Enums\ZaakRelatieType;
 use App\EventForm\Persistence\Draft;
+use App\EventForm\Schema\Steps\Vragenboom2Step;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\SubmitEventForm;
 use App\Jobs\Submit\GenerateSubmissionPdf;
@@ -41,6 +43,7 @@ use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Users\OrganiserUser;
 use App\Models\Zaak;
+use App\Models\ZaakRelatie;
 use App\Models\Zaaktype;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Bus;
@@ -261,7 +264,7 @@ test('een gekoppelde vooraankondiging krijgt bij submit de vervangt-relatie (iss
     fakeOpenzaakZaakCreate();
 
     $vooraankondiging = Zaak::factory()->create([
-        'zaaktype_id' => \App\Models\Zaaktype::factory()->create([
+        'zaaktype_id' => Zaaktype::factory()->create([
             'name' => 'Vooraankondiging gemeente Heerlen',
             'municipality_id' => $sc['heerlen']->id,
             'is_active' => true,
@@ -269,16 +272,16 @@ test('een gekoppelde vooraankondiging krijgt bij submit de vervangt-relatie (iss
         'organisation_id' => $sc['organisation']->id,
     ]);
 
-    $sc['state']->setField(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD, 'Ja');
-    $sc['state']->setField(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD, $vooraankondiging->id);
+    $sc['state']->setField(Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD, 'Ja');
+    $sc['state']->setField(Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD, $vooraankondiging->id);
 
     Bus::fake();
 
     $zaak = app(SubmitEventForm::class)->execute($sc['state'], $sc['user'], $sc['organisation']);
 
-    $relatie = \App\Models\ZaakRelatie::sole();
+    $relatie = ZaakRelatie::sole();
     expect($relatie->zaak_id)->toBe($zaak->id)
         ->and($relatie->gerelateerde_zaak_id)->toBe($vooraankondiging->id)
-        ->and($relatie->type)->toBe(\App\Enums\ZaakRelatieType::VervangtVooraankondiging)
+        ->and($relatie->type)->toBe(ZaakRelatieType::VervangtVooraankondiging)
         ->and($zaak->vervangtVooraankondiging()->pluck('zaken.id')->all())->toBe([$vooraankondiging->id]);
 });

--- a/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
+++ b/tests/Feature/EventForm/Submit/SubmitEventFormTest.php
@@ -255,3 +255,30 @@ test('OpenZaak faalt → DB-transactie gerold, geen lokale Zaak', function () {
 
     expect(Zaak::count())->toBe(0);
 });
+
+test('een gekoppelde vooraankondiging krijgt bij submit de vervangt-relatie (issue #10)', function () {
+    $sc = scenarioBuurtfeestInHeerlen();
+    fakeOpenzaakZaakCreate();
+
+    $vooraankondiging = Zaak::factory()->create([
+        'zaaktype_id' => \App\Models\Zaaktype::factory()->create([
+            'name' => 'Vooraankondiging gemeente Heerlen',
+            'municipality_id' => $sc['heerlen']->id,
+            'is_active' => true,
+        ])->id,
+        'organisation_id' => $sc['organisation']->id,
+    ]);
+
+    $sc['state']->setField(\App\EventForm\Schema\Steps\Vragenboom2Step::HEEFT_VOORAANKONDIGING_FIELD, 'Ja');
+    $sc['state']->setField(\App\EventForm\Schema\Steps\Vragenboom2Step::VOORAANKONDIGING_ZAAK_FIELD, $vooraankondiging->id);
+
+    Bus::fake();
+
+    $zaak = app(SubmitEventForm::class)->execute($sc['state'], $sc['user'], $sc['organisation']);
+
+    $relatie = \App\Models\ZaakRelatie::sole();
+    expect($relatie->zaak_id)->toBe($zaak->id)
+        ->and($relatie->gerelateerde_zaak_id)->toBe($vooraankondiging->id)
+        ->and($relatie->type)->toBe(\App\Enums\ZaakRelatieType::VervangtVooraankondiging)
+        ->and($zaak->vervangtVooraankondiging()->pluck('zaken.id')->all())->toBe([$vooraankondiging->id]);
+});

--- a/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
+++ b/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
@@ -9,10 +9,12 @@ use App\Filament\Municipality\Pages\Calendar as MunicipalityCalendarPage;
 use App\Filament\Municipality\Widgets\MunicipalityCalendarWidget;
 use App\Filament\Organiser\Pages\Calendar as OrganiserCalendarPage;
 use App\Filament\Organiser\Widgets\OrganiserCalendarWidget;
+use App\Enums\ZaakRelatieType;
 use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
+use App\Models\ZaakRelatie;
 use App\Models\Zaaktype;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Filament\Facades\Filament;
@@ -477,4 +479,97 @@ test('calendar widget table view opens the view modal when a row is clicked', fu
     $component->mountTableAction('view', $zaak)->assertOk();
 
     expect($component->instance()->getMountedAction()?->getName())->toBe('view');
+});
+
+/**
+ * Issue #10: a vooraankondiging that has been replaced by a definitive
+ * aanvraag disappears from the calendar; the aanvraag takes its place.
+ * The zaken list itself is untouched by this filter.
+ */
+function omgezetteVooraankondigingScenario(object $context): array
+{
+    $vooraankondigingZaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $context->municipality->id,
+        'name' => 'Vooraankondiging gemeente Test',
+        'is_active' => true,
+    ]);
+
+    // Answer 6: the vooraankondiging is typically already closed when the
+    // definitive aanvraag arrives — the filter must ignore its status.
+    $vooraankondiging = Zaak::factory()->create([
+        'zaaktype_id' => $vooraankondigingZaaktype->id,
+        'organisation_id' => $context->organisation->id,
+        'reference_data' => new ZaakReferenceData(
+            start_evenement: now()->toString(),
+            eind_evenement: now()->addDay()->toString(),
+            registratiedatum: now()->toString(),
+            status_name: 'Afgehandeld',
+            statustype_url: 'https://example.com/statustype/1',
+            resultaat: 'Afgehandeld',
+            naam_evenement: 'Omgezette vooraankondiging',
+        ),
+    ]);
+
+    $aanvraag = Zaak::factory()->create([
+        'zaaktype_id' => $context->zaaktype->id,
+        'organisation_id' => $context->organisation->id,
+    ]);
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    return [$vooraankondiging, $aanvraag];
+}
+
+function actAsMunicipalityAdminOnCalendar(object $context): void
+{
+    $user = User::factory()->create([
+        'email' => 'municipality-admin@example.com',
+        'role' => Role::MunicipalityAdmin,
+    ]);
+    $context->municipality->users()->attach($user);
+
+    test()->actingAs($user);
+    Filament::setCurrentPanel(Filament::getPanel('municipality'));
+    Filament::setTenant($context->municipality);
+}
+
+test('calendar hides a vooraankondiging that was replaced by a definitive aanvraag', function () {
+    [$vooraankondiging, $aanvraag] = omgezetteVooraankondigingScenario($this);
+
+    actAsMunicipalityAdminOnCalendar($this);
+
+    livewire(MunicipalityCalendarWidget::class)
+        ->callAction('toggleView')
+        ->assertSet('viewMode', 'table')
+        ->assertCanSeeTableRecords([$aanvraag])
+        ->assertCanNotSeeTableRecords([$vooraankondiging]);
+});
+
+test('calendar shows the vooraankondiging again when its successor is soft-deleted', function () {
+    [$vooraankondiging, $aanvraag] = omgezetteVooraankondigingScenario($this);
+
+    // Soft delete: the FK cascade does not fire, so the relation row stays
+    // behind — the filter itself must check the successor's deleted_at.
+    $aanvraag->delete();
+
+    actAsMunicipalityAdminOnCalendar($this);
+
+    livewire(MunicipalityCalendarWidget::class)
+        ->callAction('toggleView')
+        ->assertSet('viewMode', 'table')
+        ->assertCanSeeTableRecords([$vooraankondiging]);
+});
+
+test('the zaken list still shows a vooraankondiging that was replaced', function () {
+    [$vooraankondiging, $aanvraag] = omgezetteVooraankondigingScenario($this);
+
+    actAsMunicipalityAdminOnCalendar($this);
+
+    livewire(\App\Filament\Shared\Resources\Zaken\Pages\ListZaken::class)
+        ->filterTable('workingstock', 'all')
+        ->assertCanSeeTableRecords([$vooraankondiging, $aanvraag]);
 });

--- a/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
+++ b/tests/Feature/Filament/Shared/Widgets/CalendarWidgetTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Enums\Role;
+use App\Enums\ZaakRelatieType;
 use App\Filament\Admin\Pages\Calendar as AdminCalendarPage;
 use App\Filament\Admin\Widgets\AdminCalendarWidget;
 use App\Filament\Advisor\Pages\Calendar as AdvisorCalendarPage;
@@ -9,7 +10,7 @@ use App\Filament\Municipality\Pages\Calendar as MunicipalityCalendarPage;
 use App\Filament\Municipality\Widgets\MunicipalityCalendarWidget;
 use App\Filament\Organiser\Pages\Calendar as OrganiserCalendarPage;
 use App\Filament\Organiser\Widgets\OrganiserCalendarWidget;
-use App\Enums\ZaakRelatieType;
+use App\Filament\Shared\Resources\Zaken\Pages\ListZaken;
 use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
@@ -569,7 +570,7 @@ test('the zaken list still shows a vooraankondiging that was replaced', function
 
     actAsMunicipalityAdminOnCalendar($this);
 
-    livewire(\App\Filament\Shared\Resources\Zaken\Pages\ListZaken::class)
+    livewire(ListZaken::class)
         ->filterTable('workingstock', 'all')
         ->assertCanSeeTableRecords([$vooraankondiging, $aanvraag]);
 });

--- a/tests/Feature/Models/Zaak/ZaakRelatieTest.php
+++ b/tests/Feature/Models/Zaak/ZaakRelatieTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/**
+ * Datamodel tests for the generic typed relation table `zaak_relaties`
+ * (issue #10). Covers the guards (self-reference, uniqueness), the
+ * generic relations and the named helpers for the
+ * `vervangt_vooraankondiging` type in both directions, including the
+ * soft-delete behaviour of the successor.
+ */
+
+use App\Enums\ZaakRelatieType;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\Zaak;
+use App\Models\ZaakRelatie;
+use App\Models\Zaaktype;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function maakZaakMetZaaktypeNaam(string $zaaktypeNaam): Zaak
+{
+    $municipality = Municipality::factory()->create();
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $municipality->id,
+        'name' => $zaaktypeNaam,
+        'is_active' => true,
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => Organisation::factory()->create()->id,
+    ]);
+}
+
+test('een relatie met zichzelf wordt geweigerd', function () {
+    $zaak = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Test');
+
+    ZaakRelatie::create([
+        'zaak_id' => $zaak->id,
+        'gerelateerde_zaak_id' => $zaak->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+})->throws(InvalidArgumentException::class);
+
+test('dezelfde relatie kan niet twee keer bestaan', function () {
+    $aanvraag = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Test');
+    $vooraankondiging = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Test');
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+})->throws(QueryException::class);
+
+test('de benoemde helpers lezen de relatie in beide richtingen', function () {
+    $aanvraag = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Test');
+    $vooraankondiging = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Test');
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    expect($aanvraag->vervangtVooraankondiging()->pluck('zaken.id')->all())->toBe([$vooraankondiging->id])
+        ->and($vooraankondiging->opgevolgdDoor()->pluck('zaken.id')->all())->toBe([$aanvraag->id])
+        ->and($aanvraag->relaties()->count())->toBe(1)
+        ->and($vooraankondiging->inverseRelaties()->count())->toBe(1);
+});
+
+test('een soft-deleted opvolger telt niet meer mee als opvolging', function () {
+    $aanvraag = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Test');
+    $vooraankondiging = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Test');
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    $aanvraag->delete();
+
+    // The relation row survives a soft delete (the FK cascade only fires
+    // on hard deletes), but the successor no longer shows up.
+    expect(ZaakRelatie::count())->toBe(1)
+        ->and($vooraankondiging->refresh()->opgevolgdDoor()->count())->toBe(0);
+});
+
+test('een hard-deleted opvolger ruimt de relatierij op via de FK-cascade', function () {
+    $aanvraag = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Test');
+    $vooraankondiging = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Test');
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $vooraankondiging->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    $aanvraag->forceDelete();
+
+    expect(ZaakRelatie::count())->toBe(0);
+});
+
+test('isVooraankondiging volgt de naamconventie van het zaaktype', function () {
+    expect(maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Heerlen')->isVooraankondiging())->toBeTrue()
+        ->and(maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Heerlen')->isVooraankondiging())->toBeFalse()
+        ->and(maakZaakMetZaaktypeNaam('Melding evenement gemeente Heerlen')->isVooraankondiging())->toBeFalse();
+});
+
+test('de vooraankondigingen-scope selecteert alleen vooraankondigingen', function () {
+    $vooraankondiging = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Heerlen');
+    maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Heerlen');
+
+    expect(Zaak::query()->vooraankondigingen()->pluck('id')->all())->toBe([$vooraankondiging->id]);
+});
+
+test('de nogNietOpgevolgd-scope sluit vooraankondigingen met een definitieve aanvraag uit', function () {
+    $gekoppeld = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Heerlen');
+    $vrij = maakZaakMetZaaktypeNaam('Vooraankondiging gemeente Maastricht');
+    $aanvraag = maakZaakMetZaaktypeNaam('Evenementenvergunning gemeente Heerlen');
+
+    ZaakRelatie::create([
+        'zaak_id' => $aanvraag->id,
+        'gerelateerde_zaak_id' => $gekoppeld->id,
+        'type' => ZaakRelatieType::VervangtVooraankondiging,
+    ]);
+
+    expect(Zaak::query()->vooraankondigingen()->nogNietOpgevolgd()->pluck('id')->all())->toBe([$vrij->id]);
+
+    // A soft-deleted successor no longer blocks a new link.
+    $aanvraag->delete();
+
+    expect(Zaak::query()->vooraankondigingen()->nogNietOpgevolgd()->pluck('id')->sort()->values()->all())
+        ->toBe(collect([$gekoppeld->id, $vrij->id])->sort()->values()->all());
+});


### PR DESCRIPTION
Implements [A7 - Als organisator een vooraankondiging omzetten in een definitieve aanvraag](https://github.com/WowebNL/eventloket-fase-2/issues/10).

## What this adds

**Generic typed relation table.** New `zaak_relaties` table with a `ZaakRelatieType` enum, first type `vervangt_vooraankondiging`. Each type fixes its reading direction: `zaak_id` (subject) performs the type on `gerelateerde_zaak_id` (object). Guards: unique on `(zaak_id, gerelateerde_zaak_id, type)`, self-reference blocked at both the model and database level. `Zaak` gets generic `relaties()`/`inverseRelaties()` plus named helpers `vervangtVooraankondiging()` and `opgevolgdDoor()`; the rest of the code talks to the helpers.

**Two entry points for the organiser:**
- A dedicated "Definitieve aanvraag indienen" action on a submitted vooraankondiging. It reuses the existing prefill path, flips the copied state to the regular aanvraag flow and presets the link fields, so the zaaknummer of the vooraankondiging is carried over into a locked (`disabled()->dehydrated()`) field. The action disappears once a definitive aanvraag is linked.
- The existing "did you submit a vooraankondiging earlier?" question in the form now shows a select with the organisation's own vooraankondigingen (closed ones included, since a vooraankondiging is usually already finished by the time the aanvraag arrives). The question is only shown when the organisation actually has a linkable vooraankondiging. The entered event date is used to suggest the best match (on top, preselected when exactly one matches); the organiser always confirms explicitly. The "this will be built in 2026" promise text is removed.

**Linking on submit.** A new synchronous submit step writes the relation with server-side re-checks: same organisation, source actually is a vooraankondiging, not already replaced, and only on the vergunning path. A failing guard skips the link with a log warning instead of failing the submit.

**Visibility.** Both zaak screens show the link in both directions ("Vervangt vooraankondiging" / "Opgevolgd door") with a link to the other zaak, in the municipality, advisor, admin and organiser panels. The submission PDF shows the replaced vooraankondiging in the header right below the zaaknummer, and the report no longer duplicates the zaaknummer as a separate row.

**Calendar.** A replaced vooraankondiging is hidden from the calendar through a hard exclusion in `applyContextFilters()` (not a user-resettable filter). The filter only looks at the existence of the relation, never at status or resultaat, and re-checks `deleted_at` of the successor: soft-deleting the definitive aanvraag brings the vooraankondiging back. The zaken list is untouched.

**Draft origin.** `event_form_drafts` gets a `source_zaak_id` column so a concept persistently remembers which zaak it was prefilled from, replacing the transient `?bron=hergebruik` query param as the only trace.

## Deliberate choices

- The "aard" of a zaaktype is still a name-prefix convention on `main`; every check goes through one seam (`Zaaktype::isVooraankondiging()`) so it can be replaced by the `zaaktypen.role` column in one place after the multi-ZGW branch (#482) lands.
- The dead `related_cases` tab is intentionally left alone to keep the merge surface with #482 small.
- No ZGW coupling and no ZGW closing of the vooraankondiging; the relation lives in Eventloket only.
- A vooraankondiging can be replaced at most once; a soft-deleted successor makes it linkable again, consistent with the calendar behaviour.