### PR TITLE
Sentry: opt-in Redis ignore toggle and breadcrumb query scrub

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,10 @@ LOG_LEVEL=debug
 SENTRY_LARAVEL_DSN=
 SENTRY_TRACES_SAMPLE_RATE=0.1
 SENTRY_PROFILES_SAMPLE_RATE=0.1
+# Stop reporting RedisException to Sentry. Only set this on environments where
+# Redis connection noise is accepted (an undersized test server, for example);
+# never in production, where a Redis failure is a real incident.
+# SENTRY_IGNORE_REDIS_EXCEPTIONS=true
 
 DB_CONNECTION=pgsql
 DB_HOST=pgsql

--- a/app/Support/Sentry/BreadcrumbScrubber.php
+++ b/app/Support/Sentry/BreadcrumbScrubber.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Support\Sentry;
+
+use Sentry\Breadcrumb;
+
+/**
+ * Removes personal data from Sentry breadcrumbs before they are recorded.
+ *
+ * The SDK's HTTP client integration strips the query string from the breadcrumb
+ * URL, but adds it back as a separate `http.query` metadata field. Our address
+ * lookups against PDOK carry a postcode and house number in that query string, so
+ * without this scrub every breadcrumb of such a request ships personal data to
+ * Sentry.
+ *
+ * Referenced from config/sentry.php as an array callable instead of a closure,
+ * because the configuration has to stay serializable for `php artisan config:cache`.
+ */
+final class BreadcrumbScrubber
+{
+    public static function scrub(Breadcrumb $breadcrumb): Breadcrumb
+    {
+        return $breadcrumb->withoutMetadata('http.query');
+    }
+}

--- a/config/sentry.php
+++ b/config/sentry.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Support\Sentry\BreadcrumbScrubber;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
@@ -56,12 +57,19 @@ return [
     'send_default_pii' => env('SENTRY_SEND_DEFAULT_PII', false),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_exceptions
-    'ignore_exceptions' => [
+    'ignore_exceptions' => array_values(array_filter([
         AuthenticationException::class,
         ValidationException::class,
         NotFoundHttpException::class,
         MethodNotAllowedHttpException::class,
-    ],
+        // Opt-in per environment: some environments run Redis on hardware that is
+        // too light for the workload and produce connection blips that are noise
+        // rather than defects. Setting SENTRY_IGNORE_REDIS_EXCEPTIONS=true there
+        // silences them; dropping the variable again restores reporting without a
+        // code change. Never enable this in production, where a Redis failure is
+        // a real incident.
+        env('SENTRY_IGNORE_REDIS_EXCEPTIONS', false) ? RedisException::class : null,
+    ])),
 
     // @see: https://docs.sentry.io/platforms/php/guides/laravel/configuration/options/#ignore_transactions
     'ignore_transactions' => [
@@ -98,6 +106,15 @@ return [
         // Capture send notifications as breadcrumbs
         'notifications' => env('SENTRY_BREADCRUMBS_NOTIFICATIONS_ENABLED', true),
     ],
+
+    // The SDK's HTTP client integration strips the query string from the breadcrumb
+    // URL, but adds it back as a separate `http.query` metadata field. Our address
+    // lookups against PDOK carry a postcode and house number in that query string,
+    // so every breadcrumb for such a request would ship personal data to Sentry.
+    // Drop the field from all breadcrumbs. This is data hygiene, so it applies to
+    // every environment and is deliberately not configurable. An array callable
+    // rather than a closure, so `php artisan config:cache` keeps working.
+    'before_breadcrumb' => [BreadcrumbScrubber::class, 'scrub'],
 
     // Performance monitoring specific configuration
     'tracing' => [

--- a/tests/Unit/SentryConfigTest.php
+++ b/tests/Unit/SentryConfigTest.php
@@ -1,0 +1,94 @@
+<?php
+
+use App\Support\Sentry\BreadcrumbScrubber;
+use Illuminate\Auth\AuthenticationException;
+use Illuminate\Validation\ValidationException;
+use Sentry\Breadcrumb;
+use Sentry\ClientBuilder;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+// config/sentry.php reads its environment variables while it is evaluated, and the
+// application configuration is already resolved by the time a test runs. These tests
+// therefore evaluate the configuration file again instead of reading config('sentry'),
+// so that toggling an environment variable is actually observable.
+
+afterEach(function () {
+    putenv('SENTRY_IGNORE_REDIS_EXCEPTIONS');
+    unset($_ENV['SENTRY_IGNORE_REDIS_EXCEPTIONS'], $_SERVER['SENTRY_IGNORE_REDIS_EXCEPTIONS']);
+});
+
+/** Evaluate config/sentry.php with the environment as it is right now. */
+function freshSentryConfig(): array
+{
+    return require config_path('sentry.php');
+}
+
+it('does not ignore RedisException unless the environment opts in', function () {
+    expect(freshSentryConfig()['ignore_exceptions'])->toBe([
+        AuthenticationException::class,
+        ValidationException::class,
+        NotFoundHttpException::class,
+        MethodNotAllowedHttpException::class,
+    ]);
+});
+
+it('ignores RedisException when the environment opts in', function () {
+    putenv('SENTRY_IGNORE_REDIS_EXCEPTIONS=true');
+
+    expect(freshSentryConfig()['ignore_exceptions'])->toBe([
+        AuthenticationException::class,
+        ValidationException::class,
+        NotFoundHttpException::class,
+        MethodNotAllowedHttpException::class,
+        RedisException::class,
+    ]);
+});
+
+it('removes the http.query metadata from a breadcrumb', function () {
+    $beforeBreadcrumb = freshSentryConfig()['before_breadcrumb'];
+
+    $breadcrumb = new Breadcrumb(
+        Breadcrumb::LEVEL_INFO,
+        Breadcrumb::TYPE_HTTP,
+        'http',
+        null,
+        [
+            'url' => 'https://api.pdok.nl/bzk/locatieserver/search/v3_1/free',
+            'http.query' => 'q=postcode:1234AB+AND+huisnummer:5',
+            'http.method' => 'GET',
+            'http.response.status_code' => 200,
+        ]
+    );
+
+    expect($beforeBreadcrumb($breadcrumb)->getMetadata())->toBe([
+        'url' => 'https://api.pdok.nl/bzk/locatieserver/search/v3_1/free',
+        'http.method' => 'GET',
+        'http.response.status_code' => 200,
+    ]);
+});
+
+it('leaves a breadcrumb without http.query metadata untouched', function () {
+    $beforeBreadcrumb = freshSentryConfig()['before_breadcrumb'];
+
+    $breadcrumb = new Breadcrumb(
+        Breadcrumb::LEVEL_INFO,
+        Breadcrumb::TYPE_DEFAULT,
+        'cache',
+        'Cache hit',
+        ['key' => 'events:1']
+    );
+
+    expect($beforeBreadcrumb($breadcrumb))->toBe($breadcrumb);
+});
+
+it('keeps the breadcrumb scrubber serializable for config:cache', function () {
+    // A closure here would make `php artisan config:cache` fail, so the callback
+    // must stay an array callable that var_export() can write out.
+    expect(freshSentryConfig()['before_breadcrumb'])->toBe([BreadcrumbScrubber::class, 'scrub']);
+});
+
+it('hands the breadcrumb scrubber to the Sentry client', function () {
+    expect(app(ClientBuilder::class)->getOptions()->getBeforeBreadcrumbCallback())
+        ->toBe([BreadcrumbScrubber::class, 'scrub']);
+});


### PR DESCRIPTION
Two independent Sentry configuration changes that both reduce what we send to Sentry.

## Opt-in toggle for Redis exceptions

Not every environment runs Redis on hardware that matches the workload. On the lighter ones the connection drops now and then, which shows up as `RedisException` issues that are noise rather than defects, while the same exception on production is a real incident I do want to see.

I added a `SENTRY_IGNORE_REDIS_EXCEPTIONS` toggle that appends `\RedisException` to the existing `ignore_exceptions` list when it is set. Semantics:

- Default (variable unset) is exactly the behaviour we have today: the four existing entries, in the same order, and Redis errors are reported.
- An environment that sets `SENTRY_IGNORE_REDIS_EXCEPTIONS=true` stops reporting them.
- Turning reporting back on later is a matter of removing the line from that environment's `.env`, not a code change and not a release.
- Production should never set it.

`.env.example` documents the variable as a commented-out line with that advice. Note that, like every other `env()` call in a config file, the value is baked in when `php artisan config:cache` runs, so set the variable before caching.

## Query strings out of breadcrumbs

The SDK's HTTP client integration removes the query string from the breadcrumb `url` field, but then adds it back as a separate `http.query` metadata field. Our address lookups put a postcode and house number in that query string, so any event captured in such a request carried those values along in its breadcrumbs.

There is now a `before_breadcrumb` callback that drops `http.query` from every breadcrumb. This is data hygiene rather than a per-environment preference, so it is unconditional and has no toggle.

One implementation detail worth knowing: the callback is an array callable pointing at `App\Support\Sentry\BreadcrumbScrubber::scrub()` instead of a closure. A closure in a config file makes `php artisan config:cache` fail with "Your configuration files are not serializable", the same reason the document upload rule is a named class. I verified that `config:cache` succeeds with the array callable and that the SDK accepts it as the `before_breadcrumb` option.

Out of scope: the same lookup URL also ends up in the exception message of a failed HTTP call, which needs a different fix and is tracked separately.

## Tests

Six unit tests in `tests/Unit/SentryConfigTest.php`. They re-evaluate `config/sentry.php` so the environment toggle is actually observable, and clean up the variable afterwards: the default list without `RedisException` and with the existing entries intact, the list with the toggle set, a breadcrumb that loses only its `http.query` field, a breadcrumb without that field coming back untouched, the callback staying serializable, and the callback arriving on the Sentry client options.
