### PR TITLE
Make trusted proxies configurable per environment

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -106,6 +106,14 @@ APP_REQUIRE_2FA=true
 # REGISTRATION_MAX_ATTEMPTS=5
 # REGISTRATION_DECAY_SECONDS=900
 
+# Trusted proxies. Unset (the default, and what production runs on) means no
+# forwarded header is believed, which is what keeps the login limiters above
+# counting real client addresses. Set this only where a proxy terminates every
+# request and overwrites X-Forwarded-For itself, for example an environment behind a
+# TLS-terminating proxy, otherwise the application builds http:// URLs on an https:// page.
+# Accepts a comma separated list of addresses or CIDR ranges, "REMOTE_ADDR", or "*".
+# TRUSTED_PROXIES=*
+
 OPENZAAK_URL="https://zgw.example.com/"
 OPENZAAK_CLIENT_ID="client-id"
 OPENZAAK_CLIENT_SECRET="%8UIjR^bo9vNql%SEhDx@fLX3L"

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -18,6 +18,19 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->append(SecurityHeaders::class);
 
+        // Restrict which forwarded headers a trusted proxy may set. The only
+        // reason an environment opts in through TRUSTED_PROXIES
+        // (config/trustedproxy.php) is to let a TLS-terminating proxy report
+        // https via X-Forwarded-Proto, so we trust For, Proto and Port and
+        // nothing else. Leaving the mask at Laravel's default would also honour
+        // X-Forwarded-Host, which lets an attacker forge the host in a
+        // password-reset link (reset poisoning) on any opt-in environment. We
+        // pass only `headers:` here, so the proxy list keeps falling back to
+        // config('trustedproxy.proxies') and this only narrows the mask.
+        $middleware->trustProxies(headers: Request::HEADER_X_FORWARDED_FOR
+            | Request::HEADER_X_FORWARDED_PROTO
+            | Request::HEADER_X_FORWARDED_PORT);
+
         // Standaard valt Laravel's `AuthenticationException::redirectTo()`
         // terug op `route('login')` — die route bestaat niet, want we
         // gebruiken Filament-panel-logins (`/admin/login`,

--- a/config/auth.php
+++ b/config/auth.php
@@ -155,13 +155,21 @@ return [
     | disable the limiter or turn it into an application-wide lockout.
     |
     | The login limiters key on request()->ip(), and that is the real client
-    | address because nothing proxies production: TrustProxies is deliberately
-    | not configured, so a client cannot forge X-Forwarded-For to escape the
-    | counters. Putting a CDN, WAF or load balancer in front of the application
-    | changes that assumption: every request would then arrive from one address,
-    | which turns the login_ip backstop into an application-wide lockout and
-    | strips the IP component out of the strict login limiter. Configure
-    | TrustProxies first if that ever happens, and revisit these numbers.
+    | address because nothing proxies production: no trusted proxies are
+    | configured there, so a client cannot forge X-Forwarded-For to escape the
+    | counters. Trusting nothing stays the default, and unless TRUSTED_PROXIES
+    | is set in the environment that is exactly what happens.
+    |
+    | Environments that do sit behind a proxy opt in through TRUSTED_PROXIES
+    | (see config/trustedproxy.php), and only when that proxy overwrites
+    | X-Forwarded-For itself, so a client cannot smuggle in a forged address.
+    | Note what the opt-in costs here: every request then arrives from the
+    | proxy as far as these counters are concerned unless the forwarded address
+    | is trustworthy, which turns the login_ip backstop into an
+    | application-wide lockout and strips the IP component out of the strict
+    | login limiter. So putting a CDN, WAF or load balancer in front of
+    | production means setting TRUSTED_PROXIES and revisiting these numbers,
+    | in that order.
     |
     */
 

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,48 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Trusted Proxies
+    |--------------------------------------------------------------------------
+    |
+    | Laravel's global TrustProxies middleware falls back to this key when no
+    | proxies are configured on the middleware itself, so this file is all it
+    | takes to make the trusted-proxy list environment specific. See
+    | Illuminate\Http\Middleware\TrustProxies::setTrustedProxyIpAddresses().
+    |
+    | Unset is the default and means "trust nothing", which is what production
+    | runs on: nothing proxies it, so X-Forwarded-For is attacker controlled and
+    | must be ignored. config/auth.php spells out why that matters, because the
+    | login limiters key on request()->ip().
+    |
+    | Only set TRUSTED_PROXIES on an environment where a proxy really does
+    | terminate every request and overwrites X-Forwarded-For itself, so a client
+    | cannot smuggle in a forged address. An environment behind a
+    | TLS-terminating proxy is the case this is for: until that proxy is
+    | trusted the application generates http:// URLs on an https:// page, which
+    | the content security policy then blocks.
+    |
+    | bootstrap/app.php narrows the trusted forwarded headers to X-Forwarded-For,
+    | -Proto and -Port. X-Forwarded-Host is deliberately not trusted, so the proxy
+    | only has to set For and Proto correctly and a forged host header can never
+    | reach request()->getHost() or poison a generated URL (a password-reset link,
+    | for example). The list below therefore governs only who is trusted, not
+    | which headers.
+    |
+    | Accepts a comma separated list of addresses or CIDR ranges, the literal
+    | "REMOTE_ADDR" to trust the immediate caller, or "*" to trust whoever calls.
+    |
+    | This lives in a config file rather than in an env() call inside the
+    | withMiddleware() closure of bootstrap/app.php for two reasons. That closure
+    | runs while the HTTP kernel is being resolved (Application::handleRequest()),
+    | which is before the kernel bootstraps LoadEnvironmentVariables, so env()
+    | returns null there and the setting would silently do nothing. And a config
+    | file is also the only place a value survives `php artisan config:cache`.
+    |
+    */
+
+    'proxies' => env('TRUSTED_PROXIES'),
+
+];

--- a/tests/Feature/TrustedProxiesTest.php
+++ b/tests/Feature/TrustedProxiesTest.php
@@ -1,0 +1,169 @@
+<?php
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * The trusted-proxy contract.
+ *
+ * Two halves, and the first one is the one that must never regress: with no
+ * TRUSTED_PROXIES in the environment the application ignores every forwarded
+ * header, because the login limiters in config/auth.php key on the real client
+ * address. The second half is the opt-in that config/trustedproxy.php adds for
+ * environments that really do sit behind a proxy.
+ */
+beforeEach(function () {
+    Route::get('/_test/trusted-proxy-probe', fn (Request $request) => response()->json([
+        'ip' => $request->ip(),
+        'scheme' => $request->getScheme(),
+        'secure' => $request->isSecure(),
+        // host() and url() are what a signed link (a password reset, for example)
+        // is generated from, so they prove whether a forged X-Forwarded-Host can
+        // reach the URL generator.
+        'host' => $request->getHost(),
+        'url' => $request->url(),
+    ]));
+});
+
+afterEach(function () {
+    // setTrustedProxies() is static state on the Symfony request. The middleware
+    // resets it on every request, but leaving it set would still be a surprise
+    // for anything running after this file.
+    Request::setTrustedProxies([], Request::HEADER_X_FORWARDED_FOR);
+});
+
+/**
+ * Load config/trustedproxy.php with TRUSTED_PROXIES set to the given value and
+ * publish the result into the running config, exactly as booting the
+ * application with that environment variable would.
+ *
+ * The env has to be read through the config file itself: setting the config key
+ * directly would test nothing, since Config::set() works whether or not the
+ * file exists. A missing file yields an empty config, so these tests fail on
+ * the behaviour they describe rather than on a file that is not there.
+ */
+function bootTrustedProxyConfig(string $trustedProxies): void
+{
+    $path = config_path('trustedproxy.php');
+
+    $previous = $_ENV['TRUSTED_PROXIES'] ?? null;
+
+    putenv('TRUSTED_PROXIES='.$trustedProxies);
+    $_ENV['TRUSTED_PROXIES'] = $trustedProxies;
+    $_SERVER['TRUSTED_PROXIES'] = $trustedProxies;
+
+    try {
+        config()->set('trustedproxy', file_exists($path) ? require $path : []);
+    } finally {
+        if ($previous === null) {
+            putenv('TRUSTED_PROXIES');
+            unset($_ENV['TRUSTED_PROXIES'], $_SERVER['TRUSTED_PROXIES']);
+        } else {
+            putenv('TRUSTED_PROXIES='.$previous);
+            $_ENV['TRUSTED_PROXIES'] = $previous;
+            $_SERVER['TRUSTED_PROXIES'] = $previous;
+        }
+    }
+}
+
+it('ignores a forwarded client address when no trusted proxies are configured', function () {
+    expect(config('trustedproxy.proxies'))->toBeNull();
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-For' => '203.0.113.7',
+        ]);
+
+    $response->assertOk();
+
+    // The address the login limiters count on stays the address that actually
+    // connected, so a forged header cannot be used to escape the counters.
+    expect($response->json('ip'))->toBe('10.0.0.9');
+});
+
+it('ignores a forwarded protocol when no trusted proxies are configured', function () {
+    expect(config('trustedproxy.proxies'))->toBeNull();
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    expect($response->json('scheme'))->toBe('http');
+    expect($response->json('secure'))->toBeFalse();
+});
+
+it('honours forwarded headers when TRUSTED_PROXIES is a wildcard', function () {
+    bootTrustedProxyConfig('*');
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-For' => '203.0.113.7',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    expect($response->json('ip'))->toBe('203.0.113.7');
+    expect($response->json('scheme'))->toBe('https');
+    expect($response->json('secure'))->toBeTrue();
+});
+
+it('honours forwarded headers when the calling address is listed in TRUSTED_PROXIES', function () {
+    bootTrustedProxyConfig('198.51.100.4, 10.0.0.9');
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-For' => '203.0.113.7',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+    expect($response->json('ip'))->toBe('203.0.113.7');
+    expect($response->json('scheme'))->toBe('https');
+});
+
+it('ignores a forwarded address from a caller outside the trusted list', function () {
+    // The trusted list names a different proxy than the one that connects, so
+    // the calling address is not trusted and its forwarded header must be ignored.
+    bootTrustedProxyConfig('198.51.100.4');
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-For' => '203.0.113.7',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+
+    // The address that actually connected is kept, not the forged forwarded one,
+    // and the forwarded protocol is ignored as well.
+    expect($response->json('ip'))->toBe('10.0.0.9');
+    expect($response->json('scheme'))->toBe('http');
+    expect($response->json('secure'))->toBeFalse();
+});
+
+it('never trusts a forwarded host, even when TRUSTED_PROXIES is a wildcard', function () {
+    // The wildcard trusts every caller, which is the widest the opt-in ever gets
+    // (and what the on-forge/laravel-cloud autofallback sets). Even then the
+    // header mask in bootstrap/app.php must keep X-Forwarded-Host untrusted.
+    bootTrustedProxyConfig('*');
+
+    $response = $this->withServerVariables(['REMOTE_ADDR' => '10.0.0.9'])
+        ->getJson('/_test/trusted-proxy-probe', [
+            'X-Forwarded-Host' => 'attacker.example',
+            'X-Forwarded-For' => '203.0.113.7',
+            'X-Forwarded-Proto' => 'https',
+        ]);
+
+    $response->assertOk();
+
+    // For and Proto are still honoured, so the opt-in keeps doing its job.
+    expect($response->json('ip'))->toBe('203.0.113.7');
+    expect($response->json('scheme'))->toBe('https');
+
+    // But the forged host never reaches the request host or a generated URL, so a
+    // password-reset link cannot be poisoned through X-Forwarded-Host.
+    expect($response->json('host'))->not->toBe('attacker.example');
+    expect($response->json('url'))->not->toContain('attacker.example');
+});


### PR DESCRIPTION
Make the trusted proxies configurable per environment, without changing the default.

An environment that runs behind a TLS-terminating proxy needs to trust that proxy's forwarded headers, otherwise the application sees plain http and generates http URLs on an https page. The application deliberately trusts no proxies by default, because with no proxy in front `request()->ip()` is the real client address that the login limiters key on. That default does not move.

This adds an opt-in. `config/trustedproxy.php` maps a new `TRUSTED_PROXIES` variable onto the key that Laravel's own `TrustProxies` middleware already reads as a fallback (`Illuminate\Http\Middleware\TrustProxies::setTrustedProxyIpAddresses()`). Left unset, the value is null, no proxy is trusted, and every forwarded header is ignored exactly as before. Set to a comma separated list of addresses or CIDR ranges (or `*`), the forwarded protocol and client address are honoured.

The opt-in only needs the protocol and the address, so `bootstrap/app.php` pins the trusted forwarded headers to `X-Forwarded-For | X-Forwarded-Proto | X-Forwarded-Port`. Laravel's default mask would also trust `X-Forwarded-Host`, and since the application forces no root URL a forwarded host would flow into `request()->getHost()` and into every generated URL. There is no reason for the opt-in to trust a header it does not use. Only `headers:` is passed, so this narrows the mask and nothing else: the proxy list keeps falling back to `config('trustedproxy.proxies')` (verified against `Illuminate\Foundation\Configuration\Middleware::trustProxies()`, which with `at` left null never touches the proxy list).

The proxy list lives in a config file rather than an `env()` call in the `withMiddleware()` closure of `bootstrap/app.php`, for two reasons. That closure runs while the HTTP kernel is resolved in `Application::handleRequest()`, before `LoadEnvironmentVariables` bootstraps, so `env()` returns null there and a setting placed in the closure would silently do nothing. A config file also survives `php artisan config:cache`. The header mask is a fixed bitmask rather than an env value, so passing it in the closure is fine and does survive `config:cache`.

The trusted-proxy paragraph in `config/auth.php` is rewritten so the default and the opt-in read as one consistent explanation, the variable is documented in `.env.example` next to the other optional auth settings, and `config/trustedproxy.php` notes that the list governs who is trusted while the header mask lives in `bootstrap/app.php`.

`tests/Feature/TrustedProxiesTest.php` covers the contract: with nothing configured a forwarded `X-Forwarded-For` does not change `request()->ip()` and a forwarded `X-Forwarded-Proto` does not make the request secure; the opt-in is covered through a wildcard and through a list containing the calling address; a caller outside an explicit list is ignored; and even with `TRUSTED_PROXIES=*` a forwarded `X-Forwarded-Host` never reaches `request()->getHost()` or the generated URL while For and Proto are honoured.
