### PR TITLE
Keep a deselected location kind out of the municipality check

### DIFF
--- a/app/EventForm/Services/ServiceFetcher.php
+++ b/app/EventForm/Services/ServiceFetcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Services;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Support\LocationKinds;
 use App\Models\Municipality;
 use App\Models\Organisation;
 use App\Models\User;
@@ -111,11 +112,14 @@ class ServiceFetcher
             // Polygonen en lijnen zitten via hun gefilterde geometrieën nog
             // steeds in de hash, dus de gemeentebepaling voor kaart-items
             // triggert ongewijzigd.
-            'inGemeentenResponse' => sha1((string) json_encode([
-                'p' => $this->collectPolygonsFromEditgrid($state->get('locatieSOpKaart')),
-                'l' => $this->collectLinesFromEditgrid($state->get('routesOpKaart')),
-                'a' => $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn'), $authoritativeAddresses),
-            ])),
+            //
+            // The tick boxes of `waarVindtHetEvenementPlaats` reach the hash
+            // through `locationCheckInput()`: unticking a kind drops its
+            // value here as well, so it busts the cache instead of returning
+            // the response that still counted it.
+            'inGemeentenResponse' => sha1((string) json_encode(
+                $this->locationCheckInput($state, $authoritativeAddresses)
+            )),
             default => null,
         };
     }
@@ -172,19 +176,50 @@ class ServiceFetcher
 
     private function fetchInGemeentenResponse(FormState $state, bool $authoritativeAddresses): void
     {
-        $input = new LocationServerCheckInput(
-            polygons: $this->collectPolygonsFromEditgrid($state->get('locatieSOpKaart')),
-            line: null,
-            lines: $this->collectLinesFromEditgrid($state->get('routesOpKaart')),
-            addresses: $this->collectAddressesFromEditgrid($state->get('adresVanDeGebouwEn'), $authoritativeAddresses),
-            address: null,
-        );
+        $input = $this->locationCheckInput($state, $authoritativeAddresses);
 
         if (! $input->hasAnyInput()) {
+            // Everything the check would weigh sits in a kind the organiser
+            // dropped, so an earlier response — the copied event's, or the one
+            // from before the kind was unticked — is about a location that is
+            // no longer asked for. Leaving it standing keeps its municipality
+            // in the choice list, where it can still be submitted.
+            //
+            // A reactive run leaves out addresses whose municipality is not
+            // known yet, so its empty input alone does not prove there is no
+            // location: an address being typed is simply waiting for the gate.
+            // Weigh it the authoritative way before wiping anything.
+            $remaining = $authoritativeAddresses ? $input : $this->locationCheckInput($state, true);
+
+            if (! $remaining->hasAnyInput() && LocationKinds::hasDroppedAnswers($state)) {
+                $state->setVariable('inGemeentenResponse', null);
+            }
+
             return;
         }
 
         $state->setVariable('inGemeentenResponse', $this->locationService->execute($input));
+    }
+
+    /**
+     * The location check's input: the drawn areas, the drawn routes and the
+     * complete addresses, each one taken only when its kind is still ticked
+     * in `waarVindtHetEvenementPlaats`.
+     *
+     * Unticking a kind hides its field but leaves its raw value in the state
+     * (see `LocationKinds`), so reading the fields directly counts locations
+     * the organiser dropped. Both the fetch and its cache hash go through
+     * here, so they can never disagree about what the input is.
+     */
+    private function locationCheckInput(FormState $state, bool $authoritativeAddresses): LocationServerCheckInput
+    {
+        return new LocationServerCheckInput(
+            polygons: $this->collectPolygonsFromEditgrid(LocationKinds::valueFor($state, LocationKinds::BUITEN)),
+            line: null,
+            lines: $this->collectLinesFromEditgrid(LocationKinds::valueFor($state, LocationKinds::ROUTE)),
+            addresses: $this->collectAddressesFromEditgrid(LocationKinds::valueFor($state, LocationKinds::GEBOUW), $authoritativeAddresses),
+            address: null,
+        );
     }
 
     /**

--- a/app/EventForm/Support/LocationKinds.php
+++ b/app/EventForm/Support/LocationKinds.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventForm\Support;
+
+use App\EventForm\State\FormState;
+
+/**
+ * The three location kinds of `waarVindtHetEvenementPlaats` and the form
+ * field that answers each of them.
+ *
+ * Only the field of a ticked kind is asked for, but unticking a kind does
+ * not empty its field: Filament hides the component and keeps its raw
+ * value, and `FormState::absorbFields()` merges rather than replaces, so
+ * nothing ever removes it from the state. An application copied from an
+ * earlier event therefore still carries the source event's address after
+ * the organiser unticked "in a building" and drew a route instead.
+ *
+ * Everything that reads a location field must go through `valueFor()`, so
+ * that leftover state of an unticked kind stays out of the result.
+ */
+final class LocationKinds
+{
+    /** Field key of the question that ticks the location kinds. */
+    public const QUESTION = 'waarVindtHetEvenementPlaats';
+
+    public const GEBOUW = 'gebouw';
+
+    public const BUITEN = 'buiten';
+
+    public const ROUTE = 'route';
+
+    /**
+     * The form field holding the answer for each location kind.
+     *
+     * @var array<string, string>
+     */
+    public const FIELD_BY_KIND = [
+        self::GEBOUW => 'adresVanDeGebouwEn',
+        self::BUITEN => 'locatieSOpKaart',
+        self::ROUTE => 'routesOpKaart',
+    ];
+
+    /**
+     * Is this location kind ticked?
+     *
+     * An unanswered question has no opinion: every kind counts. That covers
+     * state built without the question (drafts from before it existed, a form
+     * filled programmatically) as well as the empty list Filament gives a
+     * checkbox list it has just filled. Nothing is lost by it: the question is
+     * required, so the wizard does not let an empty answer past the location
+     * step anyway.
+     */
+    public static function isSelected(FormState $state, string $kind): bool
+    {
+        $answer = $state->get(self::QUESTION);
+
+        if (! is_array($answer) || $answer === []) {
+            return true;
+        }
+
+        // `FormState::get()` normalises both shapes the answer occurs in:
+        // Filament's list of ticked keys (`['gebouw', 'route']`) and the
+        // object form the Open Formulieren rules used (`['gebouw' => true]`).
+        return $state->get(self::QUESTION.'.'.$kind) === true;
+    }
+
+    /**
+     * The value of the field belonging to $kind, or null when that kind is
+     * not ticked (or when $kind is not a location kind at all).
+     */
+    public static function valueFor(FormState $state, string $kind): mixed
+    {
+        $field = self::FIELD_BY_KIND[$kind] ?? null;
+
+        if ($field === null || ! self::isSelected($state, $kind)) {
+            return null;
+        }
+
+        return $state->get($field);
+    }
+
+    /**
+     * Does an unticked kind still hold an answer? That is the leftover state
+     * described above: an address, area or route the organiser dropped but
+     * that nothing removed. Anything derived from the location fields while
+     * this is true was computed over more than the organiser is asking for.
+     */
+    public static function hasDroppedAnswers(FormState $state): bool
+    {
+        foreach (self::FIELD_BY_KIND as $kind => $field) {
+            if (! self::isSelected($state, $kind) && ! empty($state->get($field))) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -13,6 +13,7 @@ use App\EventForm\State\FormDerivedState;
 use App\EventForm\State\FormState;
 use App\EventForm\Submit\ResolveZaaktype;
 use App\EventForm\Submit\SubmitEventForm;
+use App\EventForm\Support\LocationKinds;
 use App\Exceptions\GemeenteLocatieMismatchException;
 use App\Filament\Organiser\Resources\Zaken\ZaakResource;
 use App\Models\Municipality;
@@ -572,7 +573,13 @@ class EventFormPage extends Page implements HasForms
             $fetcher->fetch('evenementenInDeGemeente', $this->state);
         }
 
-        if (in_array($field, ['locatieSOpKaart', 'routesOpKaart', 'adresVanDeGebouwEn'], true)) {
+        // `waarVindtHetEvenementPlaats` belongs in this list even though it
+        // holds no location itself: unticking a kind removes its address,
+        // area or route from the check (see `LocationKinds`), and nothing
+        // else changes at that moment. Without it, the municipality of the
+        // kind just dropped stays in the choice list until the organiser
+        // happens to touch a location field again.
+        if (in_array($field, [LocationKinds::QUESTION, 'locatieSOpKaart', 'routesOpKaart', 'adresVanDeGebouwEn'], true)) {
             // Reactieve check tijdens het typen/tekenen: adressen tellen alleen
             // mee als hun gemeente al uit de auto-fill bekend is, zodat deze
             // synchrone call nooit een trage PDOK-lookup voor een adres doet.

--- a/tests/Feature/EventForm/Pages/EventFormPageServerStateTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormPageServerStateTest.php
@@ -231,3 +231,47 @@ test('een gemanipuleerde locatiecheck in de client-data stuurt de aanvraag niet 
 
     expect($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0001');
 });
+
+test('unticking a location kind takes the copied address out of the municipality choice', function () {
+    // A copy of an application that took place in a building. Unticking "in a
+    // building" leaves the address in the hidden form state — Filament keeps
+    // the raw value of a hidden component and `absorbFields()` merges — so the
+    // tick boxes are the only thing still saying the organiser dropped it.
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [
+            'watIsDeNaamVanHetEvenementVergunning' => 'Buurtfeest',
+            'waarVindtHetEvenementPlaats' => ['gebouw'],
+            'adresVanDeGebouwEn' => ['row-1' => [
+                'naamVanDeLocatieGebouw' => 'Zaal',
+                'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+                    'postcode' => '6411AA', 'huisnummer' => '1', 'brkGemeente' => 'GM0001',
+                    'straatnaam' => 'Straat', 'plaatsnaam' => 'Plaats',
+                ],
+            ]],
+            'inGemeentenResponse' => locatieCheckVoor('GM0001', 'BronGemeente'),
+            'evenementInGemeente' => ['brk_identification' => 'GM0001', 'name' => 'BronGemeente'],
+        ], 'system' => []],
+        'current_step_key' => null,
+    ]);
+
+    $component = Livewire::test(EventFormPage::class, ['draft' => $draft->id]);
+
+    // The unticking alone must already drop the source municipality.
+    $component->set('data.waarVindtHetEvenementPlaats', ['route']);
+
+    /** @var EventFormPage $page */
+    $page = $component->instance();
+    expect($page->state()->get('gemeenten'))->toBeNull();
+
+    // And with a fresh route through a single municipality there is nothing
+    // left to choose: the gate lets the organiser through without asking, and
+    // without the source municipality.
+    $component->set('data.routesOpKaart', routeMapState([[2.5, 0.0], [3.5, 0.0]]));
+    $page = $component->instance();
+    locatieGate()($page);
+
+    expect(array_keys((array) $page->state()->get('inGemeentenResponse.all.object')))->toBe(['GM0002'])
+        ->and($page->state()->get('evenementInGemeente.brk_identification'))->toBe('GM0002');
+});

--- a/tests/Feature/EventForm/Services/ServiceFetcherLocationKindTest.php
+++ b/tests/Feature/EventForm/Services/ServiceFetcherLocationKindTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Unticking a location kind must take its answer out of the municipality
+ * check.
+ *
+ * Bug report: an organiser copies an application that took place in a
+ * building, unticks "in a building", draws a route instead, and the
+ * municipality of the copied address is still offered as a choice — the
+ * application can end up with the source event's municipality.
+ *
+ * Cause: unticking hides the field but leaves its raw value in the form
+ * state (Filament keeps the value of a hidden component, and
+ * `FormState::absorbFields()` merges instead of replaces), and
+ * `ServiceFetcher` read the location fields straight from the state
+ * without looking at `waarVindtHetEvenementPlaats`.
+ */
+
+use App\EventForm\Services\ServiceFetcher;
+use App\EventForm\State\FormState;
+use App\Models\Municipality;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    $this->fetcher = app(ServiceFetcher::class);
+
+    Municipality::factory()->create([
+        'brk_identification' => 'GM0001',
+        'name' => 'BronGemeente',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[-1,-1],[1,-1],[1,1],[-1,1],[-1,-1]]]]}',
+    ]);
+    Municipality::factory()->create([
+        'brk_identification' => 'GM0002',
+        'name' => 'RouteGemeente',
+        'geometry' => '{"type":"MultiPolygon","coordinates":[[[[2,-1],[4,-1],[4,1],[2,1],[2,-1]]]]}',
+    ]);
+
+    // Any PDOK lookup would resolve to the source municipality; the copied
+    // address must not reach it in the first place.
+    Http::fake(['*' => Http::response([
+        'response' => ['docs' => [['gemeentecode' => '0001', 'gemeentenaam' => 'BronGemeente']]],
+    ])]);
+});
+
+/** The address of the copied event, as the auto-fill stored it. */
+function gekopieerdAdres(): array
+{
+    return ['row-1' => [
+        'naamVanDeLocatieGebouw' => 'Zaal',
+        'adresVanHetGebouwWaarUwEvenementPlaatsvindt1' => [
+            'postcode' => '6411AA',
+            'huisnummer' => '1',
+            'brkGemeente' => 'GM0001',
+            'straatnaam' => 'Straat',
+            'plaatsnaam' => 'Plaats',
+        ],
+    ]];
+}
+
+/** Map state as the map component writes a route away. */
+function routeDoor(array $coordinates): array
+{
+    return [
+        'lat' => 0.0,
+        'lng' => 0.0,
+        'geojson' => [
+            'type' => 'FeatureCollection',
+            'features' => [[
+                'type' => 'Feature',
+                'properties' => new stdClass,
+                'geometry' => ['type' => 'LineString', 'coordinates' => $coordinates],
+            ]],
+        ],
+    ];
+}
+
+test('an address left behind by an unticked kind stays out of the municipality check', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => gekopieerdAdres(),
+        'routesOpKaart' => routeDoor([[2.5, 0.0], [3.5, 0.0]]),
+    ]);
+
+    $this->fetcher->fetch('inGemeentenResponse', $state);
+
+    $brkIds = collect($state->get('inGemeentenResponse.all.items'))->pluck('brk_identification')->all();
+
+    expect($brkIds)->toBe(['GM0002'])
+        ->and($state->get('gemeenten'))->not->toHaveKey('GM0001');
+});
+
+test('unticking a kind re-runs the check instead of returning the cached response', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['gebouw', 'route'],
+        'adresVanDeGebouwEn' => gekopieerdAdres(),
+        'routesOpKaart' => routeDoor([[2.5, 0.0], [3.5, 0.0]]),
+    ]);
+
+    $this->fetcher->fetch('inGemeentenResponse', $state);
+
+    expect(collect($state->get('inGemeentenResponse.all.items'))->pluck('brk_identification')->sort()->values()->all())
+        ->toBe(['GM0001', 'GM0002']);
+
+    // Only the tick boxes change; the address and the route keep the value
+    // they had. That must still count as different input, or the fetcher
+    // hands back the response that included the address.
+    $state->setField('waarVindtHetEvenementPlaats', ['route']);
+
+    $this->fetcher->fetch('inGemeentenResponse', $state);
+
+    expect(collect($state->get('inGemeentenResponse.all.items'))->pluck('brk_identification')->all())
+        ->toBe(['GM0002']);
+});
+
+test('the gate drops an earlier response once no ticked kind holds a location', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => gekopieerdAdres(),
+        // The organiser has not drawn the route yet.
+        'routesOpKaart' => [],
+        // What the copied application left behind.
+        'inGemeentenResponse' => ['all' => [
+            'items' => [['brk_identification' => 'GM0001', 'name' => 'BronGemeente']],
+            'object' => ['GM0001' => ['brk_identification' => 'GM0001', 'name' => 'BronGemeente']],
+            'within' => true,
+        ]],
+    ]);
+
+    $this->fetcher->fetch('inGemeentenResponse', $state);
+
+    expect($state->get('inGemeentenResponse'))->toBeNull()
+        ->and($state->get('gemeenten'))->toBeNull();
+});


### PR DESCRIPTION
## What goes wrong

An organiser copies an application that took place in a building, unticks "in
a building or several buildings" in `waarVindtHetEvenementPlaats` and draws a
route instead. The address of the source event still decides which
municipalities are found: it stays in the choice list next to the ones the
route passes through, and it can be picked and submitted.

Unticking a kind hides its field but does not empty it. Filament keeps the raw
value of a hidden component, and `FormState::absorbFields()` merges rather than
replaces, so nothing ever removes the address from the form state.
`ServiceFetcher` read `adresVanDeGebouwEn`, `locatieSOpKaart` and
`routesOpKaart` straight from that state, without asking whether their kind was
still ticked, and its cache hash was built from the same raw fields. Unticking
a kind therefore changed neither the input nor the hash: even a fresh run got
the response that still counted the address.

I found this while looking into #479 and deliberately kept it out of that pull
request.

## The fix

- `ServiceFetcher` builds the location check's input in one place,
  `locationCheckInput()`, and takes each field only while its kind is ticked.
  The cache hash is built from that same input, so unticking a kind now busts
  the cache instead of returning the stale response.
- When everything the check would weigh sits in a kind that was dropped, the
  stored `inGemeentenResponse` is cleared rather than left standing. This only
  fires while an unticked kind still holds an answer, so it is the stale copy
  that goes and nothing else changes about when a response disappears. A
  reactive run weighs the input the authoritative way first, so an address that
  is still being typed keeps its response until the gate settles it.
- `EventFormPage` triggers the location check on `waarVindtHetEvenementPlaats`
  as well. Unticking a kind changes nothing else, so without this the
  municipality of the kind just dropped stayed in the choice list until the
  organiser happened to touch a location field again.
- The new `LocationKinds` support class holds the three kinds, the field
  belonging to each of them, and the "is it ticked" reading. An unanswered
  question has no opinion and every kind counts, so state built without the
  question (older drafts, a form filled programmatically, the empty list
  Filament gives a freshly filled checkbox list) keeps behaving as it did. The
  question is required, so an empty answer never gets past the location step
  anyway.

The same forgotten state also reaches ZGW and the PDF (`ZaakeigenschappenMap`,
`MapFormStateToReferenceData`, `SubmissionReport`). That is a separate change;
`LocationKinds` is the piece it can reuse.

## Tests

Four new tests, each one failing on the unchanged base:

- an address left behind by an unticked kind stays out of the municipality
  check;
- unticking a kind re-runs the check instead of returning the cached response;
- the gate drops an earlier response once no ticked kind holds a location;
- at page level: after unticking "in a building" the source municipality is
  gone from the choice list, and a fresh route through a single municipality
  passes the gate without a choice.
