### PR TITLE
Create doorkomst zaken for every drawn route, not just the first one

### DIFF
--- a/app/EventForm/Submit/EventLocationGeometryBuilder.php
+++ b/app/EventForm/Submit/EventLocationGeometryBuilder.php
@@ -41,13 +41,13 @@ final class EventLocationGeometryBuilder
         $geometries = [];
 
         if ($this->notEmpty($eventLocation['line'] ?? null)) {
-            foreach ($this->parseLines($eventLocation['line']) as $geometry) {
+            foreach (self::parseLines($eventLocation['line']) as $geometry) {
                 $geometries[] = $geometry;
             }
         }
 
         if ($this->notEmpty($eventLocation['multipolygons'] ?? null)) {
-            foreach ($this->parseMultipolygons($eventLocation['multipolygons']) as $geometry) {
+            foreach (self::parseMultipolygons($eventLocation['multipolygons']) as $geometry) {
                 $geometries[] = $geometry;
             }
         }
@@ -85,13 +85,18 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Pak ALLE LineString-geometrieën uit de route-input.
+     * Take ALL LineString geometries from the route input.
+     *
+     * Public and static on purpose: everything that has to reason about the
+     * drawn routes (the submit flow itself, but also `CreateDoorkomstZaken`)
+     * must read them with exactly the same parser, so no caller ends up
+     * looking at the first route only.
      *
      * @return list<Geometry>
      */
-    private function parseLines(mixed $line): array
+    public static function parseLines(mixed $line): array
     {
-        return $this->parseGeometries(
+        return self::parseGeometries(
             $line,
             OpenFormsNormalizer::normalizeGeoJson(...),
             'routeVanHetEvenement',
@@ -99,13 +104,13 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Pak ALLE polygon-geometrieën uit de locatie-input.
+     * Take ALL polygon geometries from the location input.
      *
      * @return list<Geometry>
      */
-    private function parseMultipolygons(mixed $multipolygons): array
+    private static function parseMultipolygons(mixed $multipolygons): array
     {
-        return $this->parseGeometries(
+        return self::parseGeometries(
             $multipolygons,
             OpenFormsNormalizer::normalizeJson(...),
             'buitenLocatieVanHetEvenement',
@@ -113,25 +118,25 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Gedeelde parser voor lijnen én polygonen — beide leveren hun
-     * geometrie in identiek gevormde Map-state aan, alleen de normalizer
-     * en de Repeater-row-key verschillen. Twee shapes worden ondersteund:
+     * Shared parser for lines and polygons: both arrive as identically
+     * shaped Map state, only the normalizer and the Repeater row key
+     * differ. Two shapes are supported:
      *
-     *  1. Nieuw: één Map-state-object met meerdere features in
-     *     `geojson.features[]`. Sinds de Repeater eruit kunnen er
-     *     meerdere routes/polygonen op één kaart staan.
-     *  2. Oud (Repeater-rows): `[{<candidateKey>: {...}}, ...]` —
-     *     backward-compat voor bestaande drafts.
+     *  1. Current: one Map state object with several features in
+     *     `geojson.features[]`. Since the Repeater was dropped, a single
+     *     map can hold several routes/polygons.
+     *  2. Old (Repeater rows): `[{<candidateKey>: {...}}, ...]` —
+     *     backward compatibility for existing drafts.
      *
-     * In beide gevallen pakken we `features[].geometry`; ontbreekt die,
-     * dan vallen we terug op een recursieve zoektocht naar `coordinates`
-     * (pre-Map state-shapes uit de oude OF-flow).
+     * In both cases `features[].geometry` is taken; if that is missing we
+     * fall back to a recursive search for `coordinates` (pre-Map state
+     * shapes from the old OF flow).
      *
-     * @param  callable(string): ?string  $normalizer  zet een ruwe string-payload om naar geldige JSON
-     * @param  string  $candidateKey  Repeater-row-key voor de oude shape
+     * @param  callable(string): ?string  $normalizer  turns a raw string payload into valid JSON
+     * @param  string  $candidateKey  Repeater row key for the old shape
      * @return list<Geometry>
      */
-    private function parseGeometries(mixed $input, callable $normalizer, string $candidateKey): array
+    private static function parseGeometries(mixed $input, callable $normalizer, string $candidateKey): array
     {
         $json = is_array($input) ? json_encode($input) : $normalizer($input);
         $decoded = json_decode((string) $json, true);

--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -6,33 +6,38 @@ namespace App\Jobs\Zaak;
 
 use App\Actions\Geospatial\CheckIntersects;
 use App\EventForm\State\FormState;
+use App\EventForm\Submit\EventLocationGeometryBuilder;
 use App\EventForm\Submit\ZaakeigenschappenMap;
 use App\Models\Municipality;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
-use App\Normalizers\OpenFormsNormalizer;
-use App\Support\Helpers\ArrayHelper;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use App\ValueObjects\OzZaak;
 use App\ValueObjects\ZGW\CatalogiEigenschap;
+use Brick\Geo\Curve;
 use Brick\Geo\Engine\PdoEngine;
-use Brick\Geo\Io\GeoJsonReader;
-use Brick\Geo\LineString;
+use Brick\Geo\Geometry;
+use Brick\Geo\GeometryCollection;
+use Brick\Geo\Point;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Woweb\Openzaak\Openzaak;
 
 /**
- * Voor route-events (zaaktype met `triggers_route_check = true`): maakt
- * per gemeente waar de route doorheen loopt (exclusief start- en
- * eindgemeente) een "doorkomst"-deelzaak aan en kopieert relevante
- * eigenschappen / initiator / documenten / initiële status.
+ * For route events (a zaaktype with `triggers_route_check = true`): creates
+ * a "doorkomst" deelzaak for every municipality a route passes through
+ * (excluding the start and end municipality) and copies the relevant
+ * eigenschappen / initiator / documents / initial status.
  *
- * Input is nu `Zaak`; de LineString komt uit `form_state_snapshot`
- * via `ZaakeigenschappenMap::buildEventLocation()`.
+ * Input is a `Zaak`; the routes come from `form_state_snapshot` via
+ * `ZaakeigenschappenMap::buildEventLocation()`. An event can have more than
+ * one route drawn on the map, so all of them are read and the result is the
+ * union of the municipalities they cross, minus the start and end
+ * municipalities of all routes together.
  */
 class CreateDoorkomstZaken implements ShouldQueue
 {
@@ -50,30 +55,19 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
 
         $state = FormState::fromSnapshot($this->zaak->form_state_snapshot ?? []);
-        $lineArray = $this->extractLineArray($map->buildEventLocation($state));
-        if (! $lineArray) {
+        $lines = $this->extractLines($map->buildEventLocation($state));
+        if ($lines === []) {
             return;
         }
-
-        /** @var LineString $line */
-        $line = (new GeoJsonReader)->read((string) json_encode($lineArray));
 
         $engine = new PdoEngine(DB::connection()->getPdo());
         $checkIntersects = new CheckIntersects($engine);
 
-        $all = $checkIntersects->checkIntersectsWithModels($line);
-        $startModels = $checkIntersects->checkIntersectsWithModels($line->startPoint());
-        $endModels = $checkIntersects->checkIntersectsWithModels($line->endPoint());
-
-        $excluded = $startModels->pluck('brk_identification')
-            ->merge($endModels->pluck('brk_identification'))
-            ->unique()
-            ->toArray();
+        $passing = $this->passingMunicipalities($lines, $checkIntersects);
 
         $hoofdZaakMuniBrk = $this->zaak->municipality?->brk_identification;
 
-        $passing = $all->reject(fn ($m) => in_array($m->brk_identification, $excluded, true))
-            ->reject(fn ($m) => $hoofdZaakMuniBrk && $m->brk_identification === $hoofdZaakMuniBrk);
+        $passing = $passing->reject(fn ($m) => $hoofdZaakMuniBrk && $m->brk_identification === $hoofdZaakMuniBrk);
         if ($passing->isEmpty()) {
             return;
         }
@@ -88,23 +82,82 @@ class CreateDoorkomstZaken implements ShouldQueue
     }
 
     /**
+     * All routes drawn on the map, parsed with the very same parser the
+     * submit flow uses. That parser understands both the current map state
+     * (one FeatureCollection holding N routes) and the old repeater rows
+     * kept in existing drafts.
+     *
      * @param  array<string, mixed>  $eventLocation
-     * @return array<string, mixed>|null
+     * @return list<Geometry>
      */
-    private function extractLineArray(array $eventLocation): ?array
+    private function extractLines(array $eventLocation): array
     {
         $line = $eventLocation['line'] ?? null;
-        if (! $line || $line === 'None') {
-            return null;
+        if (empty($line) || $line === 'None') {
+            return [];
         }
 
-        $json = is_array($line) ? json_encode($line) : OpenFormsNormalizer::normalizeGeoJson($line);
-        $decoded = json_decode((string) $json, true);
-        if (! is_array($decoded)) {
-            return null;
+        return array_values(array_filter(
+            EventLocationGeometryBuilder::parseLines($line),
+            static fn (Geometry $geometry) => ! $geometry->isEmpty(),
+        ));
+    }
+
+    /**
+     * The union of the municipalities the routes pass through, minus the
+     * start and end municipalities of ALL routes. The exclusion is deliberately
+     * global and not per route: a municipality where any route begins or ends
+     * is a start or end municipality for this event, so it never gets a
+     * doorkomst deelzaak, not even when another route merely passes through it.
+     *
+     * @param  list<Geometry>  $lines
+     * @return Collection<int, Municipality>
+     */
+    private function passingMunicipalities(array $lines, CheckIntersects $checkIntersects): Collection
+    {
+        $excluded = [];
+        $passing = new Collection;
+
+        foreach ($lines as $line) {
+            foreach ($this->boundaryPoints($line) as $point) {
+                foreach ($checkIntersects->checkIntersectsWithModels($point) as $municipality) {
+                    $excluded[] = $municipality->brk_identification;
+                }
+            }
+
+            $passing = $passing->merge($checkIntersects->checkIntersectsWithModels($line));
         }
 
-        return ArrayHelper::findElementWithKey($decoded, 'coordinates');
+        return $passing
+            ->reject(fn ($m) => in_array($m->brk_identification, $excluded, true))
+            ->unique('brk_identification')
+            ->values();
+    }
+
+    /**
+     * Start and end points of a route. A route drawn as a MultiLineString has
+     * no start point of its own, so its parts are walked instead.
+     *
+     * @return list<Point>
+     */
+    private function boundaryPoints(Geometry $geometry): array
+    {
+        if ($geometry instanceof Curve) {
+            return $geometry->isEmpty() ? [] : [$geometry->startPoint(), $geometry->endPoint()];
+        }
+
+        if ($geometry instanceof GeometryCollection) {
+            $points = [];
+            foreach ($geometry->geometries() as $part) {
+                foreach ($this->boundaryPoints($part) as $point) {
+                    $points[] = $point;
+                }
+            }
+
+            return $points;
+        }
+
+        return [];
     }
 
     private function createDeelzaakFor(Openzaak $openzaak, OzZaak $hoofdZaak, Municipality $muniRef, FormState $state): void

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Tests for CreateDoorkomstZaken.
+ *
+ * A route event can have more than one route drawn on the map. Every
+ * drawn route has to produce doorkomst deelzaken for the municipalities
+ * it crosses. The result is the union over all routes, minus the start
+ * and end municipalities of all routes together: a municipality where any
+ * route begins or ends never gets a deelzaak, not even when another route
+ * merely passes through it.
+ *
+ * The fixture is a grid of one-degree municipality squares:
+ *
+ *   y  2..3   GM-B1   GM-B2   GM-B3
+ *   y  1..2   GM-C1
+ *   y  0..1   GM-A1   GM-A2   GM-A3
+ *   y -1..0   GM-A0
+ *             x 0..1  x 1..2  x 2..3
+ *
+ * Route A runs west to east through row A, route B does the same through
+ * row B. Both routes start and end in an outer square, so the expected
+ * result is one deelzaak for GM-A2 and one for GM-B2. GM-A0 and GM-C1 sit
+ * in the first column and are only touched by the north-south route used
+ * for the global-exclusion case.
+ *
+ * The hoofdzaak itself belongs to GM-HOOFD, which lies outside the grid.
+ */
+
+use App\EventForm\Submit\ZaakeigenschappenMap;
+use App\Jobs\Zaak\CreateDoorkomstZaken;
+use App\Models\Municipality;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Tests\Fakes\ZgwHttpFake;
+use Woweb\Openzaak\Openzaak;
+
+uses(RefreshDatabase::class);
+
+/**
+ * A municipality square with its own active doorkomst zaaktype.
+ */
+function doorkomstMunicipality(string $brk, float $minX, float $minY, float $maxX, float $maxY, bool $withDoorkomstZaaktype = true): Municipality
+{
+    $municipality = Municipality::factory()->create([
+        'name' => $brk,
+        'brk_identification' => $brk,
+        'geometry' => json_encode([
+            'type' => 'MultiPolygon',
+            'coordinates' => [[[
+                [$minX, $minY],
+                [$maxX, $minY],
+                [$maxX, $maxY],
+                [$minX, $maxY],
+                [$minX, $minY],
+            ]]],
+        ]),
+    ]);
+
+    if ($withDoorkomstZaaktype) {
+        $zaaktype = Zaaktype::factory()->create([
+            'name' => 'Doorkomst '.$brk,
+            'municipality_id' => $municipality->id,
+            'is_active' => true,
+            'triggers_route_check' => false,
+            'zgw_zaaktype_url' => doorkomstZaaktypeUrl($brk),
+        ]);
+
+        $municipality->doorkomst_zaaktype_id = $zaaktype->id;
+        $municipality->save();
+    }
+
+    return $municipality->refresh();
+}
+
+function doorkomstZaaktypeUrl(string $brk): string
+{
+    return ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/doorkomst-'.$brk;
+}
+
+/**
+ * The grid described in the file docblock.
+ *
+ * @return array<string, Municipality>
+ */
+function doorkomstGrid(): array
+{
+    return [
+        'GM-A0' => doorkomstMunicipality('GM-A0', 0, -1, 1, 0),
+        'GM-A1' => doorkomstMunicipality('GM-A1', 0, 0, 1, 1),
+        'GM-A2' => doorkomstMunicipality('GM-A2', 1, 0, 2, 1),
+        'GM-A3' => doorkomstMunicipality('GM-A3', 2, 0, 3, 1),
+        'GM-C1' => doorkomstMunicipality('GM-C1', 0, 1, 1, 2),
+        'GM-B1' => doorkomstMunicipality('GM-B1', 0, 2, 1, 3),
+        'GM-B2' => doorkomstMunicipality('GM-B2', 1, 2, 2, 3),
+        'GM-B3' => doorkomstMunicipality('GM-B3', 2, 2, 3, 3),
+    ];
+}
+
+/**
+ * A route-check zaak whose form state holds the given map state.
+ */
+function doorkomstHoofdZaak(mixed $routeState): Zaak
+{
+    $municipality = doorkomstMunicipality('GM-HOOFD', 10, 10, 11, 11, false);
+
+    $zaaktype = Zaaktype::factory()->create([
+        'name' => 'Evenementenvergunning',
+        'municipality_id' => $municipality->id,
+        'is_active' => true,
+        'triggers_route_check' => true,
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/hoofd',
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofdzaak',
+        'form_state_snapshot' => ['values' => ['routesOpKaart' => $routeState]],
+    ]);
+}
+
+/**
+ * @param  list<mixed>  $coordinates
+ * @return array<string, mixed>
+ */
+function doorkomstFeature(array $coordinates, string $type = 'LineString'): array
+{
+    return [
+        'type' => 'Feature',
+        'properties' => [],
+        'geometry' => [
+            'type' => $type,
+            'coordinates' => $coordinates,
+        ],
+    ];
+}
+
+/**
+ * Current map state: a single Map component holding N features.
+ *
+ * @param  list<array<string, mixed>>  $features
+ * @return array<string, mixed>
+ */
+function doorkomstMapState(array $features): array
+{
+    return [
+        'lat' => 0.5,
+        'lng' => 0.5,
+        'geojson' => [
+            'type' => 'FeatureCollection',
+            'features' => $features,
+        ],
+    ];
+}
+
+/** @return list<list<float>> */
+function doorkomstRouteThroughRowA(): array
+{
+    return [[0.5, 0.5], [2.5, 0.5]];
+}
+
+/** @return list<list<float>> */
+function doorkomstRouteThroughRowB(): array
+{
+    return [[0.5, 2.5], [2.5, 2.5]];
+}
+
+/**
+ * South to north through the first column: starts in GM-A0, ends in
+ * GM-B1 and passes straight through GM-A1 and GM-C1.
+ *
+ * @return list<list<float>>
+ */
+function doorkomstRouteThroughFirstColumn(): array
+{
+    return [[0.5, -0.5], [0.5, 2.5]];
+}
+
+/**
+ * Minimal ZGW responses: creating a deelzaak succeeds, every catalogi
+ * lookup comes back empty so the job only exercises the route logic.
+ */
+function doorkomstFakeZgw(): void
+{
+    $base = ZgwHttpFake::$baseUrl;
+    $created = 0;
+
+    Http::fake(function (Request $request) use ($base, &$created) {
+        $path = (string) parse_url($request->url(), PHP_URL_PATH);
+
+        if ($request->method() === 'POST' && $path === '/zaken/api/v1/zaken') {
+            $created++;
+
+            return Http::response(['url' => $base.'/zaken/api/v1/zaken/deelzaak-'.$created], 201);
+        }
+
+        if ($request->method() === 'GET' && str_starts_with($path, '/zaken/api/v1/zaken/')) {
+            return Http::response(doorkomstZaakPayload($base.$path), 200);
+        }
+
+        return Http::response([], 200);
+    });
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function doorkomstZaakPayload(string $url): array
+{
+    return [
+        'url' => $url,
+        'identificatie' => 'ZAAK-'.basename($url),
+        'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/hoofd',
+        'omschrijving' => 'Route event',
+        'startdatum' => '2026-09-01',
+        'registratiedatum' => '2026-08-19',
+        'einddatum' => null,
+        'einddatumGepland' => null,
+        'uiterlijkeEinddatumAfdoening' => null,
+        'bronorganisatie' => '123456782',
+        'zaakgeometrie' => null,
+        '_expand' => [
+            'deelzaken' => [],
+            'eigenschappen' => [
+                doorkomstEigenschap($url, 'start_evenement', '2026-09-01T10:00:00+02:00'),
+                doorkomstEigenschap($url, 'eind_evenement', '2026-09-01T18:00:00+02:00'),
+            ],
+        ],
+    ];
+}
+
+/**
+ * @return array<string, string>
+ */
+function doorkomstEigenschap(string $zaakUrl, string $naam, string $waarde): array
+{
+    return [
+        'uuid' => $naam,
+        'url' => $zaakUrl.'/zaakeigenschappen/'.$naam,
+        'zaak' => $zaakUrl,
+        'eigenschap' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/eigenschappen/'.$naam,
+        'naam' => $naam,
+        'waarde' => $waarde,
+    ];
+}
+
+/**
+ * The zaaktype URLs the job actually created a deelzaak for.
+ *
+ * @return list<string>
+ */
+function doorkomstCreatedZaaktypen(): array
+{
+    $zaaktypen = [];
+
+    foreach (Http::recorded() as [$request, $response]) {
+        if ($request->method() !== 'POST') {
+            continue;
+        }
+        if (parse_url($request->url(), PHP_URL_PATH) !== '/zaken/api/v1/zaken') {
+            continue;
+        }
+        $zaaktypen[] = (string) ($request->data()['zaaktype'] ?? '');
+    }
+
+    sort($zaaktypen);
+
+    return $zaaktypen;
+}
+
+function doorkomstRunJob(Zaak $zaak): void
+{
+    (new CreateDoorkomstZaken($zaak))->handle(app(Openzaak::class), new ZaakeigenschappenMap);
+}
+
+beforeEach(function () {
+    // Running with PostGIS: the extension is needed for the intersect check.
+    if (config('database.default') === 'pgsql') {
+        try {
+            DB::statement('CREATE EXTENSION IF NOT EXISTS postgis;');
+        } catch (Exception) {
+            // Already present, or created by the container init script.
+        }
+    }
+
+    Config::set('openzaak.url', ZgwHttpFake::$baseUrl.'/');
+
+    doorkomstGrid();
+    doorkomstFakeZgw();
+});
+
+test('creates doorkomst zaken for the crossed municipalities of every drawn route', function () {
+    $zaak = doorkomstHoofdZaak(doorkomstMapState([
+        doorkomstFeature(doorkomstRouteThroughRowA()),
+        doorkomstFeature(doorkomstRouteThroughRowB()),
+    ]));
+
+    doorkomstRunJob($zaak);
+
+    expect(doorkomstCreatedZaaktypen())->toBe([
+        doorkomstZaaktypeUrl('GM-A2'),
+        doorkomstZaaktypeUrl('GM-B2'),
+    ]);
+});
+
+test('excludes the start and end municipality of every route', function () {
+    $zaak = doorkomstHoofdZaak(doorkomstMapState([
+        doorkomstFeature(doorkomstRouteThroughRowA()),
+        doorkomstFeature(doorkomstRouteThroughRowB()),
+    ]));
+
+    doorkomstRunJob($zaak);
+
+    $created = doorkomstCreatedZaaktypen();
+
+    foreach (['GM-A1', 'GM-A3', 'GM-B1', 'GM-B3'] as $brk) {
+        expect($created)->not->toContain(doorkomstZaaktypeUrl($brk));
+    }
+});
+
+test('never creates a deelzaak for a municipality another route starts in', function () {
+    // GM-A1 is the start municipality of the route through row A, and the
+    // route through the first column passes straight through it. It is a
+    // start municipality of this event, so it gets no deelzaak at all.
+    $zaak = doorkomstHoofdZaak(doorkomstMapState([
+        doorkomstFeature(doorkomstRouteThroughRowA()),
+        doorkomstFeature(doorkomstRouteThroughFirstColumn()),
+    ]));
+
+    doorkomstRunJob($zaak);
+
+    $created = doorkomstCreatedZaaktypen();
+
+    expect($created)->not->toContain(doorkomstZaaktypeUrl('GM-A1'))
+        ->and($created)->toBe([
+            doorkomstZaaktypeUrl('GM-A2'),
+            doorkomstZaaktypeUrl('GM-C1'),
+        ]);
+});
+
+test('reads a MultiLineString route instead of crashing on it', function () {
+    $zaak = doorkomstHoofdZaak(doorkomstMapState([
+        doorkomstFeature([
+            doorkomstRouteThroughRowA(),
+            doorkomstRouteThroughRowB(),
+        ], 'MultiLineString'),
+    ]));
+
+    doorkomstRunJob($zaak);
+
+    expect(doorkomstCreatedZaaktypen())->toBe([
+        doorkomstZaaktypeUrl('GM-A2'),
+        doorkomstZaaktypeUrl('GM-B2'),
+    ]);
+});
+
+test('reads every route from an old repeater draft state', function () {
+    $zaak = doorkomstHoofdZaak([
+        ['routeVanHetEvenement' => doorkomstMapState([doorkomstFeature(doorkomstRouteThroughRowA())])],
+        ['routeVanHetEvenement' => doorkomstMapState([doorkomstFeature(doorkomstRouteThroughRowB())])],
+    ]);
+
+    doorkomstRunJob($zaak);
+
+    expect(doorkomstCreatedZaaktypen())->toBe([
+        doorkomstZaaktypeUrl('GM-A2'),
+        doorkomstZaaktypeUrl('GM-B2'),
+    ]);
+});


### PR DESCRIPTION
## The problem

An event can have more than one route drawn on the map, and the form already
evaluates all of them. `CreateDoorkomstZaken` did not: `extractLineArray()`
ran `ArrayHelper::findElementWithKey($decoded, 'coordinates')` over the map
state, which returns the **first** `coordinates` it finds. Everything after
that point in the job (the intersect check, the start/end exclusion, the
deelzaak creation) therefore only ever saw route 1.

The effect for an applicant with two routes is that the municipalities on
route 2 and up silently never get a doorkomst deelzaak. Nothing fails, no
error is logged, the zaak just misses the municipalities it should have
notified.

A second, smaller problem sits in the same place: a route drawn as a
`MultiLineString` (one route in several parts) made the job crash on
`$line->startPoint()`, because `startPoint()` only exists on a `LineString`.

## The fix

The job now reads the routes with `EventLocationGeometryBuilder::parseLines()`,
the same parser the submit flow uses. That parser already returns **all**
geometries, and it already understands both state shapes: the current map
state with several features in one `geojson.features[]`, and the old repeater
rows that still sit in existing drafts. Reusing it means the job and the
submit flow can no longer disagree about what "the routes" are, so I made
`parseLines()` public and static instead of writing a second parser.

Selecting the municipalities is now:

- the union over all routes of the municipalities they intersect;
- minus the start and end municipalities of all routes together.

The exclusion is deliberately global, not per route. A municipality where any
route begins or ends is a start or end municipality of this event, so it never
gets a doorkomst deelzaak, not even when another route merely passes through
it. The municipality of the hoofdzaak itself is still excluded, as before.

`boundaryPoints()` replaces the direct `startPoint()`/`endPoint()` calls: for
a `Curve` it returns the start and end point, and for a geometry collection
(a `MultiLineString`) it walks the parts and returns their start and end
points. That is what fixes the crash, and it keeps the exclusion correct for
a route made of several segments.

## Tests

`tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php` is new. It builds a
grid of municipality squares, draws routes across it, and asserts which
zaaktypen the job actually posts a deelzaak for:

- doorkomst zaken are created for the crossed municipalities of every drawn
  route;
- the start and end municipality of every route stay excluded;
- a municipality that one route starts in gets no deelzaak even when a second
  route passes straight through it;
- a `MultiLineString` route is read instead of crashing;
- an old repeater draft state still yields every route.

Three of those fail on the unchanged code (two on the missing second route,
one on the `startPoint()` crash). The start/end exclusion test is the
regression guard on behaviour that was already correct, and the global
exclusion test pins down the semantics above.

## Note on the diff

While touching `EventLocationGeometryBuilder` I translated the docblocks of
the methods I changed from Dutch to English, which is why that file's diff is
larger than the actual change. The code change there is only `parseLines()`
becoming public and static, plus the two call sites that follow from it.
