### PR TITLE
Derive document visibility options from the connection map

### DIFF
--- a/app/Enums/DocumentVertrouwelijkheden.php
+++ b/app/Enums/DocumentVertrouwelijkheden.php
@@ -2,6 +2,8 @@
 
 namespace App\Enums;
 
+use App\Services\Zgw\DocumentAudience;
+
 /**
  * We only use Zaakvertrouwelijk, Vertrouwelijk and Confidentieel in the app.
  */
@@ -41,30 +43,24 @@ enum DocumentVertrouwelijkheden: string
         };
     }
 
-    public static function listUserRoles(): array
+    /**
+     * The levels a municipal user is offered when uploading a document, ordered
+     * from least to most confidential. The application deliberately uses only
+     * these three of the eight ZGW levels.
+     *
+     * Which of them are actually offered, and which roles each of them reaches,
+     * follows the vertrouwelijkheid map of the connection the zaak runs on; see
+     * {@see DocumentAudience}. This list must therefore never be used to label
+     * the choice: it says nothing about who sees what.
+     *
+     * @return array<int, string>
+     */
+    public static function uploadChoices(): array
     {
         return [
-            self::Zaakvertrouwelijk->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-                Role::Advisor,
-                Role::Organiser,
-            ],
-            self::Vertrouwelijk->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-                Role::Advisor,
-            ],
-            self::Confidentieel->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-            ],
+            self::Zaakvertrouwelijk->value,
+            self::Vertrouwelijk->value,
+            self::Confidentieel->value,
         ];
     }
 }

--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -10,6 +10,7 @@ use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZgwConnect
 use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZgwConnections\Pages\ListMunicipalityZgwConnections;
 use App\Livewire\ConnectionVerifier;
 use App\Models\MunicipalityZgwConnection;
+use App\Services\Zgw\DocumentAudience;
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
@@ -224,29 +225,17 @@ class MunicipalityZgwConnectionResource extends Resource
      * binds to; the others inherit its value on save. Roles outside these groups
      * (platform admin, koppeling beheerder) always fall back to the defaults.
      *
-     * @return array<int, array{label: string, roles: array<int, Role>}>
+     * The groups are defined once in {@see DocumentAudience::groups()}, which
+     * also labels the upload choice with them, so the form and that choice can
+     * never describe different groups. They are listed there from the broadest
+     * to the narrowest audience and reversed here, so the form keeps showing
+     * them as organisator, adviseur, gemeente.
+     *
+     * @return array<int, array{label: string, audience: string, roles: array<int, Role>}>
      */
     protected static function vertrouwelijkheidGroups(): array
     {
-        return [
-            [
-                'label' => Role::Organiser->getLabel(),
-                'roles' => [Role::Organiser],
-            ],
-            [
-                'label' => Role::Advisor->getLabel(),
-                'roles' => [Role::Advisor],
-            ],
-            [
-                'label' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente'),
-                'roles' => [
-                    Role::Reviewer,
-                    Role::Coordinator,
-                    Role::MunicipalityAdmin,
-                    Role::ReviewerMunicipalityAdmin,
-                ],
-            ],
-        ];
+        return array_reverse(DocumentAudience::groups());
     }
 
     /**

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -2,10 +2,10 @@
 
 namespace App\Filament\Shared\Resources\Zaken\Actions;
 
-use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\Role;
 use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Models\Zaak;
+use App\Services\Zgw\DocumentAudience;
 use App\Services\Zgw\ZgwConnectionConfig;
 use App\Services\Zgw\ZgwResource;
 use App\Support\Uploads\DocumentUploadType;
@@ -148,24 +148,9 @@ class UploadDocumentAction
                 ));
             });
 
-        $userRole = auth()->user()->role;
-        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin])) {
-            $fields[] = Select::make('vertrouwelijkheidaanduiding')
-                ->label(__('Wie mag dit document inzien?'))
-                ->options(function () use ($zaak) {
-                    $vertrouwelijkheden = ZgwConnectionConfig::documentVisibilityForRole($zaak->zgwConnectionName(), auth()->user()->role);
-                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
-                    $options = [];
-                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
-                        if (in_array($key, $vertrouwelijkheden)) {
-                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
-                        }
-                    }
-
-                    return $options;
-                })
-                ->visible(fn (Get $get): bool => ! empty($get('document_metadata')))
-                ->required();
+        if ($vertrouwelijkheid = self::vertrouwelijkheidSelect($zaak)) {
+            $fields[] = $vertrouwelijkheid
+                ->visible(fn (Get $get): bool => ! empty($get('document_metadata')));
         }
 
         $fields[] = Repeater::make('document_metadata')
@@ -201,23 +186,8 @@ class UploadDocumentAction
                 ->required(),
         ];
 
-        $userRole = auth()->user()->role;
-        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin])) {
-            $fields[] = Select::make('vertrouwelijkheidaanduiding')
-                ->label(__('Wie mag dit document inzien?'))
-                ->options(function () use ($zaak) {
-                    $vertrouwelijkheden = ZgwConnectionConfig::documentVisibilityForRole($zaak->zgwConnectionName(), auth()->user()->role);
-                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
-                    $options = [];
-                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
-                        if (in_array($key, $vertrouwelijkheden)) {
-                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
-                        }
-                    }
-
-                    return $options;
-                })
-                ->required();
+        if ($vertrouwelijkheid = self::vertrouwelijkheidSelect($zaak)) {
+            $fields[] = $vertrouwelijkheid;
         }
 
         $fields[] = FileUpload::make('file')
@@ -248,6 +218,39 @@ class UploadDocumentAction
             ->maxLength(255);
 
         return $fields;
+    }
+
+    /**
+     * The "who may see this document" select, or null when it should not be
+     * shown at all.
+     *
+     * The options and their labels come from the vertrouwelijkheid map of the
+     * connection this zaak runs on, so each level is labelled with the role
+     * groups that will actually see it. The select is left out entirely when the
+     * current user may not choose (an organiser never does), and when the levels
+     * on offer reach exactly the same audience: a choice that changes nothing is
+     * a promise the filtering does not keep. In both cases the connection's
+     * upload default applies, which the action already falls back to when no
+     * value is submitted.
+     */
+    private static function vertrouwelijkheidSelect(Zaak $zaak): ?Select
+    {
+        $userRole = auth()->user()->role;
+
+        if (! in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin], true)) {
+            return null;
+        }
+
+        $options = DocumentAudience::uploadOptions($zaak->zgwConnectionName(), $userRole);
+
+        if ($options === []) {
+            return null;
+        }
+
+        return Select::make('vertrouwelijkheidaanduiding')
+            ->label(__('Wie mag dit document inzien?'))
+            ->options($options)
+            ->required();
     }
 
     /**

--- a/app/Services/Zgw/DocumentAudience.php
+++ b/app/Services/Zgw/DocumentAudience.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+
+/**
+ * Answers "who really gets to see a document at this vertrouwelijkheid level on
+ * this connection", for the upload choice in the interface.
+ *
+ * The answer is read from the connection's vertrouwelijkheid map through
+ * {@see ZgwConnectionConfig::documentVisibilityForRole()} (which falls back to
+ * the hardcoded per-role defaults), so the choice offered at upload can never
+ * promise an audience the filtering does not honour.
+ */
+class DocumentAudience
+{
+    /**
+     * The role groups whose document visibility is configurable per connection,
+     * ordered from the broadest to the narrowest default audience.
+     *
+     * The first role of a group is the canonical one: the connection form binds
+     * to it and fans its value out over the other roles of the group on save
+     * (see MunicipalityZgwConnectionResource::pruneVertrouwelijkheidMap()), so
+     * the canonical role's visibility describes the whole group. Roles outside
+     * these groups (platform admin, koppeling beheerder) are not configurable
+     * and always see everything, which is why they carry no audience label.
+     *
+     * @return array<int, array{label: string, audience: string, roles: array<int, Role>}>
+     */
+    public static function groups(): array
+    {
+        return [
+            [
+                'label' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente'),
+                'audience' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente_audience'),
+                'roles' => [
+                    Role::Reviewer,
+                    Role::Coordinator,
+                    Role::MunicipalityAdmin,
+                    Role::ReviewerMunicipalityAdmin,
+                ],
+            ],
+            [
+                'label' => Role::Advisor->getLabel(),
+                'audience' => Role::Advisor->getLabel(),
+                'roles' => [Role::Advisor],
+            ],
+            [
+                'label' => Role::Organiser->getLabel(),
+                'audience' => Role::Organiser->getLabel(),
+                'roles' => [Role::Organiser],
+            ],
+        ];
+    }
+
+    /**
+     * The vertrouwelijkheid levels a user of the given role may pick when
+     * uploading a document, each labelled with the role groups that may see that
+     * level on this connection.
+     *
+     * Returns an empty array when the choice would be an illusion: nothing left
+     * to pick, or every offered level reaching exactly the same audience (the
+     * situation VRZL reported, where a connection map gives the municipal roles
+     * every level and the other groups none of them). The caller then leaves the
+     * select out and the connection's upload default applies.
+     *
+     * @return array<string, string>
+     */
+    public static function uploadOptions(string $connectionName, Role $role): array
+    {
+        $visibleToUploader = ZgwConnectionConfig::documentVisibilityForRole($connectionName, $role);
+
+        $audiences = [];
+
+        foreach (DocumentVertrouwelijkheden::uploadChoices() as $level) {
+            if (! in_array($level, $visibleToUploader, true)) {
+                continue;
+            }
+
+            $audiences[$level] = self::audienceFor($connectionName, $level);
+        }
+
+        if (! self::audiencesDiffer($audiences)) {
+            return [];
+        }
+
+        return array_map(
+            static fn (array $audience): string => $audience === []
+                ? __('Geen van deze rolgroepen')
+                : implode(', ', $audience),
+            $audiences,
+        );
+    }
+
+    /**
+     * The labels of the role groups that may see a document at this level on
+     * this connection, broadest audience first.
+     *
+     * @return array<int, string>
+     */
+    public static function audienceFor(string $connectionName, string $level): array
+    {
+        $labels = [];
+
+        foreach (self::groups() as $group) {
+            $visibility = ZgwConnectionConfig::documentVisibilityForRole($connectionName, $group['roles'][0]);
+
+            if (in_array($level, $visibility, true)) {
+                $labels[] = $group['audience'];
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Whether the offered levels tell the role groups apart at all. Two levels
+     * reaching the same audience are the same choice under a different name, and
+     * a single level (or none) is no choice to begin with.
+     *
+     * @param  array<string, array<int, string>>  $audiences
+     */
+    private static function audiencesDiffer(array $audiences): bool
+    {
+        $distinct = array_unique(array_map(
+            static fn (array $audience): string => implode('|', $audience),
+            $audiences,
+        ));
+
+        return count($distinct) > 1;
+    }
+}

--- a/docs/functionaliteiten/zgw-koppelingbeheer.md
+++ b/docs/functionaliteiten/zgw-koppelingbeheer.md
@@ -238,6 +238,8 @@ Hier bepaal je per rolgroep welke vertrouwelijkheidsniveaus zichtbaar zijn en we
 
 Laat een veld leeg om de standaardwaarden van Eventloket aan te houden. De rol-gebaseerde filtering blijft altijd actief, ongeacht deze instellingen. Als alle drie de document-tabbladen zijn uitgeschakeld, verdwijnen de per-rol velden vanzelf, omdat er dan toch niet geüpload kan worden. De standaard voor systeemdocumenten blijft dan wel relevant.
 
+**Wat een behandelaar hiervan ziet bij het uploaden.** In het uploadvenster staat de keuze "Wie mag dit document inzien?". De niveaus in die keuze en de rolgroepen die erbij staan, komen uit de zichtbare niveaus die je hier instelt. Kies je bijvoorbeeld dat de organisator ook vertrouwelijke stukken mag zien, dan staat de organisator vanaf dat moment bij dat niveau vermeld. Maken de aangeboden niveaus voor geen enkele rolgroep verschil, bijvoorbeeld omdat alleen de gemeenterollen ze mogen zien, dan verdwijnt de keuze en krijgt het document het niveau uit "Standaard bij uploaden". Een keuze die niets verandert wordt dus niet voorgelegd.
+
 Twee vaste gedragsregels gelden altijd, los van deze instellingen:
 
 - Een organisator ziet de documenten die hij zelf heeft ingediend altijd terug, ook als het vertrouwelijkheidsniveau van die documenten buiten de zichtbare niveaus van de organisator valt.

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -107,6 +107,9 @@ return [
 
     'vertrouwelijkheid_groups' => [
         'gemeente' => 'Gemeente (behandelaars en beheerders)',
+        // Short form, used where the group is named as an audience ("wie mag dit
+        // document inzien?") instead of as a form heading.
+        'gemeente_audience' => 'Gemeente',
     ],
 
     'vertrouwelijkheid_levels' => [

--- a/tests/Feature/MultiUploadDocumentActionTest.php
+++ b/tests/Feature/MultiUploadDocumentActionTest.php
@@ -13,6 +13,7 @@ use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
@@ -36,6 +37,23 @@ beforeEach(function () {
     $this->coordinator = User::factory()->create(['role' => Role::Coordinator]);
     $this->coordinator->municipalities()->attach($this->municipality);
 });
+
+/**
+ * The options of the "who may see this document" select in the multi upload
+ * schema, or null when the schema does not offer the select at all.
+ *
+ * @return array<string, string>|null
+ */
+function confidentialityOptions(Zaak $zaak): ?array
+{
+    foreach (UploadDocumentAction::schema($zaak) as $field) {
+        if ($field instanceof Select && $field->getName() === 'vertrouwelijkheidaanduiding') {
+            return $field->getOptions();
+        }
+    }
+
+    return null;
+}
 
 test('upload action exists on ZaakDocumentsTable', function () {
     $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
@@ -214,6 +232,146 @@ test('coordinator can choose the confidentiality level when uploading documents'
         ->callTableAction('upload', data: [
             'files' => [$path],
             'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Confidentieel->value,
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Intern advies', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->vertrouwelijkheidaanduiding === DocumentVertrouwelijkheden::Confidentieel->value,
+    );
+});
+
+test('the confidentiality choices are labelled with the enum defaults on a connection without a map', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    expect(confidentialityOptions($zaak))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+test('the confidentiality choices are labelled with the audiences of the active connection', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    // This connection lets the advisor see zaakvertrouwelijk documents, which
+    // the hardcoded defaults do not, and keeps the organiser on openbaar only.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    expect(confidentialityOptions($zaak))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+test('the confidentiality select disappears when the levels reach the same audience', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    // The situation reported on the VRZL staging connection: the municipal roles
+    // see every level and nobody else sees any of them, so the three choices
+    // make no difference at all.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    $fieldNames = array_map(
+        fn (Field|Repeater $field): string => $field->getName(),
+        UploadDocumentAction::schema($zaak),
+    );
+
+    expect($fieldNames)->not->toContain('vertrouwelijkheidaanduiding');
+});
+
+test('an upload without the select applies the upload default of the connection', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/coordinator-file.pdf';
+    Storage::put($path, '%PDF-1.4 coordinator file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', [
+        'visibility' => [
+            Role::Organiser->value => ['openbaar'],
+            Role::Advisor->value => ['openbaar'],
+            Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+            Role::Coordinator->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        ],
+        'upload_default' => [
+            Role::Coordinator->value => DocumentVertrouwelijkheden::Confidentieel->value,
+        ],
+    ]);
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen/1',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+                'informatieobjecttype' => $documentTypeUrl,
+            ],
+        ]), 200),
+        $documentTypeUrl => Http::response([
+            'uuid' => '1',
+            'url' => $documentTypeUrl,
+            'omschrijving' => 'Bijlage',
+            'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
             'document_metadata' => [
                 ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Intern advies', 'informatieobjecttype' => $documentTypeUrl],
             ],

--- a/tests/Unit/Zgw/DocumentAudienceTest.php
+++ b/tests/Unit/Zgw/DocumentAudienceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+use App\Services\Zgw\DocumentAudience;
+use Illuminate\Support\Facades\Config;
+
+it('names the role groups from the broadest to the narrowest audience', function () {
+    $groups = DocumentAudience::groups();
+
+    expect(array_column($groups, 'audience'))->toBe(['Gemeente', 'Adviseur', 'Organisator'])
+        // The canonical role of each group is the one the connection form binds
+        // to, so reading its visibility describes the whole group.
+        ->and(array_map(fn (array $group): Role => $group['roles'][0], $groups))
+        ->toBe([Role::Reviewer, Role::Advisor, Role::Organiser]);
+});
+
+it('labels every level with the enum defaults on a connection without a map', function () {
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+
+    expect(DocumentAudience::uploadOptions('main', Role::Reviewer))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+it('labels every level with the visibility map of the connection', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([
+        // The organiser sees vertrouwelijk here and the advisor sees none of the
+        // three: the hardcoded defaults claim the opposite for both.
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Organisator',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+it('offers no choice when every level reaches the same audience', function () {
+    // The VRZL staging situation: the municipal roles see everything, the other
+    // groups see none of the three levels on offer.
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+});
+
+it('offers no choice when the uploader may see at most one of the levels', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+});
+
+it('reads the audience of a single level from the connection', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+    ]);
+
+    expect(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value))
+        ->toBe(['Gemeente', 'Organisator'])
+        ->and(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Confidentieel->value))
+        ->toBe([]);
+});


### PR DESCRIPTION
The upload dialog's "who may view this document" select still labelled its options with a hardcoded role list, while the actual visibility has been configurable per connection since the vertrouwelijkheid map was introduced. On a connection with its own map the labels could promise something the configuration does not do.

This adds a single source of truth (`DocumentAudience`) that both the connection form and the upload select derive from, so they cannot diverge again. The option labels now show the roles that may actually see each level according to the active connection's map, and when the offered levels make no difference for any role the select is hidden entirely and the connection's upload default applies. Connections without a map (and the default connection) keep today's behaviour, apart from the group label reading "Gemeente" instead of "Behandelaar", which matches who could already see those documents.

The hardcoded `listUserRoles()` is removed rather than left behind: a second, misleading answer to "who sees what" is exactly what caused this. Ten new tests cover the label derivation, the hidden-select case and the upload default; pint and phpstan are clean.
