### PR TITLE
Fix duplicate Slack notification for failed jobs

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,6 @@ use App\Console\Commands\Zaaktypen\SyncZaaktypen;
 use App\EventForm\Template\LabelRenderer;
 use App\Filament\Admin\Resources\ApplicationResource\Pages\ListApplications;
 use App\Jobs\ProcessOpenNotification;
-use App\Listeners\NotifySlackOfFailedJob;
 use App\Livewire\PersistTableStateHook;
 use App\Models\Export;
 use App\Models\Import;
@@ -22,10 +21,8 @@ use Filament\View\PanelsRenderHook;
 use Illuminate\Auth\Notifications\VerifyEmail;
 use Illuminate\Contracts\View\View;
 use Illuminate\Notifications\Messages\MailMessage;
-use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Config;
-use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Lang;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Validation\Rules\Password;
@@ -114,8 +111,6 @@ class AppServiceProvider extends ServiceProvider
         Passport::tokensExpireIn(CarbonInterval::days(config('app.api.token_expire_in_days')));
 
         Carbon::mixin(new CarbonBusinessDaysMixin);
-
-        Event::listen(JobFailed::class, NotifySlackOfFailedJob::class);
 
         $this->bindCustomMethods();
     }

--- a/tests/Feature/Listeners/NotifySlackOfFailedJobTest.php
+++ b/tests/Feature/Listeners/NotifySlackOfFailedJobTest.php
@@ -3,6 +3,7 @@
 use App\Listeners\NotifySlackOfFailedJob;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 
 beforeEach(function () {
@@ -14,6 +15,9 @@ function makeFailedJobEvent(string $jobName = 'App\\Jobs\\TestJob', string $queu
     $job = Mockery::mock(Job::class);
     $job->shouldReceive('resolveName')->andReturn($jobName);
     $job->shouldReceive('getQueue')->andReturn($queue);
+    // Horizon's ForgetJobTimer also listens to JobFailed, so a real dispatch
+    // through the event dispatcher reaches this method as well.
+    $job->shouldReceive('getJobId')->andReturn('test-job-id');
 
     return new JobFailed('redis', $job, new RuntimeException($message));
 }
@@ -78,6 +82,24 @@ test('stack trace is truncated to 2900 characters', function () {
     (new NotifySlackOfFailedJob)->handle(makeFailedJobEvent());
 
     Http::assertSent(fn ($request) => strlen($request->data()['attachments'][0]['text']) <= 2900);
+});
+
+test('a dispatched job failed event sends exactly one slack notification', function () {
+    config(['services.slack.horizon_webhook_url' => $this->webhookUrl]);
+    Http::fake([$this->webhookUrl => Http::response('ok', 200)]);
+
+    event(makeFailedJobEvent());
+
+    Http::assertSentCount(1);
+});
+
+test('the listener is registered exactly once for the job failed event', function () {
+    $registrations = array_filter(
+        Event::getRawListeners()[JobFailed::class] ?? [],
+        fn ($listener) => is_string($listener) && str_starts_with($listener, NotifySlackOfFailedJob::class)
+    );
+
+    expect($registrations)->toHaveCount(1);
 });
 
 test('does not send slack notification when webhook url is not configured', function () {


### PR DESCRIPTION

`NotifySlackOfFailedJob` was registered twice, so every failed job produced two Slack messages instead of one.

The listener lives in `app/Listeners`, which is exactly what Laravel's automatic event discovery scans. We have no own `EventServiceProvider` in `bootstrap/providers.php`, so `ApplicationBuilder` registers the framework's default one, and that one has `$shouldDiscoverEvents = true`. Discovery therefore already binds `NotifySlackOfFailedJob@handle` to `JobFailed` by itself. On top of that, `AppServiceProvider::boot()` called `Event::listen(JobFailed::class, NotifySlackOfFailedJob::class)`. Those two land in the dispatcher as separate entries (the listener strings differ, so the `array_unique` inside the framework's `EventServiceProvider` does not collapse them) and the handler runs twice per event.

I dropped the explicit registration and kept discovery, because that is what the rest of the repo already does. It was the only listener registered by hand; `LogNotification` and the four `App\Listeners\Auth\*` listeners have always relied on discovery alone. I also checked whether the explicit call had a reason to exist and found none: it was added in the same commit as the listener itself, and the listener sits in the default discovery path with a type-hinted `handle()`, so nothing about it falls outside discovery. The three imports that only served that line are removed with it.

Two tests cover the regression, both failing on `main` before this change:

- dispatching a `JobFailed` event through the dispatcher results in exactly one faked Slack request instead of two
- the dispatcher holds exactly one raw registration for the listener instead of two

The existing tests that call the listener directly are untouched and still pass, so the message payload is unchanged. The test helper now also stubs `getJobId()`, since a real dispatch reaches Horizon's `ForgetJobTimer` listener as well.

Note for merging: `next/multi-zgw-connection` (#482) already drops the same line on its own branch, for the same reason. This PR fixes it on `main` so we do not have to wait for that one. Both sides delete the same statement, so the outcome is the same either way, but the surrounding block differs quite a bit on #482 and may need a hand during the merge.
