### PR TITLE
Report the database and cache engine versions from /__version

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ use App\Models\Zaaktype;
 use App\Settings\WelcomeSettings;
 use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Route;
 
 // service-register version probe. The register signs a "timestamp\npath" message
@@ -75,6 +77,53 @@ Route::get('/__version', function (Request $request) {
         if (! empty($osRelease['ID']) && ! empty($osRelease['VERSION_ID'])) {
             $runtimes[$osRelease['ID']] = $osRelease['VERSION_ID'];
         }
+    }
+
+    // The database and cache engines, so the register sees patches that land
+    // outside a deploy. These run only after the signature check above, so the
+    // register is the only caller (once a day), and they are read only config
+    // lookups: no table access, and the response carries bare version numbers, no
+    // host, user, schema or extension list. Each engine is wrapped separately so
+    // one that is down, absent or not configured drops out of the payload instead
+    // of failing the endpoint, because a 500 here would hide the whole version
+    // picture behind a single engine outage. Anything not detected is omitted.
+    $versionNumber = static function ($raw): ?string {
+        return is_string($raw) && preg_match('/\d+(\.\d+)*/', $raw, $m) ? $m[0] : null;
+    };
+
+    // PostgreSQL: SHOW server_version returns something like
+    // "16.15 (Debian 16.15-1.pgdg120+1)", of which we keep 16.15. Only the default
+    // connection is asked, and only when it actually runs on pgsql.
+    try {
+        $connection = DB::connection();
+        if ($connection->getDriverName() === 'pgsql') {
+            $row = (array) $connection->selectOne('SHOW server_version');
+            $postgres = $versionNumber($row['server_version'] ?? null);
+            if ($postgres !== null) {
+                $runtimes['postgresql'] = $postgres;
+            }
+        }
+    } catch (Throwable) {
+        // No usable database connection: report no engine rather than a 500.
+    }
+
+    // Redis or Valkey: INFO server carries the version. Valkey also reports a
+    // redis_version, but that is a protocol compatibility number; mapping it onto
+    // the redis cycles would produce a wrong end of life verdict, so valkey_version
+    // wins and decides which slug is reported. phpredis returns the section flat,
+    // predis nests it under "Server".
+    try {
+        $info = Redis::connection()->info('server');
+        $info = is_array($info) ? ($info['Server'] ?? $info) : [];
+        $valkey = $versionNumber($info['valkey_version'] ?? null);
+        $redis = $versionNumber($info['redis_version'] ?? null);
+        if ($valkey !== null) {
+            $runtimes['valkey'] = $valkey;
+        } elseif ($redis !== null) {
+            $runtimes['redis'] = $redis;
+        }
+    } catch (Throwable) {
+        // Same: an unreachable cache yields no redis or valkey runtime.
     }
 
     return response()->json([

--- a/tests/Unit/VersionEndpointTest.php
+++ b/tests/Unit/VersionEndpointTest.php
@@ -1,11 +1,16 @@
 <?php
 
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Process;
+use Illuminate\Support\Facades\Redis;
 
-// The /__version route reads no database. It lives in the Unit suite so it runs
-// without RefreshDatabase (which the Feature suite applies globally): no migrations
-// and no database connection are needed to verify the signature gate and payload.
+// The /__version route touches no application data. It lives in the Unit suite so
+// it runs without RefreshDatabase (which the Feature suite applies globally): no
+// migrations and no database connection are needed to verify the signature gate
+// and payload. The engine version lookups it does after the signature check are
+// read only and wrapped in try/catch, so without a running engine they simply drop
+// out of the payload; the tests below drive them through the facades.
 
 afterEach(function () {
     foreach (glob(sys_get_temp_dir().'/register-version-test-*.json') ?: [] as $file) {
@@ -48,6 +53,38 @@ function signedHeaders(string $secret, ?int $timestamp = null): array
         'X-Register-Timestamp' => (string) $timestamp,
         'X-Register-Signature' => base64_encode($signature),
     ];
+}
+
+/** Let the default connection answer SHOW server_version like a real server does. */
+function fakePostgres(string $serverVersion): void
+{
+    $connection = Mockery::mock();
+    $connection->shouldReceive('getDriverName')->andReturn('pgsql');
+    $connection->shouldReceive('selectOne')->with('SHOW server_version')
+        ->andReturn((object) ['server_version' => $serverVersion]);
+
+    DB::shouldReceive('connection')->andReturn($connection);
+}
+
+/** Let INFO server answer with the given section, in the shape the client returns. */
+function fakeRedisInfo(array $info): void
+{
+    $connection = Mockery::mock();
+    $connection->shouldReceive('info')->with('server')->andReturn($info);
+
+    Redis::shouldReceive('connection')->andReturn($connection);
+}
+
+/** No database at all, as on a host where the engine is down or absent. */
+function unreachableDatabase(): void
+{
+    DB::shouldReceive('connection')->andThrow(new RuntimeException('no database'));
+}
+
+/** Same for the cache: connecting throws instead of returning a client. */
+function unreachableCache(): void
+{
+    Redis::shouldReceive('connection')->andThrow(new RuntimeException('no cache'));
 }
 
 it('returns the version metadata for a valid signed request', function () {
@@ -94,6 +131,74 @@ it('returns null git fields when the version file is missing', function () {
     $this->get('/__version', signedHeaders($secret))
         ->assertOk()
         ->assertJson(['git_tag' => null, 'git_sha' => null, 'branch' => null]);
+});
+
+it('reports the postgresql and redis versions when both engines answer', function () {
+    $secret = registerKeypair();
+    // The Debian packaged suffix is what a managed server actually returns.
+    fakePostgres('17.6 (Debian 17.6-1.pgdg13+1)');
+    fakeRedisInfo(['redis_version' => '7.4.2', 'redis_mode' => 'standalone']);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJsonPath('runtimes.postgresql', '17.6')
+        ->assertJsonPath('runtimes.redis', '7.4.2');
+});
+
+it('reports valkey on its own slug instead of its redis compatibility version', function () {
+    $secret = registerKeypair();
+    unreachableDatabase();
+    // Valkey reports both; redis_version is a compatibility number that would map
+    // onto the wrong end of life cycles, so it must lose from valkey_version.
+    fakeRedisInfo(['redis_version' => '7.2.4', 'valkey_version' => '8.1.1']);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJsonPath('runtimes.valkey', '8.1.1')
+        ->assertJsonMissingPath('runtimes.redis');
+});
+
+it('reads the predis shaped INFO response as well as the phpredis one', function () {
+    $secret = registerKeypair();
+    unreachableDatabase();
+    // predis nests the section under its name, phpredis returns it flat.
+    fakeRedisInfo(['Server' => ['redis_version' => '8.0.3']]);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJsonPath('runtimes.redis', '8.0.3');
+});
+
+it('does not query the database when the default connection is not pgsql', function () {
+    $secret = registerKeypair();
+    unreachableCache();
+    $connection = Mockery::mock();
+    $connection->shouldReceive('getDriverName')->andReturn('sqlite');
+    $connection->shouldNotReceive('selectOne');
+    DB::shouldReceive('connection')->andReturn($connection);
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJsonMissingPath('runtimes.postgresql');
+});
+
+it('answers exactly as before when no engine is reachable', function () {
+    $secret = registerKeypair();
+    useVersionFile(['git_tag' => 'v1.2.3', 'nodejs' => '22.1.0']);
+    unreachableDatabase();
+    unreachableCache();
+
+    $this->get('/__version', signedHeaders($secret))
+        ->assertOk()
+        ->assertJson(['git_tag' => 'v1.2.3'])
+        ->assertJsonPath('runtimes.nodejs', '22.1.0')
+        ->assertJsonStructure([
+            'php', 'framework', 'git_tag', 'git_sha', 'composer_lock_hash',
+            'app_env', 'branch', 'runtimes', 'deployed_at', 'checked_at',
+        ])
+        ->assertJsonMissingPath('runtimes.postgresql')
+        ->assertJsonMissingPath('runtimes.redis')
+        ->assertJsonMissingPath('runtimes.valkey');
 });
 
 it('register:build-version writes the version file from the given options', function () {


### PR DESCRIPTION
The service register probes `/__version` once a day and checks every entry in `runtimes` against endoflife.date. Until now it saw PHP, the framework, Node and the OS, but nothing about the engines this application actually runs on, so a PostgreSQL or Redis release, or a cycle going end of life, stayed invisible to us. Measuring at deploy time would not help: the engines are patched by the hosting party outside our deploys, which is exactly the case this has to catch.

So the endpoint now measures them at request time:

- **PostgreSQL** via `SHOW server_version`, a read only config lookup with no table access. Only the default connection is asked, and only when it actually runs on `pgsql`, so a future app on another driver reports nothing rather than something wrong.
- **Redis or Valkey** via `INFO server`. Valkey also reports a `redis_version`, but that is a protocol compatibility number; mapping it onto the redis cycles would produce a wrong end of life verdict, so `valkey_version` wins and decides which slug is reported. phpredis returns the section flat and predis nests it under `Server`; both shapes are handled.

Both lookups run **after** the signature check, so only the register can trigger them (once a day), and the response still carries bare version numbers: no host, no user, no schema, no extension list. Each engine is wrapped in its own `try/catch`: one that is down, absent or not configured drops out of the payload instead of failing the endpoint, because a 500 here would hide the whole version picture behind a single engine outage.

The signature and 404 behaviour are untouched, and on a host where neither engine answers the payload is exactly what it was before. The route follows the template that ships with the register, so the register side keeps one shape to reason about; the matching end of life mapping lands on the register itself. Deployed environments start reporting engines as soon as this is released.
