### PR TITLE
Send annIdentificatie again on the initiator rol of an organisation

### DIFF
--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -201,7 +201,7 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
 
         $this->copyZaakeigenschappen($deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
-        $this->createInitiator($deelConnection, $newZaakUrl, $doorkomstZaaktype, $state, $initiator);
+        $this->createInitiator($deelConnectionName, $deelConnection, $newZaakUrl, $doorkomstZaaktype, $state, $initiator);
         $this->copyDocumenten($hoofdConnectionName, $deelConnectionName, $deelConnection, $hoofdZaak, $newZaakUrl, $doorkomstZaaktype);
         $this->createInitieleStatus($deelConnection, $newZaakUrl, $doorkomstZaaktype);
 
@@ -297,7 +297,7 @@ class CreateDoorkomstZaken implements ShouldQueue
      *
      * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
      */
-    private function createInitiator(ZgwConnection $deelConnection, string $newZaakUrl, Zaaktype $doorkomstZaaktype, FormState $state, array $initiator): void
+    private function createInitiator(string $deelConnectionName, ZgwConnection $deelConnection, string $newZaakUrl, Zaaktype $doorkomstZaaktype, FormState $state, array $initiator): void
     {
         if ($initiator === []) {
             return;
@@ -313,6 +313,7 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
 
         $rolData = InitiatorRolBuilder::build(
+            $deelConnectionName,
             $newZaakUrl,
             $roltype['url'],
             $state,

--- a/app/Jobs/Zaak/UpdateInitiatorZGW.php
+++ b/app/Jobs/Zaak/UpdateInitiatorZGW.php
@@ -21,8 +21,8 @@ use Woweb\Zgw\Facades\Zgw;
  * Sets the initiator rol on the ZGW zaak from the initiator block in the
  * FormState snapshot. Two variants, matching the aanvrager:
  *
- * - has a KvK number → `niet_natuurlijk_persoon`
- *   (statutaireNaam, kvkNummer, contactpersoon)
+ * - has a KvK number → `niet_natuurlijk_persoon` (statutaireNaam,
+ *   annIdentificatie, contactpersoon, plus kvkNummer on the default connection)
  * - otherwise → `natuurlijk_persoon` (voornamen, geslachtsnaam,
  *   anpIdentificatie, verblijfsadres)
  *
@@ -59,6 +59,7 @@ class UpdateInitiatorZGW implements ShouldQueue
         }
 
         $rolData = InitiatorRolBuilder::build(
+            $connectionName,
             $ozZaak->url,
             $roltype,
             $state,

--- a/app/Services/Zgw/InitiatorRolBuilder.php
+++ b/app/Services/Zgw/InitiatorRolBuilder.php
@@ -19,7 +19,8 @@ use Illuminate\Support\Str;
  * copied ZGW rol whose betrokkeneIdentificatie is empty across instances.
  *
  * Two variants, matching the aanvrager:
- * - has a KvK number → niet_natuurlijk_persoon (statutaireNaam, kvkNummer)
+ * - has a KvK number → niet_natuurlijk_persoon (statutaireNaam,
+ *   annIdentificatie, and kvkNummer only towards the default connection)
  * - otherwise        → natuurlijk_persoon (voornamen, geslachtsnaam,
  *   anpIdentificatie, verblijfsadres)
  *
@@ -27,22 +28,24 @@ use Illuminate\Support\Str;
  * materialise a betrokkene (OneGround/RX Mission shows nothing for a rol whose
  * betrokkeneIdentificatie only carries name parts). We have no BSN, so a stable
  * application-issued anpIdentificatie derived from the organiser user id is
- * sent, mirroring kvkNummer on the organisation variant.
+ * sent, mirroring annIdentificatie on the organisation variant.
  */
 final class InitiatorRolBuilder
 {
     /**
+     * @param  string  $connectionName  the connection the rol is posted to, which decides
+     *                                  whether the non-standard kvkNummer is sent along
      * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
      * @return array<string, mixed>|null rol payload, or null when there is no initiator data
      */
-    public static function build(string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie = null): ?array
+    public static function build(string $connectionName, string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie = null): ?array
     {
         if ($initiator === []) {
             return null;
         }
 
         return isset($initiator['kvk']) && $initiator['kvk']
-            ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator, self::kvkNummer($initiator['kvk']))
+            ? self::nietNatuurlijkPersoon($connectionName, $zaakUrl, $roltype, $initiator, self::kvkNummer($initiator['kvk']))
             : self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie);
     }
 
@@ -55,7 +58,8 @@ final class InitiatorRolBuilder
      * job (a retry, or `zaak:create-doorkomst-zaken` on an existing zaak) reads
      * the already-hashed snapshot, and writing that hash to ZGW as if it were a
      * KvK number would put a bogus company number on the zaak. The rol is then
-     * registered on the statutaireNaam alone.
+     * registered on the statutaireNaam alone, so this guard covers both
+     * annIdentificatie and kvkNummer.
      */
     private static function kvkNummer(mixed $kvk): ?string
     {
@@ -81,7 +85,7 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function nietNatuurlijkPersoon(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
+    private static function nietNatuurlijkPersoon(string $connectionName, string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
     {
         return [
             'zaak' => $zaakUrl,
@@ -89,13 +93,27 @@ final class InitiatorRolBuilder
             'roltype' => $roltype,
             'roltoelichting' => 'inzender formulier',
             'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
-            // We send only kvkNummer as the company identifier, for every
-            // connection (OpenZaak included). annIdentificatie is deliberately
-            // omitted: not every ZGW instance accepts it and the KvK number is
-            // the canonical identifier.
+            // annIdentificatie is the standard-conformant carrier for the
+            // company number. RolNietNatuurlijkPersoon has no kvkNummer
+            // property in any Zaken API release from 1.0 up to and including
+            // 1.7 (kvkNummer only exists on RolVestiging, added in 1.3.0),
+            // while annIdentificatie has been defined here since 1.0. Sending
+            // only kvkNummer therefore leaves the rol with a statutaireNaam and
+            // no identifying attribute at all, which is what happened on a real
+            // instance on 28-07-2026: the create response came back without an
+            // error and without the property, innNnpId and annIdentificatie
+            // both empty. innNnpId is not used for the number either, because
+            // that field holds the chamber-issued RSIN and a conformant backend
+            // validates it as such, which an eight-digit KvK number fails.
+            //
+            // kvkNummer is a non-standard extra and only goes to our own
+            // default connection (OpenZaak), which read it before this builder
+            // existed. Every other connection belongs to a municipality running
+            // its own instance, and those get the standard payload only.
             'betrokkeneIdentificatie' => array_filter([
                 'statutaireNaam' => $initiator['organisatie_naam'] ?? null,
-                'kvkNummer' => $kvkNummer,
+                'annIdentificatie' => $kvkNummer,
+                'kvkNummer' => ZgwConnectionConfig::isDefaultConnection($connectionName) ? $kvkNummer : null,
             ]),
         ];
     }

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -134,6 +134,21 @@ class ZgwConnectionConfig
     }
 
     /**
+     * Whether this is the global "main" connection from config/zgw.php: our own
+     * OpenZaak instance, the one every zaak used before municipalities could
+     * bring their own. Any other name belongs to a municipality-owned instance.
+     *
+     * Deliberately not expressed as "not OneGround": a future OpenZaak
+     * connection of a municipality is still someone else's instance, and
+     * behaviour we only kept for backwards compatibility with our own history
+     * should not leak into it.
+     */
+    public static function isDefaultConnection(string $connectionName): bool
+    {
+        return $connectionName === ZgwConnectionResolver::DEFAULT_CONNECTION;
+    }
+
+    /**
      * Whether this connection talks to a OneGround (RX Mission) backend, which
      * deviates from the ZGW standard on a few points (bare-string overigeData,
      * eager archiving on eind-status). Defaults to false so the global "main"

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -286,6 +286,7 @@ test('registers the initiator on the deelzaak from the form aanvrager data, not 
         && str_starts_with($request->url(), ZgwHttpFake::$baseUrl.'/zaken/api/v1/rollen')
         && $request->data()['betrokkeneType'] === 'niet_natuurlijk_persoon'
         && $request->data()['roltype'] === ZgwHttpFake::$baseUrl.'/catalogi/api/v1/roltypen/init'
+        && ($request->data()['betrokkeneIdentificatie']['annIdentificatie'] ?? null) === '12345678'
         && ($request->data()['betrokkeneIdentificatie']['kvkNummer'] ?? null) === '12345678'
         && ($request->data()['betrokkeneIdentificatie']['statutaireNaam'] ?? null) === 'Woweb');
 });
@@ -310,7 +311,8 @@ test('registers a natuurlijk_persoon initiator from the form name when there is 
         && $request->data()['betrokkeneType'] === 'natuurlijk_persoon'
         && ($request->data()['betrokkeneIdentificatie']['geslachtsnaam'] ?? null) === 'Jansen'
         && ($request->data()['betrokkeneIdentificatie']['voornamen'] ?? null) === 'Jan'
-        && ! array_key_exists('kvkNummer', $request->data()['betrokkeneIdentificatie']));
+        && ! array_key_exists('kvkNummer', $request->data()['betrokkeneIdentificatie'])
+        && ! array_key_exists('annIdentificatie', $request->data()['betrokkeneIdentificatie']));
 });
 
 test('skips the initiator when the form has no aanvrager data', function () {

--- a/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
@@ -4,10 +4,12 @@
  * UpdateInitiatorZGW sets the initiator rol on the ZGW zaak from the initiator
  * block in the FormState snapshot.
  *
- * Main behaviour covered here: for an organisation with a KvK number we send
- * only `kvkNummer` as the company identifier, for every connection (OpenZaak
- * included); `annIdentificatie` is deliberately omitted because not every ZGW
- * instance accepts it. For a private aanvrager (no KvK) the rol carries a
+ * Main behaviour covered here: for an organisation with a KvK number the rol
+ * carries the company number in `annIdentificatie` as well as in `kvkNummer`,
+ * for every connection. The Zaken API standard defines no `kvkNummer` on
+ * RolNietNatuurlijkPersoon in any release from 1.0 up to and including 1.7, so
+ * a conformant backend drops that property and only `annIdentificatie` keeps
+ * the number on the zaak. For a private aanvrager (no KvK) the rol carries a
  * stable `anpIdentificatie` and the verblijfsadres from the form's address
  * fieldset, so backends such as OneGround materialise a visible betrokkene.
  */
@@ -67,7 +69,7 @@ function fakeZaakRoltypenEnRollen(): void
     ]);
 }
 
-test('stuurt voor een organisatie alleen kvkNummer als bedrijfsidentificatie', function () {
+test('stuurt voor een organisatie annIdentificatie naast kvkNummer mee', function () {
     $zaak = zaakMetInitiator([
         'watIsHetKamerVanKoophandelNummerVanUwOrganisatie' => '12345678',
         'watIsDeNaamVanUwOrganisatie' => 'Acme BV',
@@ -85,8 +87,8 @@ test('stuurt voor een organisatie alleen kvkNummer als bedrijfsidentificatie', f
         $identificatie = $request->data()['betrokkeneIdentificatie'] ?? [];
 
         return $request->data()['betrokkeneType'] === 'niet_natuurlijk_persoon'
+            && ($identificatie['annIdentificatie'] ?? null) === '12345678'
             && ($identificatie['kvkNummer'] ?? null) === '12345678'
-            && ! array_key_exists('annIdentificatie', $identificatie)
             && ($identificatie['statutaireNaam'] ?? null) === 'Acme BV';
     });
 });

--- a/tests/Unit/Zgw/InitiatorRolBuilderTest.php
+++ b/tests/Unit/Zgw/InitiatorRolBuilderTest.php
@@ -8,7 +8,7 @@ use App\Services\Zgw\InitiatorRolBuilder;
 test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
     $state = FormState::fromSnapshot(['values' => []]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'kvk' => '12345678',
         'organisatie_naam' => 'Woweb',
         'contactpersoon' => ['naam' => 'Organisator Test'],
@@ -21,20 +21,70 @@ test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
         ->and($rol['contactpersoonRol'])->toBe(['naam' => 'Organisator Test']);
 });
 
+test('carries the KvK number in annIdentificatie, next to kvkNummer on the default connection', function () {
+    // RolNietNatuurlijkPersoon has no kvkNummer property in any Zaken API
+    // release from 1.0 up to and including 1.7 (kvkNummer only exists on
+    // RolVestiging, added in 1.3.0), so a conformant backend drops it and the
+    // organisation ends up on the zaak without a company number at all. The
+    // standard does define annIdentificatie here, so the number has to travel
+    // in that property. kvkNummer is a non-standard extra kept for our own
+    // OpenZaak instance only.
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+    ]);
+
+    expect($rol['betrokkeneIdentificatie']['annIdentificatie'])->toBe('12345678')
+        ->and($rol['betrokkeneIdentificatie']['kvkNummer'])->toBe('12345678');
+});
+
+test('sends only annIdentificatie to a municipality connection', function () {
+    // Any connection other than the default belongs to a municipality running
+    // its own ZGW instance, which gets the standard payload without the
+    // non-standard kvkNummer.
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+    ]);
+
+    expect($rol['betrokkeneType'])->toBe('niet_natuurlijk_persoon')
+        ->and($rol['betrokkeneIdentificatie']['annIdentificatie'])->toBe('12345678')
+        ->and($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer');
+});
+
+test('omits an already hashed KvK number on a municipality connection too', function () {
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => 'hash:9f3c1d2e',
+        'organisatie_naam' => 'Woweb',
+    ]);
+
+    expect($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('annIdentificatie')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer');
+});
+
 test('omits an already hashed KvK number and keeps the organisation rol', function () {
     // A rerun on a snapshot whose KvK was hashed (a job retry, or
     // zaak:create-doorkomst-zaken on an existing zaak) must not send the hash to
     // ZGW as if it were a KvK number.
     $state = FormState::fromSnapshot(['values' => []]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'kvk' => 'hash:9f3c1d2e',
         'organisatie_naam' => 'Woweb',
     ]);
 
     expect($rol['betrokkeneType'])->toBe('niet_natuurlijk_persoon')
         ->and($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
-        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer');
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('annIdentificatie');
 });
 
 test('builds a natuurlijk_persoon rol with anpIdentificatie, display name and verblijfsadres', function () {
@@ -43,7 +93,7 @@ test('builds a natuurlijk_persoon rol with anpIdentificatie, display name and ve
         'watIsUwAchternaam' => 'Jansen',
     ]]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'natuurlijk_persoon_adres' => [
             'postcode' => '6411 CD',
             'huisnummer' => '32',
@@ -76,7 +126,7 @@ test('builds a natuurlijk_persoon rol without verblijfsadres when no address is 
         'watIsUwAchternaam' => 'Jansen',
     ]]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'contactpersoon' => ['naam' => 'Jan Jansen'],
     ]);
 
@@ -88,7 +138,7 @@ test('builds a natuurlijk_persoon rol without verblijfsadres when no address is 
 test('skips the verblijfsadres for a foreign address', function () {
     $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'natuurlijk_persoon_adres' => [
             'postcode' => '4000',
             'huisnummer' => '7',
@@ -103,7 +153,7 @@ test('skips the verblijfsadres for a foreign address', function () {
 test('skips the verblijfsadres when the huisnummer is not numeric', function () {
     $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'natuurlijk_persoon_adres' => [
             'postcode' => '6411CD',
             'huisnummer' => '32a',
@@ -117,7 +167,7 @@ test('skips the verblijfsadres when the huisnummer is not numeric', function () 
 test('drops huisletter and toevoeging values that exceed the ZGW schema bounds', function () {
     $state = FormState::fromSnapshot(['values' => ['watIsUwAchternaam' => 'Jansen']]);
 
-    $rol = InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'natuurlijk_persoon_adres' => [
             'postcode' => '6411CD',
             'huisnummer' => '32',
@@ -136,7 +186,7 @@ test('drops huisletter and toevoeging values that exceed the ZGW schema bounds',
 test('returns null when there is no initiator data', function () {
     $state = FormState::fromSnapshot(['values' => []]);
 
-    expect(InitiatorRolBuilder::build('https://zgw/zaken/1', 'https://zgw/roltype/1', $state, []))->toBeNull();
+    expect(InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, []))->toBeNull();
 });
 
 test('derives a stable anpIdentificatie from the user id', function () {


### PR DESCRIPTION
An aanvrager with a KvK number reaches the zaaksysteem without any company identification: the rol carries a statutaireNaam and nothing else.

The initiator rol for an organisation has been sending kvkNummer as its only company identifier since the Zaak jobs moved to the ZGW client. That property does not exist on RolNietNatuurlijkPersoon in the Zaken API standard, in any release from 1.0 up to and including 1.7 -- kvkNummer only exists on RolVestiging, where it was added in 1.3.0. A backend that implements the standard therefore drops the property, and because annIdentificatie was removed at the same time nothing identifying is left. Confirmed against a real instance on 28-07-2026: the create response came back without an error and without the property, with innNnpId and annIdentificatie both empty.

Put the number back in annIdentificatie, which is the identifying property the standard does define for this betrokkeneType and which has been there unchanged since 1.0. innNnpId is not used for it: that field holds the chamber-issued RSIN and a conformant backend validates it as such, which an eight-digit KvK number fails.

kvkNummer is not part of the standard, so it is now sent only towards the default connection: our own OpenZaak instance, which read it before this builder existed. Every other connection belongs to a municipality running its own instance and gets the standard payload. The builder therefore takes the target connection name, which both callers already have in scope.

Both properties go through the existing guard on an already hashed snapshot, so a job retry still registers the rol on the statutaireNaam alone rather than writing a hash as if it were a company number. The doorkomst deelzaken get the same payload, since they share this builder.