### PR TITLE
Create doorkomst zaken for every drawn route, and fix the PostGIS init script for a fresh setup

### DIFF
--- a/app/EventForm/Submit/EventLocationGeometryBuilder.php
+++ b/app/EventForm/Submit/EventLocationGeometryBuilder.php
@@ -41,13 +41,13 @@ final class EventLocationGeometryBuilder
         $geometries = [];
 
         if ($this->notEmpty($eventLocation['line'] ?? null)) {
-            foreach ($this->parseLines($eventLocation['line']) as $geometry) {
+            foreach (self::parseLines($eventLocation['line']) as $geometry) {
                 $geometries[] = $geometry;
             }
         }
 
         if ($this->notEmpty($eventLocation['multipolygons'] ?? null)) {
-            foreach ($this->parseMultipolygons($eventLocation['multipolygons']) as $geometry) {
+            foreach (self::parseMultipolygons($eventLocation['multipolygons']) as $geometry) {
                 $geometries[] = $geometry;
             }
         }
@@ -85,13 +85,18 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Pak ALLE LineString-geometrieën uit de route-input.
+     * Take ALL LineString geometries from the route input.
+     *
+     * Public and static on purpose: everything that has to reason about the
+     * drawn routes (the submit flow itself, but also `CreateDoorkomstZaken`)
+     * must read them with exactly the same parser, so no caller ends up
+     * looking at the first route only.
      *
      * @return list<Geometry>
      */
-    private function parseLines(mixed $line): array
+    public static function parseLines(mixed $line): array
     {
-        return $this->parseGeometries(
+        return self::parseGeometries(
             $line,
             OpenFormsNormalizer::normalizeGeoJson(...),
             'routeVanHetEvenement',
@@ -99,13 +104,13 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Pak ALLE polygon-geometrieën uit de locatie-input.
+     * Take ALL polygon geometries from the location input.
      *
      * @return list<Geometry>
      */
-    private function parseMultipolygons(mixed $multipolygons): array
+    private static function parseMultipolygons(mixed $multipolygons): array
     {
-        return $this->parseGeometries(
+        return self::parseGeometries(
             $multipolygons,
             OpenFormsNormalizer::normalizeJson(...),
             'buitenLocatieVanHetEvenement',
@@ -113,25 +118,25 @@ final class EventLocationGeometryBuilder
     }
 
     /**
-     * Gedeelde parser voor lijnen én polygonen — beide leveren hun
-     * geometrie in identiek gevormde Map-state aan, alleen de normalizer
-     * en de Repeater-row-key verschillen. Twee shapes worden ondersteund:
+     * Shared parser for lines and polygons: both arrive as identically
+     * shaped Map state, only the normalizer and the Repeater row key
+     * differ. Three shapes are supported:
      *
-     *  1. Nieuw: één Map-state-object met meerdere features in
-     *     `geojson.features[]`. Sinds de Repeater eruit kunnen er
-     *     meerdere routes/polygonen op één kaart staan.
-     *  2. Oud (Repeater-rows): `[{<candidateKey>: {...}}, ...]` —
-     *     backward-compat voor bestaande drafts.
+     *  1. Current: one Map state object with several features in
+     *     `geojson.features[]`. Since the Repeater was dropped, a single
+     *     map can hold several routes/polygons.
+     *  2. Old (Repeater rows): `[{<candidateKey>: {...}}, ...]` —
+     *     backward compatibility for existing drafts.
+     *  3. Old (pre-Map): the state is a bare GeoJSON geometry.
      *
-     * In beide gevallen pakken we `features[].geometry`; ontbreekt die,
-     * dan vallen we terug op een recursieve zoektocht naar `coordinates`
-     * (pre-Map state-shapes uit de oude OF-flow).
+     * In the first two cases `features[].geometry` is taken; if that is
+     * missing we fall back to a recursive search for `coordinates`.
      *
-     * @param  callable(string): ?string  $normalizer  zet een ruwe string-payload om naar geldige JSON
-     * @param  string  $candidateKey  Repeater-row-key voor de oude shape
+     * @param  callable(string): ?string  $normalizer  turns a raw string payload into valid JSON
+     * @param  string  $candidateKey  Repeater row key for the old shape
      * @return list<Geometry>
      */
-    private function parseGeometries(mixed $input, callable $normalizer, string $candidateKey): array
+    private static function parseGeometries(mixed $input, callable $normalizer, string $candidateKey): array
     {
         $json = is_array($input) ? json_encode($input) : $normalizer($input);
         $decoded = json_decode((string) $json, true);
@@ -139,8 +144,15 @@ final class EventLocationGeometryBuilder
             return [];
         }
 
-        // Verzamel alle Map-states die we tegenkomen (één in nieuwe shape,
-        // N in de oude shape).
+        // A state that is itself a bare geometry is one geometry, not a list of
+        // map states: it has to be recognised before the split below, which
+        // would otherwise walk into its `coordinates` member and lose the type.
+        if (isset($decoded['type'], $decoded['coordinates'])) {
+            return [(new GeoJsonReader)->read((string) json_encode($decoded))];
+        }
+
+        // Collect every Map state present (one in the current shape, N in the
+        // old one).
         $mapStates = isset($decoded['geojson'])
             ? [$decoded]
             : array_values(array_filter($decoded, static fn ($row) => is_array($row)));
@@ -153,8 +165,8 @@ final class EventLocationGeometryBuilder
             }
             $features = $candidate['geojson']['features'] ?? null;
             if (! is_array($features)) {
-                // Fallback voor pre-Map state-shapes (bv. wanneer OF nog
-                // een platte geometrie in de FormState had staan).
+                // Fallback for pre-Map state shapes (for example a bare
+                // geometry inside an old repeater row).
                 $array = ArrayHelper::findElementWithKey($candidate, 'coordinates');
                 if ($array) {
                     $out[] = (new GeoJsonReader)->read((string) json_encode($array));

--- a/app/Jobs/Zaak/CreateDoorkomstZaken.php
+++ b/app/Jobs/Zaak/CreateDoorkomstZaken.php
@@ -6,26 +6,28 @@ namespace App\Jobs\Zaak;
 
 use App\Actions\Geospatial\CheckIntersects;
 use App\EventForm\State\FormState;
+use App\EventForm\Submit\EventLocationGeometryBuilder;
 use App\EventForm\Submit\MapFormStateToReferenceData;
 use App\EventForm\Submit\ZaakeigenschappenMap;
 use App\Models\Municipality;
 use App\Models\MunicipalityZaaktypeMapping;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
-use App\Normalizers\OpenFormsNormalizer;
 use App\Services\Zgw\InitiatorRolBuilder;
 use App\Services\Zgw\ZaakReadModel;
 use App\Services\Zgw\ZaaktypeBlueprint;
 use App\Services\Zgw\ZgwConnectionConfig;
 use App\Services\Zgw\ZgwResource;
-use App\Support\Helpers\ArrayHelper;
 use App\ValueObjects\ModelAttributes\ZaakReferenceData;
+use Brick\Geo\Curve;
 use Brick\Geo\Engine\PdoEngine;
-use Brick\Geo\Io\GeoJsonReader;
-use Brick\Geo\LineString;
+use Brick\Geo\Geometry;
+use Brick\Geo\GeometryCollection;
+use Brick\Geo\Point;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Throwable;
@@ -34,13 +36,16 @@ use Woweb\Zgw\Data\Generated\Catalogi\EigenschapData;
 use Woweb\Zgw\Facades\Zgw;
 
 /**
- * Voor route-events (zaaktype met `triggers_route_check = true`): maakt
- * per gemeente waar de route doorheen loopt (exclusief start- en
- * eindgemeente) een "doorkomst"-deelzaak aan en kopieert relevante
- * eigenschappen / initiator / documenten / initiële status.
+ * For route events (a zaaktype with `triggers_route_check = true`): creates
+ * a "doorkomst" deelzaak for every municipality a route passes through
+ * (excluding the start and end municipality) and copies the relevant
+ * eigenschappen / initiator / documents / initial status.
  *
- * Input is nu `Zaak`; de LineString komt uit `form_state_snapshot`
- * via `ZaakeigenschappenMap::buildEventLocation()`.
+ * Input is a `Zaak`; the routes come from `form_state_snapshot` via
+ * `ZaakeigenschappenMap::buildEventLocation()`. An event can have more than
+ * one route drawn on the map, so all of them are read and the result is the
+ * union of the municipalities they cross, minus the start and end
+ * municipalities of all routes together.
  */
 class CreateDoorkomstZaken implements ShouldQueue
 {
@@ -67,29 +72,17 @@ class CreateDoorkomstZaken implements ShouldQueue
         }
 
         $state = FormState::fromSnapshot($this->zaak->form_state_snapshot ?? []);
-        $lineArray = $this->extractLineArray($map->buildEventLocation($state));
-        if (! $lineArray) {
+        $lines = $this->extractLines($map->buildEventLocation($state));
+        if ($lines === []) {
             return;
         }
-
-        /** @var LineString $line */
-        $line = (new GeoJsonReader)->read((string) json_encode($lineArray));
 
         $engine = new PdoEngine(DB::connection()->getPdo());
         $checkIntersects = new CheckIntersects($engine);
 
-        $all = $checkIntersects->checkIntersectsWithModels($line);
-        $startModels = $checkIntersects->checkIntersectsWithModels($line->startPoint());
-        $endModels = $checkIntersects->checkIntersectsWithModels($line->endPoint());
-
-        $excluded = $startModels->pluck('brk_identification')
-            ->merge($endModels->pluck('brk_identification'))
-            ->unique()
-            ->toArray();
-
         $hoofdZaakMuniBrk = $this->zaak->municipality?->brk_identification;
 
-        $passing = $all->reject(fn ($m) => in_array($m->brk_identification, $excluded, true))
+        $passing = $this->passingMunicipalities($lines, $checkIntersects)
             ->reject(fn ($m) => $hoofdZaakMuniBrk && $m->brk_identification === $hoofdZaakMuniBrk);
         if ($passing->isEmpty()) {
             return;
@@ -114,23 +107,83 @@ class CreateDoorkomstZaken implements ShouldQueue
     }
 
     /**
+     * All routes drawn on the map, parsed with the very same parser the submit
+     * flow uses. That parser understands both the current map state (one
+     * FeatureCollection holding N routes) and the older shapes kept in existing
+     * drafts, so the job and the submit flow cannot disagree about what "the
+     * routes" are.
+     *
      * @param  array<string, mixed>  $eventLocation
-     * @return array<string, mixed>|null
+     * @return list<Geometry>
      */
-    private function extractLineArray(array $eventLocation): ?array
+    private function extractLines(array $eventLocation): array
     {
         $line = $eventLocation['line'] ?? null;
-        if (! $line || $line === 'None') {
-            return null;
+        if (empty($line) || $line === 'None') {
+            return [];
         }
 
-        $json = is_array($line) ? json_encode($line) : OpenFormsNormalizer::normalizeGeoJson($line);
-        $decoded = json_decode((string) $json, true);
-        if (! is_array($decoded)) {
-            return null;
+        return array_values(array_filter(
+            EventLocationGeometryBuilder::parseLines($line),
+            static fn (Geometry $geometry) => ! $geometry->isEmpty(),
+        ));
+    }
+
+    /**
+     * The union of the municipalities the routes pass through, minus the start
+     * and end municipalities of ALL routes. The exclusion is deliberately global
+     * and not per route: a municipality where any route begins or ends is a
+     * start or end municipality for this event, so it never gets a doorkomst
+     * deelzaak, not even when another route merely passes through it.
+     *
+     * @param  list<Geometry>  $lines
+     * @return Collection<int, Municipality>
+     */
+    private function passingMunicipalities(array $lines, CheckIntersects $checkIntersects): Collection
+    {
+        $excluded = [];
+        $passing = new Collection;
+
+        foreach ($lines as $line) {
+            foreach ($this->boundaryPoints($line) as $point) {
+                foreach ($checkIntersects->checkIntersectsWithModels($point) as $municipality) {
+                    $excluded[] = $municipality->brk_identification;
+                }
+            }
+
+            $passing = $passing->merge($checkIntersects->checkIntersectsWithModels($line));
         }
 
-        return ArrayHelper::findElementWithKey($decoded, 'coordinates');
+        return $passing
+            ->reject(fn ($m) => in_array($m->brk_identification, $excluded, true))
+            ->unique('brk_identification')
+            ->values();
+    }
+
+    /**
+     * Start and end points of a route. A route drawn as a MultiLineString has no
+     * start point of its own, so its parts are walked instead.
+     *
+     * @return list<Point>
+     */
+    private function boundaryPoints(Geometry $geometry): array
+    {
+        if ($geometry instanceof Curve) {
+            return $geometry->isEmpty() ? [] : [$geometry->startPoint(), $geometry->endPoint()];
+        }
+
+        if ($geometry instanceof GeometryCollection) {
+            $points = [];
+            foreach ($geometry->geometries() as $part) {
+                foreach ($this->boundaryPoints($part) as $point) {
+                    $points[] = $point;
+                }
+            }
+
+            return $points;
+        }
+
+        return [];
     }
 
     /**

--- a/docker/pgsql/init-postgis.sql
+++ b/docker/pgsql/init-postgis.sql
@@ -1,9 +1,15 @@
--- Install PostGIS extension in the main database
-\c evenement_applicatie;
+-- Install PostGIS in the application database.
+--
+-- No \c to a fixed database name here: the entrypoint already runs this script
+-- connected to POSTGRES_DB, which compose fills from DB_DATABASE. Naming the
+-- database in this file made the script depend on one specific DB_DATABASE
+-- value, so any other value (including the one in .env.example) aborted the
+-- whole init with "database ... does not exist" and left the container down.
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS postgis_topology;
 
--- Install PostGIS extension in testing database as well
+-- Install PostGIS in the testing database as well. That database is created by
+-- the Sail init script mounted before this one, so its name is fixed.
 \c testing;
 CREATE EXTENSION IF NOT EXISTS postgis;
 CREATE EXTENSION IF NOT EXISTS postgis_topology;

--- a/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
+++ b/tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php
@@ -832,3 +832,220 @@ test('is idempotent: running twice does not create a second doorkomst zaak', fun
         ->where('zaaktype_id', $doorkomstZaaktype->id)
         ->count())->toBe(1);
 });
+
+/**
+ * ---------------------------------------------------------------------------
+ * Several routes on one map
+ * ---------------------------------------------------------------------------
+ *
+ * An event can have more than one route drawn on the map. Every drawn route
+ * has to produce doorkomst deelzaken for the municipalities it crosses. The
+ * result is the union over all routes, minus the start and end municipalities
+ * of all routes together: a municipality where any route begins or ends never
+ * gets a deelzaak, not even when another route merely passes through it.
+ *
+ * These cases extend the fixture of doorkomstScenario() with a second passing
+ * municipality south of it:
+ *
+ *   y  3..4    . . . . . . . Eindgemeente (3..4)
+ *   y  1.5..2.5      Doorkomstgemeente (1.5..2.5)
+ *   y  0..1    Hoofdgemeente (0..1)
+ *   y -2.5..-1.5     Tweede doorkomstgemeente (1.5..2.5)
+ */
+
+/** A bare GeoJSON LineString geometry. */
+function lineGeometry(array $coordinates, string $type = 'LineString'): array
+{
+    return ['type' => $type, 'coordinates' => $coordinates];
+}
+
+/**
+ * Current map state: one Map component holding N drawn features. This is what
+ * the form writes since the Repeater around the route map was dropped.
+ */
+function routeMapSnapshot(array $geometries): array
+{
+    return ['values' => ['routesOpKaart' => [
+        'lat' => 0.5,
+        'lng' => 0.5,
+        'geojson' => [
+            'type' => 'FeatureCollection',
+            'features' => array_map(static fn (array $geometry) => [
+                'type' => 'Feature',
+                'properties' => [],
+                'geometry' => $geometry,
+            ], $geometries),
+        ],
+    ]]];
+}
+
+/** A second passing municipality with its own doorkomst zaaktype on main. */
+function secondPassingMunicipality(): Municipality
+{
+    $municipality = Municipality::factory()->create([
+        'name' => 'Tweede doorkomstgemeente',
+        'geometry' => multipolygon([[1.5, -2.5], [1.5, -1.5], [2.5, -1.5], [2.5, -2.5], [1.5, -2.5]]),
+    ]);
+
+    Zaaktype::factory()->create([
+        'municipality_id' => $municipality->id,
+        'role' => ZaaktypeRole::Doorkomst,
+        'connection' => 'main',
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/dk-m2',
+        'is_active' => true,
+    ]);
+
+    return $municipality;
+}
+
+/**
+ * Hoofdzaak and deelzaken all on main, with a distinct url per created
+ * deelzaak so several of them can be told apart.
+ */
+function fakeDoorkomstZgwOnMain(): void
+{
+    $created = 0;
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1*' => Http::response([
+            'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/hoofd',
+            'identificatie' => 'HOOFD-1',
+            'bronorganisatie' => '123456789',
+            'startdatum' => '2026-07-01',
+            'omschrijving' => 'Hoofdzaak',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaakinformatieobjecten*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken*' => function ($request) use (&$created) {
+            if ($request->method() === 'POST') {
+                $created++;
+
+                return Http::response(['url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/deel-'.$created], 201);
+            }
+
+            // Read back the deelzaak that was actually asked for, so several
+            // deelzaken keep their own url and identificatie.
+            $slug = basename((string) parse_url($request->url(), PHP_URL_PATH));
+
+            return Http::response(array_merge(deelZaakReadResponse(), [
+                'url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/'.$slug,
+                'identificatie' => strtoupper($slug),
+            ]), 200);
+        },
+        '*/catalogi/api/v1/*' => Http::response(ZgwHttpFake::envelope([]), 200),
+        '*' => Http::response([], 200),
+    ]);
+}
+
+/**
+ * A hoofdzaak on main whose form state holds the given route geometries.
+ */
+function multiRouteHoofdZaak(array $geometries): Zaak
+{
+    $scenario = doorkomstScenario(hoofdOwnInstance: false);
+    $scenario['hoofdzaak']->update([
+        'zgw_zaak_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/zaken/hoofd-1',
+        'form_state_snapshot' => routeMapSnapshot($geometries),
+    ]);
+    withPassingDoorkomstZaaktype($scenario['passing']);
+
+    return $scenario['hoofdzaak'];
+}
+
+/**
+ * The zaaktype urls the job actually created a deelzaak for, sorted so the
+ * assertion does not depend on the order the municipalities come back in.
+ *
+ * @return list<string>
+ */
+function createdDeelzaakZaaktypen(): array
+{
+    $zaaktypen = collect(Http::recorded())
+        ->filter(fn ($pair) => $pair[0]->method() === 'POST'
+            && parse_url($pair[0]->url(), PHP_URL_PATH) === '/zaken/api/v1/zaken')
+        ->map(fn ($pair) => (string) ($pair[0]->data()['zaaktype'] ?? ''))
+        ->values()
+        ->all();
+
+    sort($zaaktypen);
+
+    return $zaaktypen;
+}
+
+function doorkomstZaaktypeUrl(string $slug): string
+{
+    return ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/'.$slug;
+}
+
+test('creates doorkomst zaken for the crossed municipalities of every drawn route', function () {
+    fakeDoorkomstZgwOnMain();
+    secondPassingMunicipality();
+
+    // Route 1 crosses the first doorkomst municipality, route 2 the second one.
+    // Neither starts or ends in a municipality that the other one crosses.
+    $hoofdzaak = multiRouteHoofdZaak([
+        lineGeometry([[0.5, 0.5], [3.5, 3.5]]),
+        lineGeometry([[0.5, -2.0], [3.5, -2.0]]),
+    ]);
+
+    CreateDoorkomstZaken::dispatchSync($hoofdzaak);
+
+    expect(createdDeelzaakZaaktypen())->toBe([
+        doorkomstZaaktypeUrl('dk-m'),
+        doorkomstZaaktypeUrl('dk-m2'),
+    ]);
+});
+
+test('never creates a deelzaak for a municipality another route starts in', function () {
+    fakeDoorkomstZgwOnMain();
+    secondPassingMunicipality();
+
+    // Route 2 starts inside the municipality that route 1 passes through, and
+    // runs south into the second doorkomst municipality. Being a start
+    // municipality of the event wins, so only the second one gets a deelzaak.
+    $hoofdzaak = multiRouteHoofdZaak([
+        lineGeometry([[0.5, 0.5], [3.5, 3.5]]),
+        lineGeometry([[2.0, 2.0], [2.0, -3.5]]),
+    ]);
+
+    CreateDoorkomstZaken::dispatchSync($hoofdzaak);
+
+    expect(createdDeelzaakZaaktypen())->toBe([doorkomstZaaktypeUrl('dk-m2')]);
+});
+
+test('reads a MultiLineString route instead of crashing on it', function () {
+    fakeDoorkomstZgwOnMain();
+    secondPassingMunicipality();
+
+    // One route drawn in several parts: it has no start point of its own, so
+    // the parts have to be walked to find the start and end municipalities.
+    $hoofdzaak = multiRouteHoofdZaak([
+        lineGeometry([
+            [[0.5, 0.5], [3.5, 3.5]],
+            [[0.5, -2.0], [3.5, -2.0]],
+        ], 'MultiLineString'),
+    ]);
+
+    CreateDoorkomstZaken::dispatchSync($hoofdzaak);
+
+    expect(createdDeelzaakZaaktypen())->toBe([
+        doorkomstZaaktypeUrl('dk-m'),
+        doorkomstZaaktypeUrl('dk-m2'),
+    ]);
+});
+
+test('a single drawn route still yields exactly the municipality it crosses', function () {
+    // Regression anchor: one route in the current map state shape behaves the
+    // same as it always did. The tests above this block cover the same for the
+    // bare-geometry snapshot shape that existing drafts still hold.
+    fakeDoorkomstZgwOnMain();
+    secondPassingMunicipality();
+
+    $hoofdzaak = multiRouteHoofdZaak([
+        lineGeometry([[0.5, 0.5], [3.5, 3.5]]),
+    ]);
+
+    CreateDoorkomstZaken::dispatchSync($hoofdzaak);
+
+    expect(createdDeelzaakZaaktypen())->toBe([doorkomstZaaktypeUrl('dk-m')]);
+});


### PR DESCRIPTION

This branch carries two independent fixes.

### 1. Doorkomst zaken for every drawn route

`CreateDoorkomstZaken` was rewritten on this branch for the multi-connection
work, and in that rewrite it kept reading the routes the old way:
`extractLineArray()` ran `ArrayHelper::findElementWithKey($decoded, 'coordinates')`
over the map state, which returns the **first** `coordinates` it finds. An
event can have more than one route drawn on the map and the form already
evaluates all of them, but everything after that point in the job (the
intersect check, the start/end exclusion, the deelzaak creation) only ever saw
route 1.

For an applicant with two routes that means the municipalities on route 2 and
up silently never get a doorkomst deelzaak. Nothing fails, nothing is logged,
the zaak just misses municipalities it should have notified. A route drawn as a
`MultiLineString` (one route in several parts) made the job fail on
`$line->startPoint()` instead, because `startPoint()` only exists on a
`LineString`.

This is the same defect #492 fixes on `main`. The job here is not the same code
any more, so this is the fix applied to the current structure rather than a
cherry-pick.

The job now reads the routes with `EventLocationGeometryBuilder::parseLines()`,
the same parser the submit flow uses. That parser returns **all** geometries and
understands the state shapes that occur: the current map state with several
features in one `geojson.features[]`, the older repeater rows still sitting in
existing drafts, and a bare geometry. Reusing it means the job and the submit
flow can no longer disagree about what "the routes" are, so `parseLines()` is
now public and static instead of there being a second parser.

Selecting the municipalities is now:

- the union over all routes of the municipalities they intersect;
- minus the start and end municipalities of all routes together.

The exclusion is deliberately global rather than per route. A municipality where
any route begins or ends is a start or end municipality of this event, so it
gets no doorkomst deelzaak, not even when another route merely passes through
it. The municipality of the hoofdzaak itself is still excluded, as before.

`boundaryPoints()` replaces the direct `startPoint()`/`endPoint()` calls: for a
`Curve` it returns the start and end point, and for a geometry collection (a
`MultiLineString`) it walks the parts and returns their start and end points.
That is what fixes the failure above, and it keeps the exclusion correct for a
route made of several segments.

**One extra change in the shared parser.** `parseGeometries()` documented a
fallback for pre-Map state shapes, but it could not actually reach it when the
state *is* a bare geometry: the map-state split walked into the geometry's
`coordinates` member and lost the type, so nothing came back. The old
`extractLineArray()` did handle that shape, and existing snapshots hold it, so
switching the job to the shared parser without this would have been a
regression. A bare geometry is now recognised before the split. It is a small
addition, but it is the piece that lets both callers share one parser.

### 2. `docker/pgsql/init-postgis.sql` on a fresh setup

The init script opened with `\c evenement_applicatie;`, while `.env.example`
ships `DB_DATABASE=eventloket` and both compose files pass `DB_DATABASE` on as
`POSTGRES_DB`. Following the README on a fresh clone (`cp .env.example .env`,
`composer install`, `sail up -d`) therefore ran that script against a database
that does not exist. Because the entrypoint runs init scripts with
`ON_ERROR_STOP`, the whole init aborted and the database container exited with
code 3:

```
FATAL:  database "evenement_applicatie" does not exist
psql:/docker-entrypoint-initdb.d/20-init-postgis.sql:2: error: \connect: ...
```

Neither the application database nor the `testing` database got PostGIS, and
nothing came up at all. Existing checkouts do not notice it, because init
scripts only run when the data volume is empty.

The smallest fix that makes any `DB_DATABASE` work is to drop the `\c` for the
application database entirely: the entrypoint already runs the script connected
to `POSTGRES_DB`, so naming the database in the file only pinned it to one
specific value. The `\c testing;` stays, because that database is created by the
Sail init script mounted before this one and its name is fixed.

Verified on a fresh clone with an unmodified `.env.example`: before the change
the container exits (3), after it the init completes and both `eventloket` and
`testing` report `postgis` and `postgis_topology`.

## Tests

`tests/Feature/Jobs/Zaak/CreateDoorkomstZakenTest.php` gains four cases on top
of the seventeen it already had, extending the existing fixture with a second
passing municipality:

- doorkomst zaken are created for the crossed municipalities of every drawn
  route;
- a municipality that one route starts in gets no deelzaak even when a second
  route passes straight through it;
- a `MultiLineString` route is read instead of failing;
- a single drawn route still yields exactly the municipality it crosses
  (regression anchor).

The first three fail on the unchanged branch (two on the missing second route,
one on `startPoint()`); the fourth passes either way, as do all seventeen
existing cases, which are untouched and cover the single-route bare-geometry
snapshot shape.
