### PR TITLE
Bound contactpersoonRol.naam per connection

### DIFF
--- a/app/Services/Zgw/InitiatorRolBuilder.php
+++ b/app/Services/Zgw/InitiatorRolBuilder.php
@@ -35,6 +35,23 @@ use Illuminate\Support\Str;
 final class InitiatorRolBuilder
 {
     /**
+     * OneGround's Zaken API v1.5 validator caps contactpersoonRol.naam at 40
+     * characters: it kept the Zaken API 1.3/1.4 limit and never raised it. Our
+     * client sends no Api-Version header, so a request to a OneGround backend
+     * lands on that stricter v1.5 contract, and a longer composed name
+     * (voornaam plus achternaam) is rejected with a 400 on the rol POST.
+     */
+    private const CONTACTPERSOON_NAAM_MAX_ONEGROUND = 40;
+
+    /**
+     * Every other backend follows the VNG 1.5 OAS, where ContactPersoonRol.naam
+     * is maxLength 200 (OpenZaak's column matches). So a non-OneGround
+     * connection, including our own OpenZaak, keeps the standard bound and is
+     * not truncated at 40 for a limit that is not its own.
+     */
+    private const CONTACTPERSOON_NAAM_MAX_DEFAULT = 200;
+
+    /**
      * @param  string  $connectionName  the connection the rol is posted to, which decides
      *                                  which organisation variant is built
      * @param  array<string, mixed>  $initiator  output of ZaakeigenschappenMap::buildInitiator()
@@ -46,15 +63,49 @@ final class InitiatorRolBuilder
             return null;
         }
 
+        // OneGround enforces a stricter contactpersoonRol.naam limit than the
+        // VNG standard, so the bound is decided per connection, not globally.
+        $naamMax = ZgwConnectionConfig::isOneGround($connectionName)
+            ? self::CONTACTPERSOON_NAAM_MAX_ONEGROUND
+            : self::CONTACTPERSOON_NAAM_MAX_DEFAULT;
+
         if (! isset($initiator['kvk']) || ! $initiator['kvk']) {
-            return self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie);
+            return self::natuurlijkPersoon($zaakUrl, $roltype, $state, $initiator, $anpIdentificatie, $naamMax);
         }
 
         $kvkNummer = self::kvkNummer($initiator['kvk']);
 
         return ZgwConnectionConfig::isDefaultConnection($connectionName)
-            ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator, $kvkNummer)
-            : self::vestiging($zaakUrl, $roltype, $initiator, $kvkNummer);
+            ? self::nietNatuurlijkPersoon($zaakUrl, $roltype, $initiator, $kvkNummer, $naamMax)
+            : self::vestiging($zaakUrl, $roltype, $initiator, $kvkNummer, $naamMax);
+    }
+
+    /**
+     * The contactpersoonRol block for the rol, with naam bounded to the limit
+     * that applies to this connection ($naamMax). Shared by every
+     * betrokkeneType variant, since contactpersoonRol travels with all of them,
+     * so an organisation with a KvK number and a long contact name is capped
+     * just like a natuurlijk persoon. The full name survives elsewhere
+     * (afwijkendeNaamBetrokkene, geslachtsnaam plus voornamen), so a plain cut
+     * to the hard limit is enough. A name of $naamMax characters or shorter is
+     * left byte-for-byte as is.
+     *
+     * @param  array<string, mixed>  $initiator
+     * @return array<string, mixed>|null
+     */
+    private static function contactpersoonRol(array $initiator, int $naamMax): ?array
+    {
+        $contactpersoon = $initiator['contactpersoon'] ?? null;
+
+        if (! is_array($contactpersoon)) {
+            return null;
+        }
+
+        if (isset($contactpersoon['naam']) && is_string($contactpersoon['naam'])) {
+            $contactpersoon['naam'] = Str::substr($contactpersoon['naam'], 0, $naamMax);
+        }
+
+        return $contactpersoon;
     }
 
     /**
@@ -103,14 +154,14 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function nietNatuurlijkPersoon(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
+    private static function nietNatuurlijkPersoon(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer, int $naamMax): array
     {
         return [
             'zaak' => $zaakUrl,
             'betrokkeneType' => 'niet_natuurlijk_persoon',
             'roltype' => $roltype,
             'roltoelichting' => 'inzender formulier',
-            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            'contactpersoonRol' => self::contactpersoonRol($initiator, $naamMax),
             'betrokkeneIdentificatie' => array_filter([
                 'statutaireNaam' => $initiator['organisatie_naam'] ?? null,
                 'annIdentificatie' => $kvkNummer,
@@ -137,7 +188,7 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function vestiging(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer): array
+    private static function vestiging(string $zaakUrl, string $roltype, array $initiator, ?string $kvkNummer, int $naamMax): array
     {
         $organisatieNaam = $initiator['organisatie_naam'] ?? null;
 
@@ -146,7 +197,7 @@ final class InitiatorRolBuilder
             'betrokkeneType' => 'vestiging',
             'roltype' => $roltype,
             'roltoelichting' => 'inzender formulier',
-            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            'contactpersoonRol' => self::contactpersoonRol($initiator, $naamMax),
             'betrokkeneIdentificatie' => array_filter([
                 'kvkNummer' => $kvkNummer,
                 // handelsnaam is a list in the schema, and we know one name.
@@ -159,7 +210,7 @@ final class InitiatorRolBuilder
      * @param  array<string, mixed>  $initiator
      * @return array<string, mixed>
      */
-    private static function natuurlijkPersoon(string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie): array
+    private static function natuurlijkPersoon(string $zaakUrl, string $roltype, FormState $state, array $initiator, ?string $anpIdentificatie, int $naamMax): array
     {
         $voornaam = (string) $state->get('watIsUwVoornaam');
         $achternaam = (string) $state->get('watIsUwAchternaam');
@@ -171,7 +222,7 @@ final class InitiatorRolBuilder
             'betrokkeneType' => 'natuurlijk_persoon',
             'roltype' => $roltype,
             'roltoelichting' => 'inzender formulier',
-            'contactpersoonRol' => $initiator['contactpersoon'] ?? null,
+            'contactpersoonRol' => self::contactpersoonRol($initiator, $naamMax),
             'betrokkeneIdentificatie' => array_filter([
                 'anpIdentificatie' => $anpIdentificatie,
                 'geslachtsnaam' => $achternaam !== '' ? $achternaam : null,

--- a/tests/Unit/Zgw/InitiatorRolBuilderTest.php
+++ b/tests/Unit/Zgw/InitiatorRolBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\EventForm\State\FormState;
 use App\Services\Zgw\InitiatorRolBuilder;
+use App\Services\Zgw\ZgwConnectionConfig;
 
 test('keeps the default connection on the niet_natuurlijk_persoon payload it already received', function () {
     // Regression anchor: our own OpenZaak read this exact payload before, so
@@ -224,4 +225,155 @@ test('returns null when there is no initiator data', function () {
 test('derives a stable anpIdentificatie from the user id', function () {
     expect(InitiatorRolBuilder::anpIdentificatieForUser(42))->toBe('EVL42')
         ->and(InitiatorRolBuilder::anpIdentificatieForUser(null))->toBeNull();
+});
+
+// The contactpersoonRol.naam bound is decided per connection. OneGround's v1.5
+// validator (ZaakRolRequestDtoValidator) caps it at 40 characters; every other
+// backend follows the VNG 1.5 OAS / OpenZaak maximum of 200. The builder reads
+// ZgwConnectionConfig::isOneGround(), so a connection is marked OneGround by
+// setting its is_oneground config. contactpersoonRol travels with every
+// betrokkeneType, so both bounds are asserted across the variants.
+$longNaam = 'Rob van Nijnanten (Organisatie zonder kvk)';   // 42 characters
+$boundedNaam40 = 'Rob van Nijnanten (Organisatie zonder kv';  // first 40
+
+/** Mark a connection as a OneGround (RX Mission) backend for the duration of a test. */
+function markOneGround(string $connectionName): void
+{
+    config(["zgw.connections.{$connectionName}.is_oneground" => true]);
+}
+
+test('caps contactpersoonRol.naam to 40 on a natuurlijk_persoon rol on a OneGround connection and keeps the full name elsewhere', function () use ($longNaam, $boundedNaam40) {
+    expect(mb_strlen($longNaam))->toBe(42)
+        ->and(mb_strlen($boundedNaam40))->toBe(40);
+
+    markOneGround('rxmission');
+
+    // The composed name is 42 characters, so afwijkendeNaamBetrokkene (max 625)
+    // still carries it in full while contactpersoonRol.naam is bounded to 40.
+    $state = FormState::fromSnapshot(['values' => [
+        'watIsUwVoornaam' => 'Rob',
+        'watIsUwAchternaam' => 'van Nijnanten (Organisatie zonder kvk)',
+    ]]);
+
+    $rol = InitiatorRolBuilder::build('rxmission', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'contactpersoon' => ['naam' => $longNaam, 'emailadres' => 'rob@example.test'],
+    ], 'EVL42');
+
+    expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
+        ->and($rol['contactpersoonRol']['naam'])->toBe($boundedNaam40)
+        ->and(mb_strlen($rol['contactpersoonRol']['naam']))->toBe(40)
+        ->and($rol['contactpersoonRol']['emailadres'])->toBe('rob@example.test')
+        ->and($rol['afwijkendeNaamBetrokkene'])->toBe($longNaam)
+        ->and($rol['betrokkeneIdentificatie']['geslachtsnaam'])->toBe('van Nijnanten (Organisatie zonder kvk)')
+        ->and($rol['betrokkeneIdentificatie']['voornamen'])->toBe('Rob')
+        ->and($rol['betrokkeneIdentificatie']['anpIdentificatie'])->toBe('EVL42');
+});
+
+test('caps contactpersoonRol.naam to 40 on a vestiging rol on a OneGround connection and leaves the rest of the payload unchanged', function () use ($longNaam, $boundedNaam40) {
+    markOneGround('rxmission');
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('rxmission', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => $longNaam],
+    ]);
+
+    expect($rol)->toBe([
+        'zaak' => 'https://zgw/zaken/1',
+        'betrokkeneType' => 'vestiging',
+        'roltype' => 'https://zgw/roltype/1',
+        'roltoelichting' => 'inzender formulier',
+        'contactpersoonRol' => ['naam' => $boundedNaam40],
+        'betrokkeneIdentificatie' => [
+            'kvkNummer' => '12345678',
+            'handelsnaam' => ['Woweb'],
+        ],
+    ]);
+});
+
+test('caps contactpersoonRol.naam to 40 on a niet_natuurlijk_persoon rol on a OneGround connection and leaves the rest of the payload unchanged', function () use ($longNaam, $boundedNaam40) {
+    // The niet_natuurlijk_persoon variant is only built on the default
+    // connection, so this proves the cap is wired into that variant by forcing
+    // the default connection onto the OneGround bound.
+    markOneGround('main');
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => $longNaam],
+    ]);
+
+    expect($rol)->toBe([
+        'zaak' => 'https://zgw/zaken/1',
+        'betrokkeneType' => 'niet_natuurlijk_persoon',
+        'roltype' => 'https://zgw/roltype/1',
+        'roltoelichting' => 'inzender formulier',
+        'contactpersoonRol' => ['naam' => $boundedNaam40],
+        'betrokkeneIdentificatie' => [
+            'statutaireNaam' => 'Woweb',
+            'annIdentificatie' => '12345678',
+            'kvkNummer' => '12345678',
+        ],
+    ]);
+});
+
+test('leaves a contactpersoonRol.naam of exactly 40 characters byte-for-byte unchanged on a OneGround connection', function () use ($boundedNaam40) {
+    // Boundary regression anchor: a name at the OneGround limit must not be touched.
+    markOneGround('rxmission');
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    $rol = InitiatorRolBuilder::build('rxmission', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => $boundedNaam40],
+    ]);
+
+    expect($rol['contactpersoonRol']['naam'])->toBe($boundedNaam40)
+        ->and(mb_strlen($rol['contactpersoonRol']['naam']))->toBe(40);
+});
+
+test('keeps a name between 41 and 200 characters in full on a non-OneGround connection', function () use ($longNaam) {
+    // main is our own OpenZaak (not OneGround): the 42-character name that a
+    // OneGround backend would reject is sent in full, not truncated at 40.
+    expect(ZgwConnectionConfig::isOneGround('main'))->toBeFalse();
+
+    $state = FormState::fromSnapshot(['values' => [
+        'watIsUwVoornaam' => 'Rob',
+        'watIsUwAchternaam' => 'van Nijnanten (Organisatie zonder kvk)',
+    ]]);
+
+    $rol = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'contactpersoon' => ['naam' => $longNaam],
+    ], 'EVL42');
+
+    expect($rol['betrokkeneType'])->toBe('natuurlijk_persoon')
+        ->and($rol['contactpersoonRol']['naam'])->toBe($longNaam)
+        ->and(mb_strlen($rol['contactpersoonRol']['naam']))->toBe(42);
+});
+
+test('caps contactpersoonRol.naam to 200 on a non-OneGround connection and keeps exactly 200 in full', function () {
+    $name201 = str_repeat('a', 201);
+    $name200 = str_repeat('a', 200);
+    $state = FormState::fromSnapshot(['values' => []]);
+
+    // 201 characters is bounded to the VNG/OpenZaak maximum of 200.
+    $over = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => $name201],
+    ]);
+
+    // Exactly 200 characters is left byte-for-byte unchanged (boundary anchor).
+    $atLimit = InitiatorRolBuilder::build('main', 'https://zgw/zaken/1', 'https://zgw/roltype/1', $state, [
+        'kvk' => '12345678',
+        'organisatie_naam' => 'Woweb',
+        'contactpersoon' => ['naam' => $name200],
+    ]);
+
+    expect($over['contactpersoonRol']['naam'])->toBe($name200)
+        ->and(mb_strlen($over['contactpersoonRol']['naam']))->toBe(200)
+        ->and($atLimit['contactpersoonRol']['naam'])->toBe($name200)
+        ->and(mb_strlen($atLimit['contactpersoonRol']['naam']))->toBe(200);
 });


### PR DESCRIPTION
## Why

Posting an initiator rol to a OneGround (RX Mission) backend fails with a 400
when the contact person name is longer than 40 characters. OneGround's Zaken
API v1.5 validator (`ZaakRolRequestDtoValidator`) still enforces the 40 that the
Zaken API carried in 1.3 and 1.4. The VNG 1.5 OAS raised `contactpersoonRol.naam`
to 200 and OpenZaak follows that, and we send no `Api-Version` header, so the
limit is a OneGround peculiarity rather than the standard. A composed name
(voornaam plus achternaam) over 40 characters is rejected on such a connection.

`contactpersoonRol` travels with every betrokkeneType, so this affects the
natuurlijk_persoon rol and the organisation variants alike (an organisation with
a KvK number and a long contact name runs into the same wall on OneGround).

## What

The bound is now decided per connection instead of unconditionally. `build()`
reads `ZgwConnectionConfig::isOneGround($connectionName)` and picks the maximum:
40 when the connection is OneGround, 200 (the VNG 1.5 / OpenZaak maximum)
otherwise. So our own OpenZaak, and any other standard connection, keeps the
full name and is not truncated for a limit that is not its own. Using
`isOneGround()` keeps the OneGround exceptions centralised, next to the other
per-connection wire-format deviations.

The chosen maximum is threaded into all three betrokkeneType variants
(natuurlijk_persoon, vestiging, niet_natuurlijk_persoon) and applied by one
shared helper that bounds `naam`. The cut is a plain, predictable truncation to
the connection's limit; the full name still survives in full elsewhere on the
rol (`afwijkendeNaamBetrokkene`, and `geslachtsnaam` plus `voornamen` on a
natuurlijk persoon). A name at or under the limit is left byte-for-byte
unchanged. Nothing else in the rol payload changes: KvK vestiging,
natuurlijk_persoon, annIdentificatie and verblijfsadres are untouched.

## Tests

`tests/Unit/Zgw/InitiatorRolBuilderTest.php` gains coverage that on a OneGround
connection a name longer than 40 characters is bounded to 40 on each of the
three variants, with a boundary anchor that exactly 40 passes through
byte-for-byte. On a non-OneGround (default) connection a 41 to 200 character
name is kept in full and is only bounded once it exceeds 200, with an exactly
200 boundary anchor. The OneGround cap tests fail on a builder without the
truncation, and the non-OneGround full-name test fails on a builder that caps
unconditionally at 40, so both directions of the per-connection behaviour are
pinned. The existing whole-payload assertions with shorter names remain the
regression anchors for the sub-limit case.
