### PR TITLE
Keep a deselected location kind out of ZGW and the PDF

### DIFF
--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -8,6 +8,7 @@ use App\EventForm\Schema\Steps\RisicoscanStep;
 use App\EventForm\Schema\Steps\TijdenStep;
 use App\EventForm\Schema\Steps\TypeAanvraagStep;
 use App\EventForm\State\FormState;
+use App\EventForm\Support\LocationKinds;
 use Carbon\Carbon;
 use Closure;
 use Filament\Forms\Components\CheckboxList;
@@ -101,6 +102,32 @@ final class SubmissionReport
     ];
 
     /**
+     * The location fields and the `waarVindtHetEvenementPlaats` kind each one
+     * belongs to. Unticking a kind hides its component but leaves the value in
+     * the state (Filament keeps a hidden field's value; see `LocationKinds`),
+     * so a copied application still carries the source event's address, area or
+     * route. Reading such a field into the report would print a location the
+     * organiser is no longer asking for. The three geometry/address fields are
+     * `LocationKinds::FIELD_BY_KIND`; the two name fields hang on the same kind
+     * as their component (`naamVanDeLocatieKaart` on "buiten",
+     * `naamVanDeRoute` on "route") and are hidden together with it.
+     *
+     * The generic Open Formulieren name fields (`naamVanDeLocatie`,
+     * `watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt`) are deliberately not
+     * here: they are not bound to a single kind and are not hidden by unticking
+     * one.
+     *
+     * @var array<string, string>
+     */
+    private const LOCATION_FIELD_KIND = [
+        'adresVanDeGebouwEn' => LocationKinds::GEBOUW,
+        'locatieSOpKaart' => LocationKinds::BUITEN,
+        'naamVanDeLocatieKaart' => LocationKinds::BUITEN,
+        'routesOpKaart' => LocationKinds::ROUTE,
+        'naamVanDeRoute' => LocationKinds::ROUTE,
+    ];
+
+    /**
      * @return list<array{label: string, value: string, sub?: list<array{label: string, value: string}>, table?: array{header: list<string>, rows: list<list<string>>}}>
      */
     private function extractEntries(Step $step, FormState $state): array
@@ -135,6 +162,11 @@ final class SubmissionReport
             if ($component instanceof Repeater) {
                 $key = $component->getName();
                 if ($key === '') {
+                    return;
+                }
+                // A location repeater of a kind the organiser unticked still
+                // holds copied-over state; keep it out of the report.
+                if ($this->isDeselectedLocationField($key, $state)) {
                     return;
                 }
                 $fullKey = $keyPrefix === null ? $key : "{$keyPrefix}.{$key}";
@@ -176,6 +208,12 @@ final class SubmissionReport
                 if ($key !== '') {
                     if ($isTijdenStep && in_array($key, self::TIJDEN_TABEL_KEYS, true)) {
                         // Al in de tijden-tabel verwerkt; sla over.
+                        return;
+                    }
+                    // A location field (the patched map, or a name field) of a
+                    // kind the organiser unticked still holds copied-over state;
+                    // keep it out of the report.
+                    if ($this->isDeselectedLocationField($key, $state)) {
                         return;
                     }
                     $fullKey = $keyPrefix === null ? $key : "{$keyPrefix}.{$key}";
@@ -282,6 +320,21 @@ final class SubmissionReport
     private function heeftRisicoscanDoorlopen(FormState $state): bool
     {
         return $state->isStepApplicable(RisicoscanStep::UUID);
+    }
+
+    /**
+     * Is this a location field whose kind the organiser unticked? Its value is
+     * then leftover state that must stay out of the report, the same way the
+     * ZGW mapping and the municipality check (see `LocationKinds`) already keep
+     * it out. Any other field, and any location field of a ticked kind (or when
+     * no kind is ticked at all, which counts as "no opinion"), passes through
+     * unchanged.
+     */
+    private function isDeselectedLocationField(string $key, FormState $state): bool
+    {
+        $kind = self::LOCATION_FIELD_KIND[$key] ?? null;
+
+        return $kind !== null && ! LocationKinds::isSelected($state, $kind);
     }
 
     /**

--- a/app/EventForm/Submit/MapFormStateToReferenceData.php
+++ b/app/EventForm/Submit/MapFormStateToReferenceData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Submit;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Support\LocationKinds;
 use App\Models\Organisation;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
 use Carbon\Carbon;
@@ -78,7 +79,11 @@ final class MapFormStateToReferenceData
     {
         $names = [];
 
-        $gebouwen = $state->get('adresVanDeGebouwEn');
+        // Read every location field through `LocationKinds` so that state left
+        // behind by a kind the organiser unticked (Filament keeps a hidden
+        // field's value; see `LocationKinds`) does not leak a copied-over
+        // source event's location into the local reference_data.
+        $gebouwen = LocationKinds::valueFor($state, LocationKinds::GEBOUW);
         if (is_array($gebouwen)) {
             foreach ($gebouwen as $entry) {
                 if (is_array($entry) && ! empty($entry['naamVanDeLocatieGebouw'])) {
@@ -87,12 +92,19 @@ final class MapFormStateToReferenceData
             }
         }
 
-        $kaart = $this->stringOrNull($state->get('naamVanDeLocatieKaart'));
+        // The map/route name fields hang on the "buiten" resp. "route" kind:
+        // both are hidden together with their kind's component, so their
+        // leftover value counts only while that kind is ticked.
+        $kaart = LocationKinds::isSelected($state, LocationKinds::BUITEN)
+            ? $this->stringOrNull($state->get('naamVanDeLocatieKaart'))
+            : null;
         if ($kaart !== null) {
             $names[] = $kaart;
         }
 
-        $route = $this->stringOrNull($state->get('naamVanDeRoute'));
+        $route = LocationKinds::isSelected($state, LocationKinds::ROUTE)
+            ? $this->stringOrNull($state->get('naamVanDeRoute'))
+            : null;
         if ($route !== null) {
             $names[] = $route;
         }
@@ -102,8 +114,9 @@ final class MapFormStateToReferenceData
 
     private function naamLocatie(FormState $state): ?string
     {
-        // Gebouw-tak: eerste naam uit adresVanDeGebouwEn.
-        $gebouwen = $state->get('adresVanDeGebouwEn');
+        // Gebouw-tak: eerste naam uit adresVanDeGebouwEn, alleen zolang de
+        // gebouw-soort is aangevinkt (LocationKinds houdt afgevinkte state weg).
+        $gebouwen = LocationKinds::valueFor($state, LocationKinds::GEBOUW);
         if (is_array($gebouwen)) {
             foreach ($gebouwen as $entry) {
                 if (is_array($entry) && ! empty($entry['naamVanDeLocatieGebouw'])) {
@@ -112,7 +125,10 @@ final class MapFormStateToReferenceData
             }
         }
 
-        // Buiten/route-tak: eventuele opgegeven naam.
+        // Generic fallback name migrated from Open Formulieren
+        // (`watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt` → `naamVanDeLocatie`,
+        // see `BackfillSnapshotsFromObjects`). It is not bound to a single kind
+        // and is not hidden by unticking one, so it stays a direct read.
         return $this->stringOrNull($state->get('naamVanDeLocatie'));
     }
 

--- a/app/EventForm/Submit/ZaakeigenschappenMap.php
+++ b/app/EventForm/Submit/ZaakeigenschappenMap.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\EventForm\Submit;
 
 use App\EventForm\State\FormState;
+use App\EventForm\Support\LocationKinds;
 
 /**
  * Mapping tussen FormState-veldnamen en ZGW-zaakeigenschap-namen.
@@ -77,7 +78,11 @@ final class ZaakeigenschappenMap
     {
         $names = [];
 
-        $gebouwen = $state->get('adresVanDeGebouwEn');
+        // Read every location field through `LocationKinds` so that state left
+        // behind by a kind the organiser unticked (Filament keeps a hidden
+        // field's value; see `LocationKinds`) does not leak a copied-over
+        // source event's location into the zaakeigenschappen.
+        $gebouwen = LocationKinds::valueFor($state, LocationKinds::GEBOUW);
         if (is_array($gebouwen)) {
             foreach ($gebouwen as $entry) {
                 if (is_array($entry) && ! empty($entry['naamVanDeLocatieGebouw'])) {
@@ -86,12 +91,19 @@ final class ZaakeigenschappenMap
             }
         }
 
-        $kaart = $this->stringOrNull($state->get('naamVanDeLocatieKaart'));
+        // The map/route name fields hang on the "buiten" resp. "route" kind:
+        // both are hidden together with their kind's component, so their
+        // leftover value counts only while that kind is ticked.
+        $kaart = LocationKinds::isSelected($state, LocationKinds::BUITEN)
+            ? $this->stringOrNull($state->get('naamVanDeLocatieKaart'))
+            : null;
         if ($kaart !== null) {
             $names[] = $kaart;
         }
 
-        $route = $this->stringOrNull($state->get('naamVanDeRoute'));
+        $route = LocationKinds::isSelected($state, LocationKinds::ROUTE)
+            ? $this->stringOrNull($state->get('naamVanDeRoute'))
+            : null;
         if ($route !== null) {
             $names[] = $route;
         }
@@ -126,9 +138,16 @@ final class ZaakeigenschappenMap
     public function buildEventLocation(FormState $state): array
     {
         return array_filter([
-            'multipolygons' => $state->get('locatieSOpKaart'),
-            'line' => $state->get('routesOpKaart'),
-            'bag_addresses' => $state->get('adresVanDeGebouwEn'),
+            // Geometry and address fields: read through `LocationKinds` so an
+            // unticked kind's leftover polygon/line/address does not travel to
+            // the zaakgeometrie (`AddGeometryZGW`/`CreateDoorkomstZaken`).
+            'multipolygons' => LocationKinds::valueFor($state, LocationKinds::BUITEN),
+            'line' => LocationKinds::valueFor($state, LocationKinds::ROUTE),
+            'bag_addresses' => LocationKinds::valueFor($state, LocationKinds::GEBOUW),
+            // `watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt` is the generic
+            // event-location name migrated from Open Formulieren (see
+            // `BackfillSnapshotsFromObjects`); it is not bound to a single kind
+            // and is not hidden by unticking one, so it stays a direct read.
             'name' => $this->stringOrNull($state->get('watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt')),
         ], fn ($v) => $v !== null && $v !== '' && $v !== []);
     }

--- a/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
+++ b/tests/Feature/EventForm/Reporting/SubmissionReportTest.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 use App\EventForm\Reporting\SubmissionReport;
 use App\EventForm\Schema\EventFormSchema;
+use App\EventForm\Schema\Patches\LocatiePolygonsPatch;
 use App\EventForm\Schema\Steps\BijlagenStep;
 use App\EventForm\Schema\Steps\ContactgegevensStep;
 use App\EventForm\Schema\Steps\LocatieVanHetEvenement2Step;
@@ -547,6 +548,79 @@ test('Radio met Closure-options resolveert label uit dynamische bron (#2 Michel:
     $waarden = collect($sections[0]['entries'])->pluck('value')->all();
     expect($waarden)->toContain('Beekdaelen')
         ->and($waarden)->not->toContain('GM1954');
+});
+
+// --- Location-state leak (ZGW/PDF counterpart of #493) ---------------------
+//
+// Unticking a location kind hides its field but leaves the value in the state.
+// SubmissionReport walks every field regardless of its `->hidden()` rule, so a
+// copied application would otherwise print the source event's leftover location
+// in the PDF. These tests prove that a field of an unticked kind stays out of
+// the report, while a ticked kind (or an unanswered question) is unchanged.
+
+test('een afgevinkte gebouw-soort lekt zijn adres niet in de PDF (ongepatchte repeaters)', function () {
+    // Alleen "route" aangevinkt; het gebouwadres staat nog in de state.
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => [
+            'row-1' => ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [LocatieVanHetEvenement2Step::make()]);
+
+    $flat = (string) json_encode($sections);
+    expect($flat)->not->toContain('Sporthal Noord');
+});
+
+test('regressie-anker: met de gebouw-soort aangevinkt verschijnt het adres wél in de PDF', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['gebouw'],
+        'adresVanDeGebouwEn' => [
+            'row-1' => ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [LocatieVanHetEvenement2Step::make()]);
+
+    $flat = (string) json_encode($sections);
+    expect($flat)->toContain('Sporthal Noord');
+});
+
+test('afgevinkte buiten/route-naamvelden lekken niet in de PDF (gepatchte productie-schema)', function () {
+    // Productie-pad: LocatiePolygonsPatch maakt van locatieSOpKaart/routesOpKaart
+    // Map-velden met losse naam-TextInputs. Alleen "gebouw" aangevinkt; de
+    // naam-velden van buiten en route dragen nog overgekopieerde state.
+    $step = LocatiePolygonsPatch::apply(LocatieVanHetEvenement2Step::make());
+
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['gebouw'],
+        'adresVanDeGebouwEn' => [
+            'row-1' => ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+        ],
+        'naamVanDeLocatieKaart' => 'Stadspark',
+        'naamVanDeRoute' => 'Route Centrum',
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [$step]);
+
+    $flat = (string) json_encode($sections);
+    expect($flat)->toContain('Sporthal Noord')
+        ->and($flat)->not->toContain('Stadspark')
+        ->and($flat)->not->toContain('Route Centrum');
+});
+
+test('geen mening: zonder waarVindtHetEvenementPlaats verschijnt de locatie ongewijzigd in de PDF', function () {
+    $state = new FormState(values: [
+        'adresVanDeGebouwEn' => [
+            'row-1' => ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+        ],
+    ]);
+
+    $sections = app(SubmissionReport::class)->build($state, [LocatieVanHetEvenement2Step::make()]);
+
+    $flat = (string) json_encode($sections);
+    expect($flat)->toContain('Sporthal Noord');
 });
 
 test('the internal brkGemeente of an address does not leak into the report', function () {

--- a/tests/Unit/EventForm/Submit/MapFormStateToReferenceDataTest.php
+++ b/tests/Unit/EventForm/Submit/MapFormStateToReferenceDataTest.php
@@ -115,6 +115,64 @@ test('persoonlijke organisatie → organisator valt terug op de persoonsnaam', f
     expect($ref->organisator)->toBe('Jan Jansen');
 });
 
+// --- Location-state leak (ZGW/PDF counterpart of #493) ---------------------
+//
+// Unticking a location kind hides its field but leaves the value in the state.
+// A copied application therefore still carries the source event's location.
+// These tests prove that leftover state of an unticked kind no longer reaches
+// the local reference_data, while a ticked kind is unchanged.
+
+test('locaties_evenement laat de naam van een afgevinkte soort niet lekken', function () {
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-06-14T14:00',
+        'EvenementEind' => '2026-06-14T18:00',
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => [['naamVanDeLocatieGebouw' => 'Sporthal Noord']],
+        'naamVanDeLocatieKaart' => 'Stadspark',
+        'naamVanDeRoute' => 'Route Centrum',
+    ]);
+
+    $ref = $this->map->build($state, 'Ingediend', '');
+
+    expect($ref->locaties_evenement)->toBe('Route Centrum');
+});
+
+test('naam_locatie_evenement lekt geen gebouwnaam van een afgevinkte gebouw-soort', function () {
+    // Alleen "route" aangevinkt; het gebouwadres met naam staat nog in de
+    // state maar mag niet als naam_locatie_evenement terugkomen. Er is geen
+    // generieke naamVanDeLocatie, dus het resultaat valt terug op null.
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-06-14T14:00',
+        'EvenementEind' => '2026-06-14T18:00',
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => [
+            'uuid-1' => ['naamVanDeLocatieGebouw' => 'Sporthal De Geusselt', 'huisnummer' => '1'],
+        ],
+    ]);
+
+    $ref = $this->map->build($state, 'Ingediend', '');
+
+    expect($ref->naam_locatie_evenement)->toBeNull();
+});
+
+test('regressie-anker: met de gebouw-soort aangevinkt blijft naam_locatie_evenement de gebouwnaam', function () {
+    $state = new FormState(values: [
+        'EvenementStart' => '2026-06-14T14:00',
+        'EvenementEind' => '2026-06-14T18:00',
+        'waarVindtHetEvenementPlaats' => ['gebouw', 'buiten', 'route'],
+        'adresVanDeGebouwEn' => [
+            'uuid-1' => ['naamVanDeLocatieGebouw' => 'Sporthal De Geusselt', 'huisnummer' => '1'],
+        ],
+        'naamVanDeLocatieKaart' => 'Stadspark',
+        'naamVanDeRoute' => 'Route Centrum',
+    ]);
+
+    $ref = $this->map->build($state, 'Ingediend', '');
+
+    expect($ref->naam_locatie_evenement)->toBe('Sporthal De Geusselt')
+        ->and($ref->locaties_evenement)->toBe('Sporthal De Geusselt, Stadspark, Route Centrum');
+});
+
 test('registratiedatum wordt gezet op "nu" bij elke build', function () {
     $state = new FormState(values: [
         'EvenementStart' => '2026-06-14T14:00',

--- a/tests/Unit/EventForm/Submit/ZaakeigenschappenMapTest.php
+++ b/tests/Unit/EventForm/Submit/ZaakeigenschappenMapTest.php
@@ -171,3 +171,82 @@ test('locaties_evenement ontbreekt als geen locatie-velden zijn opgegeven', func
 
     expect($naden)->not->toContain('locaties_evenement');
 });
+
+// --- Location-state leak (ZGW/PDF counterpart of #493) ---------------------
+//
+// Unticking a location kind hides its field but leaves the value in the state
+// (Filament keeps a hidden field's value). A copied application therefore still
+// carries the source event's location. These tests prove that leftover state of
+// an unticked kind no longer reaches the zaakeigenschappen, while a ticked kind
+// (or an unanswered question, which counts as "no opinion") is unchanged.
+
+test('event_location laat een afgevinkte gebouw/buiten-soort niet lekken', function () {
+    // Alleen "route" aangevinkt, maar gebouw-adres en buiten-vlak staan nog in
+    // de state (overgekopieerd uit een eerder evenement).
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => ['uuid-1' => ['postcode' => '6211AB', 'huisnummer' => '1']],
+        'locatieSOpKaart' => ['type' => 'MultiPolygon', 'coordinates' => [[[[5, 50]]]]],
+        'routesOpKaart' => ['type' => 'LineString', 'coordinates' => [[5, 50], [5.1, 50.1]]],
+    ]);
+
+    $location = $this->map->buildEventLocation($state);
+
+    expect($location)->toHaveKey('line')
+        ->and($location)->not->toHaveKey('bag_addresses')
+        ->and($location)->not->toHaveKey('multipolygons');
+});
+
+test('locaties_evenement laat de naam van een afgevinkte soort niet lekken', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'adresVanDeGebouwEn' => [['naamVanDeLocatieGebouw' => 'Sporthal Noord']],
+        'naamVanDeLocatieKaart' => 'Stadspark',
+        'naamVanDeRoute' => 'Route Centrum',
+    ]);
+
+    $plat = collect($this->map->buildEigenschappen($state))->mapWithKeys(fn ($e) => $e)->all();
+
+    expect($plat)->toHaveKey('locaties_evenement', 'Route Centrum');
+});
+
+test('regressie-anker: met alle waarde-dragende soorten aangevinkt blijft de output identiek', function () {
+    $state = new FormState(values: [
+        'waarVindtHetEvenementPlaats' => ['gebouw', 'buiten', 'route'],
+        'adresVanDeGebouwEn' => [
+            ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+            ['naamVanDeLocatieGebouw' => 'Gymzaal West'],
+        ],
+        'locatieSOpKaart' => ['type' => 'MultiPolygon', 'coordinates' => [[[[5, 50]]]]],
+        'routesOpKaart' => ['type' => 'LineString', 'coordinates' => [[5, 50], [5.1, 50.1]]],
+        'naamVanDeLocatieKaart' => 'Stadspark',
+        'naamVanDeRoute' => 'Route Centrum',
+        'watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt' => 'Vrijthof',
+    ]);
+
+    $plat = collect($this->map->buildEigenschappen($state))->mapWithKeys(fn ($e) => $e)->all();
+
+    expect($plat)->toHaveKey('locaties_evenement', 'Sporthal Noord, Gymzaal West, Stadspark, Route Centrum')
+        ->and($this->map->buildEventLocation($state))->toBe([
+            'multipolygons' => ['type' => 'MultiPolygon', 'coordinates' => [[[[5, 50]]]]],
+            'line' => ['type' => 'LineString', 'coordinates' => [[5, 50], [5.1, 50.1]]],
+            'bag_addresses' => [
+                ['naamVanDeLocatieGebouw' => 'Sporthal Noord'],
+                ['naamVanDeLocatieGebouw' => 'Gymzaal West'],
+            ],
+            'name' => 'Vrijthof',
+        ]);
+});
+
+test('geen mening: zonder waarVindtHetEvenementPlaats telt elke soort mee (ongewijzigd)', function () {
+    // Exact het bestaande event_location-scenario, maar nu expliciet als anker
+    // voor het "geen mening"-contract: een afwezige vraag mag niets wissen.
+    $state = new FormState(values: [
+        'locatieSOpKaart' => ['type' => 'MultiPolygon', 'coordinates' => [[[[5, 50]]]]],
+        'routesOpKaart' => ['type' => 'LineString', 'coordinates' => [[5, 50], [5.1, 50.1]]],
+        'adresVanDeGebouwEn' => ['uuid-1' => ['postcode' => '6211AB', 'huisnummer' => '1']],
+        'watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt' => 'Vrijthof',
+    ]);
+
+    expect($this->map->buildEventLocation($state))->toHaveKeys(['multipolygons', 'line', 'bag_addresses', 'name']);
+});


### PR DESCRIPTION

`waarVindtHetEvenementPlaats` decides which of the three location kinds (a building, an outdoor area, a route) an application uses. Unticking a kind hides its field but does not clear it: Filament keeps the value of a hidden component, and `FormState::absorbFields()` merges rather than replaces, so nothing removes it from the state. An application copied from an earlier event therefore still carries the source event's location after the organiser switched kinds.

The municipality check already routes around this (it goes through `LocationKinds`, added for exactly this reason). The three output paths that build the submission did not: they read the location fields directly, so the leftover value of a deselected kind still travelled to the ZGW zaakeigenschappen, the local reference data and the submission PDF. In the worst case an application reaches one municipality carrying another municipality's address, both in the case system and on the PDF.

This routes every location-field read in those three paths through `LocationKinds`, with the same meaning the municipality check uses:

- `ZaakeigenschappenMap` builds `locaties_evenement` and the `event_location` block (`multipolygons` / `line` / `bag_addresses`) through `LocationKinds::valueFor()`, so a field of an unticked kind counts as absent.
- `MapFormStateToReferenceData` does the same for `locaties_evenement` and `naam_locatie_evenement`.
- `SubmissionReport` skips a location field (repeater, map or name input) while its kind is unticked, so the leftover value never renders in the PDF.

The `waarVindtHetEvenementPlaats` contract is unchanged: an unanswered question has no opinion and every kind still counts (the field is required in the wizard, and this keeps old or programmatically filled drafts from losing their location). Only a kind that is unticked while it still holds a value drops out.

### Field-to-kind decisions

The three geometry/address fields (`adresVanDeGebouwEn`, `locatieSOpKaart`, `routesOpKaart`) map one-to-one onto the kinds via `LocationKinds::FIELD_BY_KIND`. Two derived name fields hang on a kind as well and are hidden together with it, so they are gated on the same kind: `naamVanDeLocatieKaart` on "buiten", `naamVanDeRoute` on "route" (`naamVanDeLocatieGebouw` lives inside the `adresVanDeGebouwEn` rows and follows the "gebouw" kind automatically). The two generic Open Formulieren name fields (`naamVanDeLocatie`, `watIsDeNaamVanDeLocatieSWaarUwEvenementPlaatsvindt`) are deliberately left as direct reads: they are not bound to a single kind and are not hidden by unticking one, so forcing them onto a kind would be wrong.

### Tests

Each output path gets an A/B test (leftover state of a deselected kind no longer appears in the zaakeigenschappen, reference data or PDF; each fails on the unchanged code) plus a regression anchor proving byte-identical output when every value-carrying kind is ticked, and that an absent `waarVindtHetEvenementPlaats` still counts every kind.

