### PR TITLE
Register the KvK number on a vestiging rol outside our own OpenZaak

### DIFF
--- a/app/Jobs/Zaak/UpdateInitiatorZGW.php
+++ b/app/Jobs/Zaak/UpdateInitiatorZGW.php
@@ -19,10 +19,13 @@ use Woweb\Zgw\Facades\Zgw;
 
 /**
  * Sets the initiator rol on the ZGW zaak from the initiator block in the
- * FormState snapshot. Two variants, matching the aanvrager:
+ * FormState snapshot. The variant matches the aanvrager and the connection
+ * ({@see InitiatorRolBuilder}):
  *
- * - has a KvK number → `niet_natuurlijk_persoon` (statutaireNaam,
- *   annIdentificatie, contactpersoon, plus kvkNummer on the default connection)
+ * - has a KvK number, own default connection → `niet_natuurlijk_persoon`
+ *   (statutaireNaam, annIdentificatie, kvkNummer, contactpersoon)
+ * - has a KvK number, any other connection → `vestiging` (kvkNummer,
+ *   handelsnaam, contactpersoon)
  * - otherwise → `natuurlijk_persoon` (voornamen, geslachtsnaam,
  *   anpIdentificatie, verblijfsadres)
  *

--- a/app/Services/Zgw/InitiatorRolBuilder.php
+++ b/app/Services/Zgw/InitiatorRolBuilder.php
@@ -18,11 +18,13 @@ use Illuminate\Support\Str;
  * deelzaak gets the same, properly filled aanvrager identification instead of a
  * copied ZGW rol whose betrokkeneIdentificatie is empty across instances.
  *
- * Two variants, matching the aanvrager:
- * - has a KvK number → niet_natuurlijk_persoon (statutaireNaam,
- *   annIdentificatie, and kvkNummer only towards the default connection)
- * - otherwise        → natuurlijk_persoon (voornamen, geslachtsnaam,
- *   anpIdentificatie, verblijfsadres)
+ * Variants, matching the aanvrager:
+ * - has a KvK number, own default connection → niet_natuurlijk_persoon
+ *   (statutaireNaam, annIdentificatie, kvkNummer)
+ * - has a KvK number, any other connection   → vestiging (kvkNummer,
+ *   handelsnaam)
+ * - otherwise                                → natuurlijk_persoon (voornamen,
+ *   geslachtsnaam, anpIdentificatie, verblijfsadres)
  *
  * A natuurlijk_persoon rol needs an identifying attribute for a ZGW backend to
  * materialise a betrokkene (OneGround/RX Mission shows nothing for a rol whose
@@ -34,7 +36,7 @@ final class InitiatorRolBuilder
 {
     /**
      * @param  string  $connectionName  the connection the rol is posted to, which decides
-     *                                  whether the non-standard kvkNummer is sent along
+     *                                  which organisation variant is built
      * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
      * @return array<string, mixed>|null rol payload, or null when there is no initiator data
      */
@@ -44,9 +46,15 @@ final class InitiatorRolBuilder
             return null;
         }
 
-        return isset($initiator['kvk']) && $initiator['kvk']
-            ? self::nietNatuurlijkPersoon($connectionName, $zaakUrl, $roltype, $initiator, self::kvkNummer($initiator['kvk']))
-            : self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie);
+        if (! isset($initiator['kvk']) || ! $initiator['kvk']) {
+            return self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie);
+        }
+
+        $kvkNummer = self::kvkNummer($initiator['kvk']);
+
+        return ZgwConnectionConfig::isDefaultConnection($connectionName)
+            ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator, $kvkNummer)
+            : self::vestiging($zaakUrl, $roltype, $initiator, $kvkNummer);
     }
 
     /**
@@ -58,8 +66,9 @@ final class InitiatorRolBuilder
      * job (a retry, or `zaak:create-doorkomst-zaken` on an existing zaak) reads
      * the already-hashed snapshot, and writing that hash to ZGW as if it were a
      * KvK number would put a bogus company number on the zaak. The rol is then
-     * registered on the statutaireNaam alone, so this guard covers both
-     * annIdentificatie and kvkNummer.
+     * registered on the organisation name alone (statutaireNaam or handelsnaam,
+     * depending on the variant), so this guard covers annIdentificatie and
+     * kvkNummer in both.
      */
     private static function kvkNummer(mixed $kvk): ?string
     {
@@ -82,10 +91,19 @@ final class InitiatorRolBuilder
     }
 
     /**
+     * The organisation rol as our own OpenZaak has always received it.
+     *
+     * annIdentificatie is the standard-conformant carrier for the company
+     * number on this betrokkeneType: RolNietNatuurlijkPersoon has no kvkNummer
+     * property in any Zaken API release from 1.0 up to and including 1.7, while
+     * annIdentificatie has been defined here since 1.0. kvkNummer is a
+     * non-standard extra that our own instance read before this builder
+     * existed, so it is sent alongside and nowhere else.
+     *
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function nietNatuurlijkPersoon(string $connectionName, string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
+    private static function nietNatuurlijkPersoon(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
     {
         return [
             'zaak' => $zaakUrl,
@@ -93,27 +111,46 @@ final class InitiatorRolBuilder
             'roltype' => $roltype,
             'roltoelichting' => 'inzender formulier',
             'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
-            // annIdentificatie is the standard-conformant carrier for the
-            // company number. RolNietNatuurlijkPersoon has no kvkNummer
-            // property in any Zaken API release from 1.0 up to and including
-            // 1.7 (kvkNummer only exists on RolVestiging, added in 1.3.0),
-            // while annIdentificatie has been defined here since 1.0. Sending
-            // only kvkNummer therefore leaves the rol with a statutaireNaam and
-            // no identifying attribute at all, which is what happened on a real
-            // instance on 28-07-2026: the create response came back without an
-            // error and without the property, innNnpId and annIdentificatie
-            // both empty. innNnpId is not used for the number either, because
-            // that field holds the chamber-issued RSIN and a conformant backend
-            // validates it as such, which an eight-digit KvK number fails.
-            //
-            // kvkNummer is a non-standard extra and only goes to our own
-            // default connection (OpenZaak), which read it before this builder
-            // existed. Every other connection belongs to a municipality running
-            // its own instance, and those get the standard payload only.
             'betrokkeneIdentificatie' => array_filter([
                 'statutaireNaam' => $initiator['organisatie_naam'] ?? null,
                 'annIdentificatie' => $kvkNummer,
-                'kvkNummer' => ZgwConnectionConfig::isDefaultConnection($connectionName) ? $kvkNummer : null,
+                'kvkNummer' => $kvkNummer,
+            ]),
+        ];
+    }
+
+    /**
+     * The organisation rol for every connection other than our own.
+     *
+     * A KvK number belongs on a vestiging in the ZGW standard: RolVestiging is
+     * the only betrokkeneType that defines a kvkNummer property (added in Zaken
+     * API 1.3.0 and present ever since), so this is the one place a receiving
+     * instance can store the number as a company number instead of dropping it.
+     * The rol stays on the same initiator roltype; vestiging is a
+     * betrokkeneType, and RolType carries no betrokkeneType binding at all.
+     *
+     * Only what the form actually asks for is sent. vestigingsNummer is not
+     * asked and is not invented, and the organisation address is not the
+     * vestiging address, so no verblijfsadres either. RolVestiging requires no
+     * field, so a rol on handelsnaam alone (hashed KvK on a rerun) is valid.
+     *
+     * @param  array<string, mixed>  $initiator
+     * @return array<string, mixed>
+     */
+    private static function vestiging(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
+    {
+        $organisatieNaam = $initiator['organisatie_naam'] ?? null;
+
+        return [
+            'zaak' => $zaakUrl,
+            'betrokkeneType' => 'vestiging',
+            'roltype' => $roltype,
+            'roltoelichting' => 'inzender formulier',
+            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            'betrokkeneIdentificatie' => array_filter([
+                'kvkNummer' => $kvkNummer,
+                // handelsnaam is a list in the schema, and we know one name.
+                'handelsnaam' => is_string($organisatieNaam) && $organisatieNaam !== '' ? [$organisatieNaam] : null,
             ]),
         ];
     }

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -272,10 +272,92 @@ function routeSnapshotWithValues(array $values): array
     return ['values' => array_merge(routeSnapshot()['values'], $values)];
 }
 
+/**
+ * Fake a doorkomst whose deelzaak lands on the passing municipality's own
+ * instance (OWN_HOST) while the hoofdzaak lives on main, so the initiator rol is
+ * posted to a non-default connection.
+ */
+function fakeDoorkomstForInitiatorOnOwnInstance(): void
+{
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        OWN_HOST.'/catalogi/api/v1/roltypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => OWN_HOST.'/catalogi/api/v1/roltypen/init', 'omschrijvingGeneriek' => 'initiator'],
+        ]), 200),
+        OWN_HOST.'/zaken/api/v1/rollen*' => Http::response(['url' => OWN_HOST.'/zaken/api/v1/rollen/1'], 201),
+        OWN_HOST.'/zaken/api/v1/zaken*' => function ($request) {
+            if ($request->method() === 'POST') {
+                return Http::response(['url' => OWN_HOST.'/zaken/api/v1/zaken/deel-1'], 201);
+            }
+
+            return Http::response(array_merge(deelZaakReadResponse(), [
+                'url' => OWN_HOST.'/zaken/api/v1/zaken/deel-1',
+                'zaaktype' => OWN_HOST.'/catalogi/api/v1/zaaktypen/dk-m',
+            ]), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+}
+
+test('registers a vestiging initiator on a deelzaak in the doorkomst gemeente own instance', function () {
+    // Non-default connection: the KvK number goes out as a vestiging rol, the
+    // only betrokkeneType in the Zaken API that defines a kvkNummer property.
+    // annIdentificatie and statutaireNaam belong to niet_natuurlijk_persoon and
+    // are not part of RolVestiging, so neither is sent.
+    fakeDoorkomstForInitiatorOnOwnInstance();
+
+    $scenario = doorkomstScenario(hoofdOwnInstance: false);
+    $scenario['hoofdzaak']->update([
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1',
+        'form_state_snapshot' => routeSnapshotWithValues([
+            'watIsHetKamerVanKoophandelNummerVanUwOrganisatie' => '12345678',
+            'watIsDeNaamVanUwOrganisatie' => 'Woweb',
+        ]),
+    ]);
+
+    MunicipalityZgwConnection::factory()->active()->create(['municipality_id' => $scenario['passing']->id]);
+    Zaaktype::factory()->create([
+        'municipality_id' => $scenario['passing']->id,
+        'role' => ZaaktypeRole::Doorkomst,
+        'connection' => "gemeente_{$scenario['passing']->id}",
+        'zgw_zaaktype_url' => OWN_HOST.'/catalogi/api/v1/zaaktypen/dk-m',
+        'is_active' => true,
+    ]);
+
+    CreateDoorkomstZaken::dispatchSync($scenario['hoofdzaak']);
+
+    Http::assertSent(function ($request) {
+        if ($request->method() !== 'POST' || ! str_starts_with($request->url(), OWN_HOST.'/zaken/api/v1/rollen')) {
+            return false;
+        }
+
+        $identificatie = $request->data()['betrokkeneIdentificatie'] ?? [];
+
+        return $request->data()['betrokkeneType'] === 'vestiging'
+            && $request->data()['roltype'] === OWN_HOST.'/catalogi/api/v1/roltypen/init'
+            && $request->data()['roltoelichting'] === 'inzender formulier'
+            && ($identificatie['kvkNummer'] ?? null) === '12345678'
+            && ($identificatie['handelsnaam'] ?? null) === ['Woweb']
+            && ! array_key_exists('annIdentificatie', $identificatie)
+            && ! array_key_exists('statutaireNaam', $identificatie);
+    });
+});
+
 test('registers the initiator on the deelzaak from the form aanvrager data, not the copied ZGW rol', function () {
     // The initiator is rebuilt from the form (KvK + organisation name), matching
     // the hoofdzaak. The hoofdzaak ZGW rol is not copied: its identificatie is
-    // empty and its betrokkene url is not portable across instances.
+    // empty and its betrokkene url is not portable across instances. The
+    // deelzaak lands on our own default connection here, which keeps the
+    // niet_natuurlijk_persoon payload it has always received.
     fakeDoorkomstForInitiator();
 
     $scenario = doorkomstScenario(hoofdOwnInstance: true);

--- a/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
+++ b/tests/Feature/Jobs/Zaak/UpdateInitiatorZGWTest.php
@@ -5,19 +5,23 @@
  * block in the FormState snapshot.
  *
  * Main behaviour covered here: for an organisation with a KvK number the rol
- * carries the company number in `annIdentificatie` as well as in `kvkNummer`,
- * for every connection. The Zaken API standard defines no `kvkNummer` on
- * RolNietNatuurlijkPersoon in any release from 1.0 up to and including 1.7, so
- * a conformant backend drops that property and only `annIdentificatie` keeps
- * the number on the zaak. For a private aanvrager (no KvK) the rol carries a
- * stable `anpIdentificatie` and the verblijfsadres from the form's address
- * fieldset, so backends such as OneGround materialise a visible betrokkene.
+ * depends on the connection. Our own OpenZaak keeps the
+ * `niet_natuurlijk_persoon` payload it has always received, in which
+ * `annIdentificatie` carries the company number (the Zaken API defines no
+ * `kvkNummer` on RolNietNatuurlijkPersoon in any release from 1.0 up to and
+ * including 1.7) and the non-standard `kvkNummer` rides along. Every other
+ * connection gets a `vestiging` rol, the only betrokkeneType that defines a
+ * `kvkNummer` property, so the number can actually be stored. For a private
+ * aanvrager (no KvK) the rol carries a stable `anpIdentificatie` and the
+ * verblijfsadres from the form's address fieldset, so backends such as
+ * OneGround materialise a visible betrokkene.
  */
 
 use App\Enums\Role;
 use App\EventForm\Submit\ZaakeigenschappenMap;
 use App\Jobs\Zaak\UpdateInitiatorZGW;
 use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
@@ -26,6 +30,8 @@ use Illuminate\Support\Facades\Http;
 use Tests\Fakes\ZgwHttpFake;
 
 uses(RefreshDatabase::class);
+
+const MUNICIPALITY_HOST = 'https://gemeente.example.com';
 
 function zaakMetInitiator(array $values, ?int $organiserUserId = null): Zaak
 {
@@ -40,6 +46,24 @@ function zaakMetInitiator(array $values, ?int $organiserUserId = null): Zaak
         'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/abc-123',
         'form_state_snapshot' => ['values' => $values],
         'organiser_user_id' => $organiserUserId,
+    ]);
+}
+
+/** The same zaak, but on a municipality running its own ZGW instance. */
+function zaakMetInitiatorOpEigenInstance(array $values): Zaak
+{
+    $muni = Municipality::factory()->create();
+    MunicipalityZgwConnection::factory()->active()->create(['municipality_id' => $muni->id]);
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => $muni->id,
+        'connection' => "gemeente_{$muni->id}",
+        'zgw_zaaktype_url' => MUNICIPALITY_HOST.'/catalogi/api/v1/zaaktypen/1',
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'zgw_zaak_url' => MUNICIPALITY_HOST.'/zaken/api/v1/zaken/abc-123',
+        'form_state_snapshot' => ['values' => $values],
     ]);
 }
 
@@ -68,6 +92,58 @@ function fakeZaakRoltypenEnRollen(): void
         ], 200),
     ]);
 }
+
+function fakeZaakRoltypenEnRollenOpEigenInstance(): void
+{
+    $zaakUrl = MUNICIPALITY_HOST.'/zaken/api/v1/zaken/abc-123';
+
+    Http::fake([
+        MUNICIPALITY_HOST.'/catalogi/api/v1/roltypen*' => Http::response(ZgwHttpFake::envelope([
+            ['url' => MUNICIPALITY_HOST.'/catalogi/api/v1/roltypen/1', 'omschrijvingGeneriek' => 'initiator'],
+        ]), 200),
+        MUNICIPALITY_HOST.'/zaken/api/v1/rollen' => Http::response(['url' => MUNICIPALITY_HOST.'/zaken/api/v1/rollen/1'], 201),
+        $zaakUrl.'*' => Http::response([
+            'url' => $zaakUrl,
+            'uuid' => 'abc-123',
+            'identificatie' => 'ZAAK-123',
+            'zaaktype' => MUNICIPALITY_HOST.'/catalogi/api/v1/zaaktypen/1',
+            'omschrijving' => 'Test',
+            'startdatum' => '2026-06-26',
+            'registratiedatum' => '2026-06-26',
+            'einddatum' => null,
+            'einddatumGepland' => null,
+            'uiterlijkeEinddatumAfdoening' => null,
+            'bronorganisatie' => '820151130',
+            'zaakgeometrie' => null,
+        ], 200),
+    ]);
+}
+
+test('stuurt voor een organisatie op een gemeente-instance een vestiging-rol met kvkNummer en handelsnaam', function () {
+    $zaak = zaakMetInitiatorOpEigenInstance([
+        'watIsHetKamerVanKoophandelNummerVanUwOrganisatie' => '12345678',
+        'watIsDeNaamVanUwOrganisatie' => 'Acme BV',
+    ]);
+
+    fakeZaakRoltypenEnRollenOpEigenInstance();
+
+    (new UpdateInitiatorZGW($zaak))->handle(app(ZaakeigenschappenMap::class));
+
+    Http::assertSent(function ($request) {
+        if (! str_contains($request->url(), '/zaken/api/v1/rollen') || $request->method() !== 'POST') {
+            return false;
+        }
+
+        $identificatie = $request->data()['betrokkeneIdentificatie'] ?? [];
+
+        return $request->data()['betrokkeneType'] === 'vestiging'
+            && $request->data()['roltoelichting'] === 'inzender formulier'
+            && ($identificatie['kvkNummer'] ?? null) === '12345678'
+            && ($identificatie['handelsnaam'] ?? null) === ['Acme BV']
+            && ! array_key_exists('annIdentificatie', $identificatie)
+            && ! array_key_exists('statutaireNaam', $identificatie);
+    });
+});
 
 test('stuurt voor een organisatie annIdentificatie naast kvkNummer mee', function () {
     $zaak = zaakMetInitiator([

--- a/tests/Unit/Zgw/InitiatorRolBuilderTest.php
+++ b/tests/Unit/Zgw/InitiatorRolBuilderTest.php
@@ -5,7 +5,12 @@ declare(strict_types=1);
 use App\EventForm\State\FormState;
 use App\Services\Zgw\InitiatorRolBuilder;
 
-test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
+test('keeps the default connection on the niet_natuurlijk_persoon payload it already received', function () {
+    // Regression anchor: our own OpenZaak read this exact payload before, so
+    // the whole rol is asserted, not a few keys. RolNietNatuurlijkPersoon has
+    // no kvkNummer property in any Zaken API release from 1.0 up to and
+    // including 1.7, so annIdentificatie carries the number and the
+    // non-standard kvkNummer rides along for our own instance only.
     $state = FormState::fromSnapshot(['values' => []]);
 
     $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
@@ -14,36 +19,50 @@ test('builds a niet_natuurlijk_persoon rol from a KvK initiator', function () {
         'contactpersoon' => ['naam' => 'Organisator Test'],
     ]);
 
-    expect($rol['betrokkeneType'])->toBe('niet_natuurlijk_persoon')
-        ->and($rol['roltype'])->toBe('https://zgw/roltype/1')
-        ->and($rol['betrokkeneIdentificatie']['kvkNummer'])->toBe('12345678')
-        ->and($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
-        ->and($rol['contactpersoonRol'])->toBe(['naam' => 'Organisator Test']);
+    expect($rol)->toBe([
+        'zaak' => 'https://zgw/zaken/1',
+        'betrokkeneType' => 'niet_natuurlijk_persoon',
+        'roltype' => 'https://zgw/roltype/1',
+        'roltoelichting' => 'inzender formulier',
+        'contactpersoonRol' => ['naam' => 'Organisator Test'],
+        'betrokkeneIdentificatie' => [
+            'statutaireNaam' => 'Woweb',
+            'annIdentificatie' => '12345678',
+            'kvkNummer' => '12345678',
+        ],
+    ]);
 });
 
-test('carries the KvK number in annIdentificatie, next to kvkNummer on the default connection', function () {
-    // RolNietNatuurlijkPersoon has no kvkNummer property in any Zaken API
-    // release from 1.0 up to and including 1.7 (kvkNummer only exists on
-    // RolVestiging, added in 1.3.0), so a conformant backend drops it and the
-    // organisation ends up on the zaak without a company number at all. The
-    // standard does define annIdentificatie here, so the number has to travel
-    // in that property. kvkNummer is a non-standard extra kept for our own
-    // OpenZaak instance only.
+test('builds a vestiging rol with kvkNummer and handelsnaam on a municipality connection', function () {
+    // RolVestiging is the only betrokkeneType in the Zaken API that defines a
+    // kvkNummer property (since 1.3.0), so this is the one payload in which a
+    // receiving instance can store the number as a company number. No
+    // annIdentificatie and no statutaireNaam: those belong to
+    // niet_natuurlijk_persoon and are not part of RolVestiging.
     $state = FormState::fromSnapshot(['values' => []]);
 
-    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+    $rol = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
         'kvk' => '12345678',
         'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => 'Organisator Test'],
     ]);
 
-    expect($rol['betrokkeneIdentificatie']['annIdentificatie'])->toBe('12345678')
-        ->and($rol['betrokkeneIdentificatie']['kvkNummer'])->toBe('12345678');
+    expect($rol)->toBe([
+        'zaak' => 'https://zgw/zaken/1',
+        'betrokkeneType' => 'vestiging',
+        'roltype' => 'https://zgw/roltype/1',
+        'roltoelichting' => 'inzender formulier',
+        'contactpersoonRol' => ['naam' => 'Organisator Test'],
+        'betrokkeneIdentificatie' => [
+            'kvkNummer' => '12345678',
+            'handelsnaam' => ['Woweb'],
+        ],
+    ]);
 });
 
-test('sends only annIdentificatie to a municipality connection', function () {
-    // Any connection other than the default belongs to a municipality running
-    // its own ZGW instance, which gets the standard payload without the
-    // non-standard kvkNummer.
+test('sends no vestigingsNummer or verblijfsadres on a vestiging rol', function () {
+    // The form asks for neither, and the organisation address is not
+    // necessarily the address of the vestiging, so nothing is invented.
     $state = FormState::fromSnapshot(['values' => []]);
 
     $rol = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
@@ -51,13 +70,15 @@ test('sends only annIdentificatie to a municipality connection', function () {
         'organisatie_naam' => 'Woweb',
     ]);
 
-    expect($rol['betrokkeneType'])->toBe('niet_natuurlijk_persoon')
-        ->and($rol['betrokkeneIdentificatie']['annIdentificatie'])->toBe('12345678')
-        ->and($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
-        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer');
+    expect($rol['betrokkeneIdentificatie'])->not->toHaveKey('vestigingsNummer')
+        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('verblijfsadres');
 });
 
-test('omits an already hashed KvK number on a municipality connection too', function () {
+test('registers a vestiging on handelsnaam alone when the KvK number is already hashed', function () {
+    // A rerun on a snapshot whose KvK was hashed (a job retry, or
+    // zaak:create-doorkomst-zaken on an existing zaak) must not send the hash to
+    // ZGW as if it were a KvK number. RolVestiging requires no field, so the rol
+    // on handelsnaam alone is valid.
     $state = FormState::fromSnapshot(['values' => []]);
 
     $rol = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
@@ -65,15 +86,11 @@ test('omits an already hashed KvK number on a municipality connection too', func
         'organisatie_naam' => 'Woweb',
     ]);
 
-    expect($rol['betrokkeneIdentificatie']['statutaireNaam'])->toBe('Woweb')
-        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('annIdentificatie')
-        ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('kvkNummer');
+    expect($rol['betrokkeneType'])->toBe('vestiging')
+        ->and($rol['betrokkeneIdentificatie'])->toBe(['handelsnaam' => ['Woweb']]);
 });
 
 test('omits an already hashed KvK number and keeps the organisation rol', function () {
-    // A rerun on a snapshot whose KvK was hashed (a job retry, or
-    // zaak:create-doorkomst-zaken on an existing zaak) must not send the hash to
-    // ZGW as if it were a KvK number.
     $state = FormState::fromSnapshot(['values' => []]);
 
     $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
@@ -133,6 +150,21 @@ test('builds a natuurlijk_persoon rol without verblijfsadres when no address is 
     expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
         ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('verblijfsadres')
         ->and($rol['betrokkeneIdentificatie'])->not->toHaveKey('anpIdentificatie');
+});
+
+test('builds the same natuurlijk_persoon rol whatever the connection is', function () {
+    // Only the organisation variant branches on the connection; a private
+    // aanvrager gets one payload everywhere.
+    $state = FormState::fromSnapshot(['values' => [
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Jansen',
+    ]]);
+    $initiator = ['contactpersoon' => ['naam' => 'Jan Jansen']];
+
+    $default = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, $initiator, 'EVL42');
+    $municipality = InitiatorRolBuilder::build('heerlen', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, $initiator, 'EVL42');
+
+    expect($municipality)->toBe($default);
 });
 
 test('skips the verblijfsadres for a foreign address', function () {


### PR DESCRIPTION

### What changes

The initiator rol of an organisation now depends on the connection it is posted to.

- Our own default connection keeps exactly the payload it already received: `niet_natuurlijk_persoon` with `statutaireNaam`, `annIdentificatie` and the non-standard `kvkNummer`.
- Every other connection now gets `betrokkeneType: vestiging` with `kvkNummer` and `handelsnaam`, and no longer `annIdentificatie` or `statutaireNaam`.

The private aanvrager (`natuurlijk_persoon`) is untouched, on every connection.

### Why

`RolVestiging` is the only betrokkeneType in the Zaken API that defines a `kvkNummer` property. I checked this against the VNG `zaken-api` OpenAPI: the property was added in 1.3.0 and is present in every release since, up to and including the current 1.5.1 on master. It is absent from 1.0.3 and 1.2.0. `RolNietNatuurlijkPersoon` has no `kvkNummer` in any release from 1.0 up to and including 1.7, which is why we put the number in `annIdentificatie` there.

That works on our own instance, but a municipality instance shows an organisation without a recognisable company number: `annIdentificatie` is a generic identifying attribute, not a KvK field, and `innNnpId` is not an alternative because it holds the chamber-issued RSIN, which an eight-digit KvK number is not. Sending the number as a vestiging is the only way the standard offers to have it land as a company number.

Vestiging is a betrokkeneType, not a roltype. The Catalogi API `RolType` schema has only `omschrijving` and `omschrijvingGeneriek` and carries no betrokkeneType binding, so the rol stays on the same initiator roltype and there is nothing to configure in a catalogus.

Our own OpenZaak stays on the current route deliberately. It already reads the number from `kvkNummer` on the niet-natuurlijk-persoon rol and there is no reason to move existing behaviour that works; this keeps the change to the instances where the number is currently getting lost.

### Fields on the vestiging rol

Only what the form actually asks for: `kvkNummer` and `handelsnaam` (a list in the schema, holding the organisation name). No `vestigingsNummer`, because the form does not ask for one and I am not inventing one, and no `verblijfsadres`, because the organisation address is not necessarily the address of the vestiging. `RolVestiging` requires no field at all, so this is a valid rol. The generic Rol fields (`roltoelichting`, `contactpersoonRol`) are unchanged.

The consequence is that the rol identifies the company rather than one specific vestiging. That matches the data we have; a real vestigingsnummer would be a form change, not a change here.

### Payload A/B

Same initiator snapshot through the builder before and after, per connection type. Only the two organisation cases on a non-default connection change; the default connection and both private-person cases are byte-identical.

```diff
 === municipality connection / organisation
 {
     "zaak": "https://zgw/zaken/1",
-    "betrokkeneType": "niet_natuurlijk_persoon",
+    "betrokkeneType": "vestiging",
     "roltype": "https://zgw/roltype/1",
     "roltoelichting": "inzender formulier",
     "contactpersoonRol": {
         "naam": "Jan Jansen",
         "emailadres": "jan@example.com",
         "telefoonnummer": "0612345678"
     },
     "betrokkeneIdentificatie": {
-        "statutaireNaam": "Acme BV",
-        "annIdentificatie": "12345678"
+        "kvkNummer": "12345678",
+        "handelsnaam": [
+            "Acme BV"
+        ]
     }
 }

 === municipality connection / organisation, hashed KvK
 {
     "zaak": "https://zgw/zaken/1",
-    "betrokkeneType": "niet_natuurlijk_persoon",
+    "betrokkeneType": "vestiging",
     "roltype": "https://zgw/roltype/1",
     "roltoelichting": "inzender formulier",
     "contactpersoonRol": {
         "naam": "Jan Jansen",
         "emailadres": "jan@example.com",
         "telefoonnummer": "0612345678"
     },
     "betrokkeneIdentificatie": {
-        "statutaireNaam": "Acme BV"
+        "handelsnaam": [
+            "Acme BV"
+        ]
     }
 }
```

Unchanged in the same run: `default connection / organisation`, `default connection / organisation, hashed KvK`, and the private person on both connection types.

### Degradation

- A rerun on a snapshot whose KvK number was already hashed (a job retry, or `zaak:create-doorkomst-zaken` on an existing zaak) still never sends the hash as a company number. On a non-default connection the rol is then registered on `handelsnaam` alone, which the schema allows.
- A zaaktype without an initiator roltype behaves exactly as before: the hoofdzaak job returns silently, the doorkomst job logs a warning. That is unrelated to betrokkeneType.

### Not in this change

- No backfill. Rollen are not mutable in ZGW, so repairing existing zaken would mean a delete plus create per zaak. Existing rollen stay `niet_natuurlijk_persoon`; the read paths already key on the roltype's `omschrijvingGeneriek` and not on betrokkeneType, so they keep working for both.
- No response check after the POST. The instances that need this do not return the rol data on create, only a status code, so a check there would prove nothing. The proof is the payload diff above plus a staging run.

### Verification

- Full suite green (1913 passed, 0 failed), Pint passed, PHPStan no errors.
- Unit: the default connection is asserted on the whole payload as a regression anchor, the vestiging payload likewise; plus the hashed-KvK case and a check that the private-person rol is identical on both connection types.
- Feature: `UpdateInitiatorZGWTest` and `CreateDoorkomstZakenTest` each assert the faked POST body per connection type.
- Still to do on staging: a new request with a KvK number, then read the rol back and confirm the number is visible. Note that one backend writes the field back as `kvknummer` in lowercase while OpenZaak uses `kvkNummer`, so read case-insensitively.
