### PR TITLE
Stop a hidden field's last value from reaching the application

### DIFF
--- a/app/EventForm/Reporting/SubmissionReport.php
+++ b/app/EventForm/Reporting/SubmissionReport.php
@@ -1056,6 +1056,17 @@ final class SubmissionReport
             {
                 return $this->state;
             }
+
+            /**
+             * The form page answers this with the state minus the questions it
+             * is no longer asking. There is no schema to ask here, and there is
+             * no need for one: a report is built from a state that has already
+             * been settled.
+             */
+            public function stateAsAsked(): FormState
+            {
+                return $this->state;
+            }
         };
     }
 }

--- a/app/EventForm/Schema/CustomSteps/SamenvattingStep.php
+++ b/app/EventForm/Schema/CustomSteps/SamenvattingStep.php
@@ -34,7 +34,12 @@ final class SamenvattingStep
             ->schema([
                 TextEntry::make('samenvattingOverzicht')
                     ->hiddenLabel()
-                    ->state(fn ($livewire) => new HtmlString(self::renderHtml($livewire->state())))
+                    // The summary reads the state as the form is asking for it,
+                    // so it shows the application that will be submitted: an
+                    // answer to a question that is no longer being put to the
+                    // organiser is left out here just as it is left out of the
+                    // application itself.
+                    ->state(fn ($livewire) => new HtmlString(self::renderHtml($livewire->stateAsAsked())))
                     ->columnSpanFull(),
                 Checkbox::make('akkoordVerwerkingGegevens')
                     ->label('Ik ga akkoord dat mijn gegevens verwerkt worden voor de behandeling van deze aanvraag.')

--- a/app/EventForm/Schema/Steps/TijdenStep.php
+++ b/app/EventForm/Schema/Steps/TijdenStep.php
@@ -227,7 +227,12 @@ final class TijdenStep
                     // waarden zijn ISO-strings (geen user-text-input),
                     // dus self-XSS is in de praktijk niet mogelijk, maar
                     // safe-by-default is het beleid.
-                    ->state(fn ($livewire) => new HtmlString(app(LabelRenderer::class)->renderHtml('<h2>Overzicht ingevulde tijden</h2><figure class="table"><table><thead><tr><th><strong>Activiteit</strong></th><th>&nbsp;</th><th><strong>Start</strong></th><th>&nbsp;</th><th><strong>Eind</strong></th></tr></thead><tbody><tr><th><strong>Opbouw</strong></th><td>&nbsp;</td><td>{{ OpbouwStart }}</td><td>&nbsp;</td><td>{{ OpbouwEind }}</td></tr><tr><th><strong>Publiek</strong></th><td>&nbsp;</td><td>{{ EvenementStart }}</td><td>&nbsp;</td><td>{{ EvenementEind }}</td></tr><tr><th><strong>Afbouw</strong></th><td>&nbsp;</td><td>{{ AfbouwStart }}</td><td>&nbsp;</td><td>{{ AfbouwEind }}</td></tr></tbody></table></figure><p><br>Wijzig de velden boven dit overzicht indien de tijden niet correct zijn.</p>', $livewire->state()))),
+                    //
+                    // The overview reads the state as the form is asking for
+                    // it: a build-up or take-down time that was filled in and
+                    // then answered away is no longer part of the answer, so
+                    // its row has to be empty here too.
+                    ->state(fn ($livewire) => new HtmlString(app(LabelRenderer::class)->renderHtml('<h2>Overzicht ingevulde tijden</h2><figure class="table"><table><thead><tr><th><strong>Activiteit</strong></th><th>&nbsp;</th><th><strong>Start</strong></th><th>&nbsp;</th><th><strong>Eind</strong></th></tr></thead><tbody><tr><th><strong>Opbouw</strong></th><td>&nbsp;</td><td>{{ OpbouwStart }}</td><td>&nbsp;</td><td>{{ OpbouwEind }}</td></tr><tr><th><strong>Publiek</strong></th><td>&nbsp;</td><td>{{ EvenementStart }}</td><td>&nbsp;</td><td>{{ EvenementEind }}</td></tr><tr><th><strong>Afbouw</strong></th><td>&nbsp;</td><td>{{ AfbouwStart }}</td><td>&nbsp;</td><td>{{ AfbouwEind }}</td></tr></tbody></table></figure><p><br>Wijzig de velden boven dit overzicht indien de tijden niet correct zijn.</p>', $livewire->stateAsAsked()))),
             ]);
     }
 }

--- a/app/EventForm/State/FormState.php
+++ b/app/EventForm/State/FormState.php
@@ -239,6 +239,38 @@ class FormState implements Arrayable
     }
 
     /**
+     * Drop state keys that are no longer part of the answer.
+     *
+     * `absorbFields()` merges and never removes a key, so a value outlives
+     * the field it belongs to: once a field is hidden it stops being
+     * submitted, yet its last value stays in the bag and keeps flowing into
+     * everything built from this state. Callers that know the current schema
+     * use this to bring the bag back in line with what is actually asked.
+     *
+     * @param  list<string>  $keys
+     */
+    public function forgetFields(array $keys): void
+    {
+        $removed = false;
+
+        foreach ($keys as $key) {
+            if (! array_key_exists($key, $this->values)) {
+                continue;
+            }
+
+            unset($this->values[$key]);
+            $removed = true;
+        }
+
+        if (! $removed) {
+            return;
+        }
+
+        $this->getCache = [];
+        $this->version++;
+    }
+
+    /**
      * Set meerdere variabelen in één keer (bv. initial values of service response).
      *
      * @param  array<string, mixed>  $values

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -853,14 +853,48 @@ class EventFormPage extends Page implements HasForms
      */
     private function pruneStateToVisible(): void
     {
+        $this->state->forgetFields($this->stateKeysNotBeingAsked());
+    }
+
+    /**
+     * The state as the form is currently asking for it: everything that has
+     * been filled in, minus the answers to questions that are no longer being
+     * put to the organiser.
+     *
+     * The components that show back what has been filled in read this instead
+     * of the raw state. Without it they print a value the organiser can no
+     * longer see or correct — the same stale value {@see pruneStateToVisible}
+     * keeps out of the submitted application — so the overview and the
+     * application would disagree about what was asked.
+     *
+     * The state itself is deliberately left untouched. Only submitting settles
+     * what the answers are; until then a question that comes back has to show
+     * what was typed before, and a stored draft keeps its own bag.
+     */
+    public function stateAsAsked(): FormState
+    {
+        $shown = FormState::fromSnapshot($this->state->toSnapshot());
+        $shown->forgetFields($this->stateKeysNotBeingAsked());
+
+        return $shown;
+    }
+
+    /**
+     * The top-level state keys the wizard owns but is not currently asking
+     * for: hidden fields, and fields of a step the answers do not apply to.
+     *
+     * @return list<string>
+     */
+    private function stateKeysNotBeingAsked(): array
+    {
         $wizard = $this->form->getComponents(withHidden: true)[0] ?? null;
         if (! $wizard instanceof Component) {
-            return;
+            return [];
         }
 
         $wizardSchema = $wizard->getChildSchema();
         if ($wizardSchema === null) {
-            return;
+            return [];
         }
 
         /** @var array{owned: list<string>, answerable: list<string>} $keys */
@@ -874,13 +908,13 @@ class EventFormPage extends Page implements HasForms
                     continue;
                 }
 
-                $owned = [...$owned, ...$this->fieldStateKeys($stepSchema->getFlatFields(withHidden: true))];
+                $owned = [...$owned, ...$this->fieldStateKeys($this->fieldsOf($stepSchema, withHidden: true))];
 
                 if (! $this->state->isStepApplicable(self::stepUuid($step))) {
                     continue;
                 }
 
-                $answerable = [...$answerable, ...$this->fieldStateKeys($stepSchema->getFlatFields(withHidden: false))];
+                $answerable = [...$answerable, ...$this->fieldStateKeys($this->fieldsOf($stepSchema, withHidden: false))];
             }
 
             return ['owned' => $owned, 'answerable' => $answerable];
@@ -895,13 +929,48 @@ class EventFormPage extends Page implements HasForms
             array_keys(FormDerivedState::COMPUTED_KEYS),
         );
 
-        $this->state->forgetFields(array_values(array_unique($forget)));
+        return array_values(array_unique($forget));
+    }
+
+    /**
+     * The fields of a schema, optionally including the ones it is currently
+     * hiding.
+     *
+     * Deliberately not `getFlatFields()`: that memoises its result per
+     * visibility flag on the schema, and the schema outlives the moment the
+     * answers change. The overviews ask for the visible set while the page
+     * renders, submitting asks for it again after the last answer is in, and a
+     * memoised set would hand the second caller the first caller's world. This
+     * walk mirrors what Filament does but evaluates the visibility every time
+     * it is asked.
+     *
+     * @return list<Field>
+     */
+    private function fieldsOf(Schema $schema, bool $withHidden): array
+    {
+        $fields = [];
+
+        foreach ($schema->getComponents(withActions: false, withHidden: $withHidden) as $component) {
+            if (! $component instanceof Component) {
+                continue;
+            }
+
+            if ($component instanceof Field) {
+                $fields[] = $component;
+            }
+
+            foreach ($component->getChildSchemas($withHidden) as $childSchema) {
+                $fields = [...$fields, ...$this->fieldsOf($childSchema, $withHidden)];
+            }
+        }
+
+        return $fields;
     }
 
     /**
      * The top-level state keys the given fields write to.
      *
-     * @param  array<string, Field>  $fields
+     * @param  list<Field>  $fields
      * @return list<string>
      */
     private function fieldStateKeys(array $fields): array

--- a/app/Filament/Organiser/Pages/EventFormPage.php
+++ b/app/Filament/Organiser/Pages/EventFormPage.php
@@ -23,11 +23,13 @@ use App\Models\Users\OrganiserUser;
 use Carbon\CarbonInterface;
 use Filament\Actions\Action;
 use Filament\Facades\Filament;
+use Filament\Forms\Components\Field;
 use Filament\Forms\Concerns\InteractsWithForms;
 use Filament\Forms\Contracts\HasForms;
 use Filament\Notifications\Notification;
 use Filament\Pages\Page;
 use Filament\Panel;
+use Filament\Schemas\Components\Component;
 use Filament\Schemas\Schema;
 use Livewire\Attributes\Locked;
 
@@ -738,6 +740,7 @@ class EventFormPage extends Page implements HasForms
         $dehydrationState = [];
         $this->form->callBeforeStateDehydrated($dehydrationState);
         $this->absorbFormData($this->form->getStateSnapshot());
+        $this->pruneStateToVisible();
 
         $user = $this->state->get('authUser');
         $org = $this->state->get('authOrganisation');
@@ -817,17 +820,128 @@ class EventFormPage extends Page implements HasForms
         }
 
         foreach ($wizard->getChildSchema()->getComponents() as $step) {
-            // Filament prefixeert de step-key met "form." (de naam van de form-schema-
-            // binding); COMPUTED_STEPS bevat alleen de kale UUID's. Dezelfde strip
-            // staat in vertical-wizard.blade.php.
-            $rawKey = $step->getKey();
-            $stepUuid = str_starts_with($rawKey, 'form.') ? substr($rawKey, 5) : $rawKey;
-
-            if (! $this->state->isStepApplicable($stepUuid)) {
+            if (! $this->state->isStepApplicable(self::stepUuid($step))) {
                 continue;
             }
             $step->getChildSchema()->validate();
         }
+    }
+
+    /**
+     * Bring the state back in line with the answers the form is actually
+     * collecting, so that everything built from it describes the application
+     * the organiser is submitting.
+     *
+     * A field that was filled in and later became hidden keeps its value:
+     * `absorbFields()` merges and never drops a key. The value is invisible in
+     * the interface from that moment on, but it still reaches the outputs, so
+     * an application can carry an answer that was withdrawn or that came along
+     * with a copied application. Filament already leaves a hidden field out of
+     * its own dehydration, so the visible set below is exactly what the
+     * organiser sees; this only stops the merge from putting the stale value
+     * back.
+     *
+     * Step applicability is a second layer, because it is not a Filament
+     * concept: a step the answers make irrelevant is only dimmed in the step
+     * list, its fields stay rendered and would therefore count as visible.
+     *
+     * Two boundaries are respected. Nested values (repeater rows and the like)
+     * are not addressed here: the whole top-level value is replaced on absorb,
+     * so Filament's own pruning of those already survives. And keys the server
+     * owns are never dropped, for the same reason {@see absorbFormData} never
+     * lets the client write them: they are computed, not answered.
+     */
+    private function pruneStateToVisible(): void
+    {
+        $wizard = $this->form->getComponents(withHidden: true)[0] ?? null;
+        if (! $wizard instanceof Component) {
+            return;
+        }
+
+        $wizardSchema = $wizard->getChildSchema();
+        if ($wizardSchema === null) {
+            return;
+        }
+
+        /** @var array{owned: list<string>, answerable: list<string>} $keys */
+        $keys = Component::withVisibilityCache(function () use ($wizardSchema): array {
+            $owned = [];
+            $answerable = [];
+
+            foreach ($wizardSchema->getComponents(withHidden: true) as $step) {
+                $stepSchema = $step->getChildSchema();
+                if ($stepSchema === null) {
+                    continue;
+                }
+
+                $owned = [...$owned, ...$this->fieldStateKeys($stepSchema->getFlatFields(withHidden: true))];
+
+                if (! $this->state->isStepApplicable(self::stepUuid($step))) {
+                    continue;
+                }
+
+                $answerable = [...$answerable, ...$this->fieldStateKeys($stepSchema->getFlatFields(withHidden: false))];
+            }
+
+            return ['owned' => $owned, 'answerable' => $answerable];
+        });
+
+        // A key can be owned by more than one step, so a field is only dropped
+        // when no step offers it to the organiser at all.
+        $forget = array_diff(
+            $keys['owned'],
+            $keys['answerable'],
+            ServiceFetcher::FETCHED_VARIABLES,
+            array_keys(FormDerivedState::COMPUTED_KEYS),
+        );
+
+        $this->state->forgetFields(array_values(array_unique($forget)));
+    }
+
+    /**
+     * The top-level state keys the given fields write to.
+     *
+     * @param  array<string, Field>  $fields
+     * @return list<string>
+     */
+    private function fieldStateKeys(array $fields): array
+    {
+        $prefix = $this->form->getStatePath();
+        $prefix = filled($prefix) ? $prefix.'.' : '';
+
+        $keys = [];
+
+        foreach ($fields as $field) {
+            $path = (string) $field->getStatePath();
+
+            if ($prefix !== '') {
+                if (! str_starts_with($path, $prefix)) {
+                    continue;
+                }
+
+                $path = substr($path, strlen($prefix));
+            }
+
+            if ($path === '' || str_contains($path, '.')) {
+                continue;
+            }
+
+            $keys[] = $path;
+        }
+
+        return $keys;
+    }
+
+    /**
+     * Filament prefixes a step key with the name of the schema binding
+     * ("form."); the applicability rules are keyed on the bare UUID. The same
+     * strip lives in vertical-wizard.blade.php.
+     */
+    private static function stepUuid(Component $step): string
+    {
+        $key = (string) $step->getKey();
+
+        return str_starts_with($key, 'form.') ? substr($key, 5) : $key;
     }
 
     public function getTitle(): string

--- a/tests/Feature/EventForm/Pages/EventFormStatePruneSchemaWalkTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormStatePruneSchemaWalkTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Walks the whole form instead of naming fields.
+ *
+ * The leak this covers is not a property of one field, it is a property of the
+ * state layer, so a test that lists the fields it knows about proves nothing
+ * about the next conditional field somebody adds. This walk asks the schema
+ * itself which fields exist and which of them the organiser is actually being
+ * asked, puts a recognisable value on every field that is not being asked, and
+ * then requires that none of those values survive anywhere.
+ *
+ * Both sides of the invariant are checked, because a prune that is too eager
+ * is as wrong as one that is too careful:
+ *
+ *   - a field the organiser cannot answer must be gone from the state and from
+ *     all four outputs;
+ *   - a field the organiser can answer must keep the value it had.
+ *
+ * The expectation is worked out on a second, identical page, so the page under
+ * test cannot hand the test its own answer through Filament's per-schema
+ * caches.
+ */
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\EventForm\Reporting\SubmissionReport;
+use App\EventForm\Schema\EventFormSchema;
+use App\EventForm\Services\ServiceFetcher;
+use App\EventForm\State\FormDerivedState;
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\MapFormStateToReferenceData;
+use App\EventForm\Submit\ZaakeigenschappenMap;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Users\OrganiserUser;
+use Dotswan\MapPicker\Fields\Map;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\BaseFileUpload;
+use Filament\Forms\Components\Checkbox;
+use Filament\Forms\Components\CheckboxList;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Field;
+use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
+use Filament\Schemas\Components\Component;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+uses(RefreshDatabase::class);
+
+/** A moment no scenario in this file uses, so it is recognisable in an output. */
+const WALK_STALE_DATE = '2035-06-15 12:00';
+
+const WALK_STALE_YEAR = '2035-06-15';
+
+beforeEach(function () {
+    $this->user = User::factory()->state(['role' => Role::Organiser])->create();
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach(
+        $this->organisation->id,
+        ['role' => OrganisationRole::Admin->value],
+    );
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->organisation);
+});
+
+/**
+ * A page on its own draft, with the given answers already in place.
+ *
+ * @param  array<string, mixed>  $values
+ */
+function walkPage(User $user, Organisation $organisation, array $values): EventFormPage
+{
+    $draft = Draft::create([
+        'user_id' => $user->id,
+        'organisation_id' => $organisation->id,
+        'state' => ['values' => $values, 'system' => []],
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $draft->id])->instance();
+
+    $page->data = array_merge($page->data ?? [], $values);
+    $page->state()->absorbFields($values);
+    $page->state()->setSystem('authUser', OrganiserUser::find($user->id));
+    $page->state()->setSystem('authOrganisation', $organisation);
+
+    return $page;
+}
+
+/**
+ * A recognisable value for a field, in the shape that field holds.
+ *
+ * The shapes are read off the component class rather than off a list of field
+ * names, so a new conditional field is covered the moment it is added.
+ */
+function walkMarkerFor(Field $field, string $key): mixed
+{
+    $marker = 'NIET-GEVRAAGD-'.$key;
+
+    if ($field instanceof Repeater) {
+        return ['walk-row' => ['walkMarker' => $marker]];
+    }
+
+    if ($field instanceof CheckboxList || $field instanceof BaseFileUpload) {
+        return [$marker];
+    }
+
+    if ($field instanceof Select && $field->isMultiple()) {
+        return [$marker];
+    }
+
+    if ($field instanceof Map) {
+        return ['lat' => 0.0, 'lng' => 0.0, 'walkMarker' => $marker];
+    }
+
+    if ($field instanceof DateTimePicker) {
+        // A date field cannot hold the marker, so it gets a date no scenario
+        // uses; the assertions look for that date as well.
+        return WALK_STALE_DATE;
+    }
+
+    if ($field instanceof Checkbox) {
+        // Nothing recognisable fits in a boolean; the key-level assertion
+        // still covers it.
+        return true;
+    }
+
+    return $marker;
+}
+
+/**
+ * Which top-level state keys the wizard owns, and which of those the organiser
+ * is being asked right now: the field is visible and it sits on a step the
+ * current answers apply to.
+ *
+ * @return array{owned: list<string>, answerable: list<string>, fields: array<string, Field>}
+ */
+function walkSchemaKeys(EventFormPage $page): array
+{
+    $form = $page->getSchema('form');
+
+    $wizard = $form->getComponents(withHidden: true)[0] ?? null;
+    expect($wizard)->toBeInstanceOf(Component::class);
+
+    $prefix = $form->getStatePath().'.';
+
+    /** @param array<string, Field> $fields */
+    $keysOf = function (array $fields) use ($prefix): array {
+        $keys = [];
+        foreach ($fields as $field) {
+            $path = (string) $field->getStatePath();
+            if (! str_starts_with($path, $prefix)) {
+                continue;
+            }
+            $path = substr($path, strlen($prefix));
+            if ($path === '' || str_contains($path, '.')) {
+                continue;
+            }
+            $keys[$path] = $field;
+        }
+
+        return $keys;
+    };
+
+    $owned = [];
+    $answerable = [];
+
+    foreach ($wizard->getChildSchema()->getComponents(withHidden: true) as $step) {
+        $key = (string) $step->getKey();
+        $uuid = str_starts_with($key, 'form.') ? substr($key, 5) : $key;
+
+        $owned = [...$owned, ...$keysOf($step->getChildSchema()->getFlatFields(withHidden: true))];
+
+        if (! $page->state()->isStepApplicable($uuid)) {
+            continue;
+        }
+
+        $answerable = [...$answerable, ...$keysOf($step->getChildSchema()->getFlatFields(withHidden: false))];
+    }
+
+    // Keys the server computes are not answers and are never pruned; they are
+    // out of scope for this walk.
+    $vanDeServer = array_flip([...ServiceFetcher::FETCHED_VARIABLES, ...array_keys(FormDerivedState::COMPUTED_KEYS)]);
+
+    $owned = array_diff_key($owned, $vanDeServer);
+    $answerable = array_diff_key($answerable, $vanDeServer);
+
+    return [
+        'owned' => array_keys($owned),
+        'answerable' => array_keys($answerable),
+        'fields' => $owned,
+    ];
+}
+
+/**
+ * Everything the application produces from this state, as one blob of JSON.
+ */
+function walkOutputs(FormState $state): string
+{
+    return json_encode([
+        app(ZaakeigenschappenMap::class)->buildEigenschappen($state),
+        app(MapFormStateToReferenceData::class)
+            ->build($state, 'Ingediend', 'https://zgw.example.com/statustypen/1')
+            ->toArray(),
+        $state->toSnapshot()['values'],
+        app(SubmissionReport::class)->build($state, EventFormSchema::stepsForReport()),
+    ], JSON_THROW_ON_ERROR);
+}
+
+/**
+ * The walk itself. Fills every field the organiser is not being asked with a
+ * value that names the field, submits the state through the same two calls
+ * `submit()` makes, and then requires those values to be gone everywhere while
+ * the answers that were being asked are untouched.
+ *
+ * @param  array<string, mixed>  $antwoorden
+ */
+function loopHetSchemaAf(User $user, Organisation $organisation, array $antwoorden): void
+{
+    $verkenning = walkSchemaKeys(walkPage($user, $organisation, $antwoorden));
+
+    $nietGevraagd = array_values(array_diff($verkenning['owned'], $verkenning['answerable']));
+    expect($nietGevraagd)->not->toBeEmpty();
+
+    $vervuild = $antwoorden;
+    foreach ($nietGevraagd as $key) {
+        if (array_key_exists($key, $antwoorden)) {
+            continue;
+        }
+        $vervuild[$key] = walkMarkerFor($verkenning['fields'][$key], $key);
+    }
+
+    // A second page for the expectation, so the page under test evaluates its
+    // own visibility from scratch.
+    $verwachting = walkSchemaKeys(walkPage($user, $organisation, $vervuild));
+    $nietGevraagd = array_values(array_diff($verwachting['owned'], $verwachting['answerable']));
+
+    $page = walkPage($user, $organisation, $vervuild);
+
+    $form = $page->getSchema('form');
+    $dehydrationState = [];
+    $form->callBeforeStateDehydrated($dehydrationState);
+
+    $absorb = new ReflectionMethod($page, 'absorbFormData');
+    $absorb->setAccessible(true);
+    $absorb->invoke($page, $form->getStateSnapshot());
+
+    $voor = $page->state()->fields();
+
+    $prune = new ReflectionMethod($page, 'pruneStateToVisible');
+    $prune->setAccessible(true);
+    $prune->invoke($page);
+
+    $na = $page->state();
+    $uitgaand = walkOutputs($na);
+
+    $blijvenHangen = array_values(array_intersect($nietGevraagd, array_keys($na->fields())));
+    expect($blijvenHangen)->toBe([], 'fields that are not being asked survived the prune: '.implode(', ', $blijvenHangen));
+
+    expect(str_contains($uitgaand, 'NIET-GEVRAAGD-'))->toBeFalse('a value of a field that is not being asked reached one of the outputs')
+        ->and(str_contains($uitgaand, WALK_STALE_YEAR))->toBeFalse('a date of a field that is not being asked reached one of the outputs');
+
+    $verdwenen = [];
+    foreach ($verwachting['answerable'] as $key) {
+        if (array_key_exists($key, $voor) && ! array_key_exists($key, $na->fields())) {
+            $verdwenen[] = $key;
+        }
+    }
+    expect($verdwenen)->toBe([], 'answers that are being asked were pruned: '.implode(', ', $verdwenen));
+}
+
+test('no field of a vooraankondiging keeps an answer it is not asked for', function () {
+    loopHetSchemaAf($this->user, $this->organisation, [
+        'waarvoorWiltUEventloketGebruiken' => 'vooraankondiging',
+        'waarVindtHetEvenementPlaats' => ['gebouw'],
+    ]);
+});
+
+test('no field of a melding keeps an answer it is not asked for', function () {
+    loopHetSchemaAf($this->user, $this->organisation, [
+        'waarvoorWiltUEventloketGebruiken' => 'aanvraag',
+        'waarVindtHetEvenementPlaats' => ['gebouw'],
+        'isHetAantalAanwezigenBijUwEvenementMinderDanSdf' => 'Ja',
+        'vindenDeActiviteitenVanUwEvenementPlaatsTussenTijdstippen' => 'Ja',
+        'WordtErAlleenMuziekGeluidGeproduceerdTussen' => 'Ja',
+        'IsdeGeluidsproductieLagerDan' => 'Ja',
+        'erVindenGeenActiviteitenPlaatsOpDeRijbaanBromFietspadOfParkeerplaatsOfAnderszinsEenBelemmeringVormenVoorHetVerkeerEnDeHulpdiensten' => 'Ja',
+        'wordenErMinderDanObjectenBijvTentSpringkussenGeplaatst' => 'Ja',
+        'indienErObjectenGeplaatstWordenZijnDezeDanKleiner' => 'Ja',
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Nee',
+    ]);
+});
+
+test('no field of a permit application keeps an answer it is not asked for', function () {
+    loopHetSchemaAf($this->user, $this->organisation, [
+        'waarvoorWiltUEventloketGebruiken' => 'aanvraag',
+        'waarVindtHetEvenementPlaats' => ['buiten'],
+        'isHetAantalAanwezigenBijUwEvenementMinderDanSdf' => 'Nee',
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Ja',
+    ]);
+});
+
+test('no field of a route event keeps an answer it is not asked for', function () {
+    loopHetSchemaAf($this->user, $this->organisation, [
+        'waarvoorWiltUEventloketGebruiken' => 'aanvraag',
+        'waarVindtHetEvenementPlaats' => ['route'],
+        'isHetAantalAanwezigenBijUwEvenementMinderDanSdf' => 'Ja',
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Nee',
+    ]);
+});

--- a/tests/Feature/EventForm/Pages/EventFormStatePruneTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormStatePruneTest.php
@@ -235,6 +235,21 @@ function zaakeigenschap(FormState $state, string $naam): mixed
     return null;
 }
 
+/**
+ * Renders one of the overview components of the live wizard and returns its
+ * HTML, by evaluating the component the organiser actually looks at.
+ */
+function overzichtHtml(EventFormPage $page, string $naam): string
+{
+    foreach ($page->getSchema('form')->getFlatComponents(withActions: false, withHidden: true) as $component) {
+        if (method_exists($component, 'getName') && $component->getName() === $naam) {
+            return (string) $component->getState();
+        }
+    }
+
+    throw new RuntimeException("overview component [{$naam}] not found in the form");
+}
+
 test('a location the organiser no longer ticks does not reach the outputs', function () {
     // The copied application took place outdoors; this one is in a building.
     // The outdoor location field is hidden from the moment the tick is gone,
@@ -509,4 +524,84 @@ test('a resumed draft is submitted without the answers it no longer shows', func
 
     expect($state->get('watIsDeAantrekkingskrachtVanHetEvenement'))->toBeNull();
     verwachtNergensIn($state, 'EERDERE-SESSIE-BUITENTERREIN');
+});
+
+/**
+ * The two places the wizard shows back what has been filled in: the times
+ * overview on the times step, and the summary before submitting. Both used to
+ * read the raw state, so a copied application that no longer has build-up
+ * activities still listed the build-up times of the application it came from.
+ * The times were kept out of the submitted application, but the organiser saw
+ * them right up to the moment of submitting.
+ */
+
+/** A copy that brought build-up and take-down times along. */
+function tijdenVanEenKopie(): array
+{
+    return [
+        'OpbouwStart' => '2035-06-30 08:15',
+        'OpbouwEind' => '2035-06-30 09:15',
+        'AfbouwStart' => '2035-07-02 20:15',
+        'AfbouwEind' => '2035-07-02 21:15',
+    ];
+}
+
+test('build-up times the organiser answered away are gone from the times overview', function () {
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), [
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Nee',
+        'zijnErAansluitendAanHetEvenementAfbouwactiviteiten' => 'Nee',
+    ]), tijdenVanEenKopie());
+
+    expect(overzichtHtml($page, 'overzichtTijden'))->not->toContain('2035');
+});
+
+test('build-up times the organiser answered away are gone from the summary', function () {
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), [
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Nee',
+        'zijnErAansluitendAanHetEvenementAfbouwactiviteiten' => 'Nee',
+    ]), tijdenVanEenKopie());
+
+    $samenvatting = overzichtHtml($page, 'samenvattingOverzicht');
+
+    expect($samenvatting)->not->toContain('2035')
+        ->and($samenvatting)->not->toContain('Opbouw')
+        ->and($samenvatting)->not->toContain('Afbouw');
+});
+
+test('the overviews leave the state itself alone', function () {
+    // Only submitting settles what the answers are. Until then the wizard has
+    // to be able to show the times again the moment the question comes back,
+    // and the stored draft keeps its own bag.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), [
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Nee',
+    ]), tijdenVanEenKopie());
+
+    overzichtHtml($page, 'overzichtTijden');
+    overzichtHtml($page, 'samenvattingOverzicht');
+
+    expect($page->state()->get('OpbouwStart'))->toBe('2035-06-30 08:15')
+        ->and($page->stateAsAsked()->get('OpbouwStart'))->toBeNull();
+});
+
+test('times the organiser is asked for stay in both overviews', function () {
+    // The other direction: as long as the question is being asked, the
+    // overviews show exactly what they showed before.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), tijdenVanEenKopie(), [
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Ja',
+        'zijnErAansluitendAanHetEvenementAfbouwactiviteiten' => 'Ja',
+    ]));
+
+    expect(overzichtHtml($page, 'overzichtTijden'))->toContain('2035')
+        ->and(overzichtHtml($page, 'samenvattingOverzicht'))->toContain('2035');
+
+    // And nothing else is filtered either: with every answer still being
+    // asked, the summary is byte for byte the one the raw state produces.
+    $gevraagd = app(SubmissionReport::class)->build($page->stateAsAsked(), EventFormSchema::stepsForReport());
+    $rauw = app(SubmissionReport::class)->build($page->state(), EventFormSchema::stepsForReport());
+
+    expect(json_encode($gevraagd, JSON_THROW_ON_ERROR))->toBe(json_encode($rauw, JSON_THROW_ON_ERROR));
 });

--- a/tests/Feature/EventForm/Pages/EventFormStatePruneTest.php
+++ b/tests/Feature/EventForm/Pages/EventFormStatePruneTest.php
@@ -1,0 +1,512 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * A field that was filled in and then stopped being asked used to keep its
+ * value. `FormState::absorbFields()` merges and never drops a key, so once a
+ * field became hidden its last value stayed in the bag: invisible in the
+ * interface, still present in everything built from that state. The organiser
+ * could see an answer disappear from the form and still find it back in the
+ * submitted application.
+ *
+ * The same happened one level up, for whole steps: the wizard only dims a step
+ * the current answers make irrelevant, so its fields count as visible to
+ * Filament and their values travelled along as well.
+ *
+ * All four outputs are built from that one state — the ZGW zaakeigenschappen,
+ * the reference data, the stored form state snapshot and the submission report
+ * behind the PDF — so each test asserts on all four.
+ *
+ * The scenarios that run through `submit()` prove the pruning is wired into
+ * the submit path. The ones that need a melding or a permit application drive
+ * the prune directly, because reaching `submit()` there means filling in every
+ * required field of ten more steps; `absorbAndPruneLikeSubmit()` performs
+ * exactly the two calls `submit()` makes.
+ */
+
+use App\Enums\OrganisationRole;
+use App\Enums\Role;
+use App\EventForm\Persistence\Draft;
+use App\EventForm\Persistence\PrefillLoader;
+use App\EventForm\Reporting\SubmissionReport;
+use App\EventForm\Schema\EventFormSchema;
+use App\EventForm\State\FormState;
+use App\EventForm\Submit\MapFormStateToReferenceData;
+use App\EventForm\Submit\SubmitEventForm;
+use App\EventForm\Submit\ZaakeigenschappenMap;
+use App\Filament\Organiser\Pages\EventFormPage;
+use App\Models\Municipality;
+use App\Models\Organisation;
+use App\Models\User;
+use App\Models\Users\OrganiserUser;
+use App\Models\Zaak;
+use App\Models\Zaaktype;
+use Filament\Facades\Filament;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\ValidationException;
+use Livewire\Livewire;
+use Tests\Feature\EventForm\Pages\FakeSubmitEventForm;
+
+uses(RefreshDatabase::class);
+
+beforeEach(function () {
+    Bus::fake();
+    Notification::fake();
+
+    $this->user = User::factory()->state(['role' => Role::Organiser])->create();
+    $this->organisation = Organisation::factory()->create();
+    $this->user->organisations()->attach(
+        $this->organisation->id,
+        ['role' => OrganisationRole::Admin->value],
+    );
+
+    $this->actingAs($this->user);
+    Filament::setTenant($this->organisation);
+});
+
+/**
+ * The valid answers of a vooraankondiging. Taken from the submit guard test:
+ * this path makes every conditional step non-applicable, so `submit()` only
+ * has to get past the required fields of the base steps.
+ *
+ * @return array<string, mixed>
+ */
+function geldigeVooraankondiging(): array
+{
+    $morgen = now()->addDay()->format('Y-m-d');
+
+    return [
+        'watIsUwVoornaam' => 'Jan',
+        'watIsUwAchternaam' => 'Test',
+        'watIsUwEMailadres' => 'jan@example.com',
+        'watIsUwTelefoonnummer' => '0612345678',
+
+        'watIsDeNaamVanHetEvenementVergunning' => 'Test Evenement',
+        'geefEenKorteOmschrijvingVanHetEvenementWatIsDeNaamVanHetEvenementVergunning' => 'Een omschrijving.',
+        'soortEvenement' => 'Festival',
+
+        'waarVindtHetEvenementPlaats' => ['gebouw'],
+        'adresVanDeGebouwEn' => [
+            ['naamVanDeLocatieGebouw' => 'Stadhuis Heerlen'],
+        ],
+
+        'EvenementStart' => $morgen.' 10:00',
+        'EvenementEind' => $morgen.' 18:00',
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Nee',
+        'zijnErTijdensHetEvenementXOpbouwactiviteiten' => 'Nee',
+        'zijnErAansluitendAanHetEvenementAfbouwactiviteiten' => 'Nee',
+        'zijnErTijdensHetEvenementXAfbouwactiviteiten3' => 'Nee',
+
+        'postcode1' => '6411CD',
+        'straatnaam1' => 'Teststraat',
+        'huisnummer1' => '1',
+        'plaatsnaam1' => 'Heerlen',
+
+        'waarvoorWiltUEventloketGebruiken' => 'vooraankondiging',
+
+        'akkoordVerwerkingGegevens' => true,
+    ];
+}
+
+/** A live page on an empty draft, with a user and organisation the submit accepts. */
+function pruneTestPage(User $user, Organisation $organisation): EventFormPage
+{
+    $draft = Draft::create([
+        'user_id' => $user->id,
+        'organisation_id' => $organisation->id,
+        'state' => FormState::empty()->toSnapshot(),
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $draft->id])->instance();
+
+    $page->state()->setSystem('authUser', OrganiserUser::find($user->id));
+    $page->state()->setSystem('authOrganisation', $organisation);
+
+    return $page;
+}
+
+/**
+ * Put answers on the page the way the wizard would have left them: in
+ * Livewire's data as well as in the state.
+ *
+ * @param  array<string, mixed>  $answers
+ * @param  array<string, mixed>  $stale  values that only live in the state,
+ *                                       as a copied or resumed application
+ *                                       leaves them behind
+ */
+function beantwoord(EventFormPage $page, array $answers, array $stale = []): void
+{
+    $page->data = array_merge($page->data ?? [], $answers, $stale);
+    $page->state()->absorbFields(array_merge($answers, $stale));
+}
+
+/** The two calls `submit()` makes between validation and handing the state over. */
+function absorbAndPruneLikeSubmit(EventFormPage $page): void
+{
+    $form = $page->getSchema('form');
+
+    $dehydrationState = [];
+    $form->callBeforeStateDehydrated($dehydrationState);
+
+    $absorb = new ReflectionMethod($page, 'absorbFormData');
+    $absorb->setAccessible(true);
+    $absorb->invoke($page, $form->getStateSnapshot());
+
+    $prune = new ReflectionMethod($page, 'pruneStateToVisible');
+    $prune->setAccessible(true);
+    $prune->invoke($page);
+}
+
+/** Submits for real and returns the state `SubmitEventForm` was handed. */
+function stateNaSubmit(EventFormPage $page): FormState
+{
+    $fake = new FakeSubmitEventForm(resultaat: Zaak::factory()->create([
+        'organisation_id' => $page->state()->get('authOrganisation')->id,
+        'organiser_user_id' => $page->state()->get('authUser')->id,
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'municipality_id' => Municipality::factory()->create()->id,
+        ])->id,
+    ]));
+    app()->instance(SubmitEventForm::class, $fake);
+
+    $page->submit();
+
+    expect($fake->aantalAanroepen)->toBe(1)
+        ->and($fake->ontvangenState)->toBeInstanceOf(FormState::class);
+
+    return $fake->ontvangenState;
+}
+
+/**
+ * Everything an application produces from its state, as JSON so a test can
+ * look for a value without knowing the shape of each output.
+ *
+ * @return array<string, string>
+ */
+function uitgaandeGegevens(FormState $state): array
+{
+    return [
+        'zaakeigenschappen' => json_encode(
+            app(ZaakeigenschappenMap::class)->buildEigenschappen($state),
+            JSON_THROW_ON_ERROR,
+        ),
+        'reference_data' => json_encode(
+            app(MapFormStateToReferenceData::class)
+                ->build($state, 'Ingediend', 'https://zgw.example.com/statustypen/1')
+                ->toArray(),
+            JSON_THROW_ON_ERROR,
+        ),
+        'form_state_snapshot' => json_encode($state->toSnapshot()['values'], JSON_THROW_ON_ERROR),
+        'submission_report' => json_encode(
+            app(SubmissionReport::class)->build($state, EventFormSchema::stepsForReport()),
+            JSON_THROW_ON_ERROR,
+        ),
+    ];
+}
+
+/** Fails naming the output that still carries the value. */
+function verwachtNergensIn(FormState $state, string $needle): void
+{
+    foreach (uitgaandeGegevens($state) as $naam => $json) {
+        expect(str_contains($json, $needle))->toBeFalse("'{$needle}' still ends up in {$naam}");
+    }
+}
+
+function verwachtOveralIn(FormState $state, string $needle): void
+{
+    foreach (uitgaandeGegevens($state) as $naam => $json) {
+        expect(str_contains($json, $needle))->toBeTrue("'{$needle}' is missing from {$naam}");
+    }
+}
+
+/** The value ZGW is given for one zaakeigenschap, or null when it is left out. */
+function zaakeigenschap(FormState $state, string $naam): mixed
+{
+    foreach (app(ZaakeigenschappenMap::class)->buildEigenschappen($state) as $eigenschap) {
+        if (array_key_exists($naam, $eigenschap)) {
+            return $eigenschap[$naam];
+        }
+    }
+
+    return null;
+}
+
+test('a location the organiser no longer ticks does not reach the outputs', function () {
+    // The copied application took place outdoors; this one is in a building.
+    // The outdoor location field is hidden from the moment the tick is gone,
+    // so its name is an answer the organiser cannot see, let alone correct.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, geldigeVooraankondiging(), [
+        'locatieSOpKaart' => [['naamVanDeLocatieKaart' => 'WEGGEKLIKT-BUITENTERREIN']],
+    ]);
+
+    $state = stateNaSubmit($page);
+
+    expect($state->get('locatieSOpKaart'))->toBeNull();
+    verwachtNergensIn($state, 'WEGGEKLIKT-BUITENTERREIN');
+});
+
+test('a build-up time the organiser answered away does not reach the outputs', function () {
+    // Build-up start and end are gated on a radio rather than on a rule of the
+    // visibility engine, so this covers the other way a field gets hidden.
+    // Both are mapped straight onto zaakeigenschappen, so a stale value is
+    // handed to ZGW as the build-up window of this event.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, geldigeVooraankondiging(), [
+        'OpbouwStart' => '2035-01-01 08:00',
+        'OpbouwEind' => '2035-01-01 09:00',
+    ]);
+
+    expect($page->state()->get('zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten'))->toBe('Nee');
+
+    $state = stateNaSubmit($page);
+
+    expect($state->get('OpbouwStart'))->toBeNull()
+        ->and($state->get('OpbouwEind'))->toBeNull()
+        ->and(zaakeigenschap($state, 'start_opbouw'))->toBeNull()
+        ->and(zaakeigenschap($state, 'eind_opbouw'))->toBeNull();
+    verwachtNergensIn($state, '2035-01-01');
+});
+
+test('the answers of a step that does not apply do not reach the outputs', function () {
+    // A vooraankondiging has no risk scan and no melding. Both steps stay
+    // clickable but dimmed, so Filament considers their fields visible; only
+    // the applicability layer knows they are not being asked.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, geldigeVooraankondiging(), [
+        'watIsDeAantrekkingskrachtVanHetEvenement' => '3',
+        'watIsHetAantalGelijktijdigAanwezigPersonen' => '3',
+        'isErSprakeVanOvernachten' => '3',
+        'wordtErAlcoholGeschonkenTijdensUwEvenement' => 'Ja',
+    ]);
+
+    $state = stateNaSubmit($page);
+
+    expect($state->get('watIsDeAantrekkingskrachtVanHetEvenement'))->toBeNull()
+        ->and($state->get('watIsHetAantalGelijktijdigAanwezigPersonen'))->toBeNull()
+        ->and($state->get('wordtErAlcoholGeschonkenTijdensUwEvenement'))->toBeNull()
+        ->and($state->get('risicoClassificatie'))->toBeNull()
+        ->and(zaakeigenschap($state, 'risico_classificatie'))->toBeNull();
+});
+
+test('a melding does not carry the answers of a permit application', function () {
+    // Every screening question answered "Ja" keeps the application a melding,
+    // which makes the permit steps non-applicable.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), [
+        'waarvoorWiltUEventloketGebruiken' => 'aanvraag',
+        'isHetAantalAanwezigenBijUwEvenementMinderDanSdf' => 'Ja',
+        'vindenDeActiviteitenVanUwEvenementPlaatsTussenTijdstippen' => 'Ja',
+        'WordtErAlleenMuziekGeluidGeproduceerdTussen' => 'Ja',
+        'IsdeGeluidsproductieLagerDan' => 'Ja',
+        'erVindenGeenActiviteitenPlaatsOpDeRijbaanBromFietspadOfParkeerplaatsOfAnderszinsEenBelemmeringVormenVoorHetVerkeerEnDeHulpdiensten' => 'Ja',
+        'wordenErMinderDanObjectenBijvTentSpringkussenGeplaatst' => 'Ja',
+        'indienErObjectenGeplaatstWordenZijnDezeDanKleiner' => 'Ja',
+        // "Nee" here keeps it a melding and takes the risk scan step out of
+        // the flow; "Ja" would be the one screening answer that asks for a
+        // permit instead.
+        'wordenErGebiedsontsluitingswegenEnOfDoorgaandeWegenAfgeslotenVoorHetVerkeer' => 'Nee',
+    ]), [
+        'watIsDeAantrekkingskrachtVanHetEvenement' => '5',
+        'watIsHetAantalGelijktijdigAanwezigPersonen' => '5',
+    ]);
+
+    expect($page->state()->get('isVergunningaanvraag'))->not->toBe(true);
+
+    absorbAndPruneLikeSubmit($page);
+    $state = $page->state();
+
+    // The screening answers themselves are asked on an applicable step and
+    // stay, so the application keeps being a melding after the prune.
+    expect($state->get('isHetAantalAanwezigenBijUwEvenementMinderDanSdf'))->toBe('Ja')
+        ->and($state->get('isVergunningaanvraag'))->not->toBe(true)
+        ->and($state->get('watIsDeAantrekkingskrachtVanHetEvenement'))->toBeNull()
+        ->and($state->get('watIsHetAantalGelijktijdigAanwezigPersonen'))->toBeNull()
+        ->and(zaakeigenschap($state, 'risico_classificatie'))->toBeNull();
+});
+
+test('a permit application keeps the risk scan it is asked to fill in', function () {
+    // One "Nee" turns the application into a permit application; the risk scan
+    // step applies from that moment and its answers have to survive.
+    $risicoscan = [
+        'watIsDeAantrekkingskrachtVanHetEvenement' => '1',
+        'watIsDeBelangrijksteLeeftijdscategorieVanDeDoelgroep' => '1',
+        'isErSprakeVanZanwezigheidVanPolitiekeAandachtEnOfMediageniekheid' => '1',
+        'isEenDeelVanDeDoelgroepVerminderdZelfredzaam' => '0',
+        'isErSprakeVanAanwezigheidVanRisicovolleActiviteiten' => '0',
+        'watIsHetGrootsteDeelVanDeSamenstellingVanDeDoelgroep' => '1',
+        'isErSprakeVanOvernachten' => '0',
+        'isErGebruikVanAlcoholEnDrugs' => '1',
+        'watIsHetAantalGelijktijdigAanwezigPersonen' => '1',
+        'inWelkSeizoenVindtHetEvenementPlaats' => '0',
+        'inWelkeLocatieVindtHetEvenementPlaats' => '0',
+        'opWelkSoortOndergrondVindtHetEvenementPlaats' => '0',
+        'watIsDeTijdsduurVanHetEvenement' => '0',
+        'welkeBeschikbaarheidVanAanEnAfvoerwegenIsVanToepassing' => '0',
+    ];
+
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), $risicoscan, [
+        'waarvoorWiltUEventloketGebruiken' => 'aanvraag',
+        'isHetAantalAanwezigenBijUwEvenementMinderDanSdf' => 'Nee',
+    ]));
+
+    expect($page->state()->get('isVergunningaanvraag'))->toBeTrue();
+
+    absorbAndPruneLikeSubmit($page);
+    $state = $page->state();
+
+    expect($state->get('isVergunningaanvraag'))->toBeTrue()
+        ->and($state->get('watIsDeAantrekkingskrachtVanHetEvenement'))->not->toBeNull()
+        ->and($state->get('isErSprakeVanOvernachten'))->not->toBeNull()
+        ->and(zaakeigenschap($state, 'risico_classificatie'))->toBe('A');
+});
+
+test('an application without withdrawn answers comes out of the prune unchanged', function () {
+    // The anchor for the other direction: with nothing stale in the state, the
+    // four outputs have to be byte for byte what they were before the prune.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, geldigeVooraankondiging());
+
+    $form = $page->getSchema('form');
+    $dehydrationState = [];
+    $form->callBeforeStateDehydrated($dehydrationState);
+
+    $absorb = new ReflectionMethod($page, 'absorbFormData');
+    $absorb->setAccessible(true);
+    $absorb->invoke($page, $form->getStateSnapshot());
+
+    $voor = uitgaandeGegevens(FormState::fromSnapshot($page->state()->toSnapshot()));
+
+    $prune = new ReflectionMethod($page, 'pruneStateToVisible');
+    $prune->setAccessible(true);
+    $prune->invoke($page);
+
+    $na = uitgaandeGegevens($page->state());
+
+    foreach (['zaakeigenschappen', 'reference_data', 'submission_report'] as $uitgaand) {
+        expect($na[$uitgaand])->toBe($voor[$uitgaand], "{$uitgaand} changed while nothing was withdrawn");
+    }
+
+    // The snapshot is the one output that does change: it is the bag itself,
+    // and it loses the empty keys Filament never dehydrated. No answer may
+    // disappear from it, though.
+    foreach (geldigeVooraankondiging() as $key => $value) {
+        expect($page->state()->get($key))->not->toBeNull("answer {$key} was dropped");
+    }
+});
+
+test('an answered gate that keeps its field visible keeps the value', function () {
+    // The mirror image of the leak: as long as the organiser can see the
+    // field, the value stays, however conditional the field is.
+    $page = pruneTestPage($this->user, $this->organisation);
+    beantwoord($page, array_merge(geldigeVooraankondiging(), [
+        'waarVindtHetEvenementPlaats' => ['gebouw', 'buiten'],
+        'locatieSOpKaart' => [['naamVanDeLocatieKaart' => 'INGETEKEND-BUITENTERREIN']],
+        'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Ja',
+        'OpbouwStart' => now()->addDay()->format('Y-m-d').' 08:00',
+        'OpbouwEind' => now()->addDay()->format('Y-m-d').' 09:00',
+    ]));
+
+    absorbAndPruneLikeSubmit($page);
+    $state = $page->state();
+
+    expect($state->get('locatieSOpKaart'))->not->toBeNull()
+        ->and($state->get('OpbouwStart'))->not->toBeNull()
+        ->and($state->get('OpbouwEind'))->not->toBeNull()
+        ->and(zaakeigenschap($state, 'start_opbouw'))->not->toBeNull()
+        ->and(json_encode($state->toSnapshot()['values'], JSON_THROW_ON_ERROR))
+        ->toContain('INGETEKEND-BUITENTERREIN');
+});
+
+test('an unanswered location question is stopped by the step validation, not by the prune', function () {
+    // `LocationKinds` treats an unanswered location question as "every kind
+    // counts". That contract lives in the mapping layer and is untouched here:
+    // the question is required, so a submit without an answer never gets as
+    // far as the state being pruned.
+    $page = pruneTestPage($this->user, $this->organisation);
+    $antwoorden = geldigeVooraankondiging();
+    unset($antwoorden['waarVindtHetEvenementPlaats']);
+    beantwoord($page, $antwoorden);
+
+    $fake = new FakeSubmitEventForm;
+    app()->instance(SubmitEventForm::class, $fake);
+
+    expect(fn () => $page->submit())->toThrow(ValidationException::class);
+    expect($fake->aantalAanroepen)->toBe(0)
+        ->and($page->state()->get('adresVanDeGebouwEn'))->not->toBeNull();
+});
+
+test('a copied application is submitted without the answers of its source', function () {
+    // The copy loads the full snapshot of the source application, so every
+    // conditional answer of that application travels along. Ticking a
+    // different location kind hides the copied one, and that is where it used
+    // to stay: out of sight, still on its way to ZGW and the PDF.
+    $zaaktype = Zaaktype::factory()->create([
+        'municipality_id' => Municipality::factory()->create()->id,
+        'is_active' => true,
+    ]);
+    $bron = Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'organiser_user_id' => $this->user->id,
+        'form_state_snapshot' => ['values' => [
+            'watIsDeNaamVanHetEvenementVergunning' => 'Vorig jaar',
+            'waarVindtHetEvenementPlaats' => ['buiten'],
+            'locatieSOpKaart' => [['naamVanDeLocatieKaart' => 'VORIG-JAAR-BUITENTERREIN']],
+            'zijnErVoorafgaandAanHetEvenementOpbouwactiviteiten' => 'Ja',
+            'OpbouwStart' => '2035-01-01 08:00',
+            'OpbouwEind' => '2035-01-01 09:00',
+        ], 'system' => []],
+    ]);
+
+    $gekopieerd = (new PrefillLoader)->load((string) $bron->id, $this->user, $this->organisation);
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => $gekopieerd->toSnapshot(),
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $draft->id])->instance();
+    $page->state()->setSystem('authUser', OrganiserUser::find($this->user->id));
+    $page->state()->setSystem('authOrganisation', $this->organisation);
+
+    // This year it is indoors and there is no build-up.
+    beantwoord($page, geldigeVooraankondiging());
+
+    $state = stateNaSubmit($page);
+
+    verwachtNergensIn($state, 'VORIG-JAAR-BUITENTERREIN');
+    verwachtNergensIn($state, '2035-01-01');
+});
+
+test('a resumed draft is submitted without the answers it no longer shows', function () {
+    // A draft that was filled in over several sessions keeps everything that
+    // was ever typed, including answers to questions that are no longer asked.
+    $draft = Draft::create([
+        'user_id' => $this->user->id,
+        'organisation_id' => $this->organisation->id,
+        'state' => ['values' => [
+            'waarVindtHetEvenementPlaats' => ['buiten'],
+            'locatieSOpKaart' => [['naamVanDeLocatieKaart' => 'EERDERE-SESSIE-BUITENTERREIN']],
+            'watIsDeAantrekkingskrachtVanHetEvenement' => '5',
+        ], 'system' => []],
+    ]);
+
+    /** @var EventFormPage $page */
+    $page = Livewire::test(EventFormPage::class, ['draft' => $draft->id])->instance();
+    $page->state()->setSystem('authUser', OrganiserUser::find($this->user->id));
+    $page->state()->setSystem('authOrganisation', $this->organisation);
+
+    beantwoord($page, geldigeVooraankondiging());
+
+    $state = stateNaSubmit($page);
+
+    expect($state->get('watIsDeAantrekkingskrachtVanHetEvenement'))->toBeNull();
+    verwachtNergensIn($state, 'EERDERE-SESSIE-BUITENTERREIN');
+});

--- a/tests/Feature/EventForm/Pages/FakeSubmitEventForm.php
+++ b/tests/Feature/EventForm/Pages/FakeSubmitEventForm.php
@@ -2,9 +2,14 @@
 
 namespace Tests\Feature\EventForm\Pages;
 
+use App\EventForm\State\FormState;
+
 class FakeSubmitEventForm
 {
     public int $aantalAanroepen = 0;
+
+    /** The state of the last call, so a test can assert on what was handed over. */
+    public ?FormState $ontvangenState = null;
 
     public function __construct(
         public ?\Throwable $gooitException = null,
@@ -14,6 +19,8 @@ class FakeSubmitEventForm
     public function execute(mixed ...$args): mixed
     {
         $this->aantalAanroepen++;
+        $this->ontvangenState = ($args[0] ?? null) instanceof FormState ? $args[0] : null;
+
         if ($this->gooitException) {
             throw $this->gooitException;
         }

--- a/tests/Feature/EventForm/Schema/SamenvattingStepTest.php
+++ b/tests/Feature/EventForm/Schema/SamenvattingStepTest.php
@@ -90,6 +90,17 @@ function samenvattingHtml(FormState $state): string
         {
             return $this->state;
         }
+
+        /**
+         * The summary asks the page for the state as the form is currently
+         * asking for it. These tests hand it a state directly and check how it
+         * is rendered, so here the two are the same thing; which answers are
+         * still being asked is covered where the pruning lives.
+         */
+        public function stateAsAsked(): FormState
+        {
+            return $this->state;
+        }
     };
 
     return (string) $closure($stub);


### PR DESCRIPTION

`FormState::absorbFields()` merges and never removes a key. A field that was filled in and then became hidden therefore kept its value in the state: gone from the form, still on its way out. Because all four outputs of an application are built from that one state, the value ended up in the ZGW zaakeigenschappen, in the reference data, in the stored form state snapshot and in the submission report behind the PDF. A submitted application could carry an answer the organiser had withdrawn, or one that came along with a copied application.

The same thing happened a level up. The wizard only dims a step the current answers make irrelevant, so its fields count as visible to Filament and their values travelled along too. That is how the risk scan of a permit application could reach a melding.

And it was visible inside the form as well. The two places that show back what has been filled in, the times overview on the times step and the summary before submitting, read the same raw state. A copied application whose organiser answers "no" to build-up activities still listed the build-up times of the application it came from, with no field left to correct them in. Take-down times behaved the same way.

### What this changes

**One rule, computed once.** `submit()` prunes the state right after the last absorb and before the application is built, against the schema itself: everything the wizard owns, minus what it currently shows on a step the answers apply to. The two overviews read that same set, so the overview and the application can no longer disagree about what was asked.

- Filament already leaves a hidden field out of its own dehydration, so the visible set is exactly what the organiser sees. This only stops the merge from putting the value back.
- No per-field list. A new conditional field is covered the moment it has a visibility rule, and so is a field that becomes conditional later.
- Step applicability is applied as a second layer, because Filament does not model it. The interface is unchanged: a step that does not apply stays clickable and dimmed.
- Keys the server computes are never dropped. That is the same boundary `absorbFormData()` already draws between answers and computed state.
- Nested values (repeater rows and the like) need nothing extra: the whole top-level value is replaced on absorb, so Filament's own pruning of those already survives.

**Submitting prunes, showing does not.** `pruneStateToVisible()` changes the state; `stateAsAsked()` hands out a pruned view and leaves the state alone. Only submitting settles what the answers are, so a question that comes back still shows what was typed before, and a stored draft keeps its own bag.

**Visibility is evaluated every time it is asked.** The key computation deliberately does not use `getFlatFields()`: that memoises its result per visibility flag on a schema that outlives the answers. The overviews ask for the visible set while the page renders and submitting asks again after the last answer is in, and the second caller was handed the first caller's world. A short recursive walk mirrors what Filament does without the memoisation.

Files touched: `FormState` (new `forgetFields()`), `EventFormPage` (`pruneStateToVisible()`, `stateAsAsked()` and the key computation; `validateApplicableSteps()` now shares the step-key helper), and the two overview components, which ask the page for `stateAsAsked()` instead of `state()`. The headless report stub answers that call with its own state, because a report is built from a state that has already been settled.

### Why not clear the dependent fields when the gate flips

The other obvious route was to null the dependent values in `afterStateUpdated` when a gate goes to "no". It was not taken:

- It only fixes the gates that get such a handler, so it is a per-field list by another name, which is the very thing the rest of this change removes.
- It destroys what the organiser typed. Ticking the option back on would come back empty, which is a worse answer to "I clicked the wrong one" than showing the value again.
- It cannot cover step applicability at all, because no single field flips a step.
- It would leave two sources of truth about what counts as an answer, and they would drift.

Reading the answers through one "what is the form asking" rule keeps the interface, the submitted application and the PDF on the same story, and the values stay recoverable until the moment of submitting.

### Scope

Only `submit()` prunes the state. Whatever is in a draft is pruned when it is submitted, so a resumed draft and a copied application both go in clean. Applications submitted before this change keep the snapshot they were stored with; the per-field guards on the location mapping stay in place as a safety net for those.

### Tests

The tests walk the schema instead of naming fields, since the defect is a property of the state layer and not of any one field. For a vooraankondiging, a melding, a permit application and a route event, every field the organiser is not being asked is given a recognisable value, and the walk then requires:

- none of those values survive in the state or in any of the four outputs;
- every answer the organiser *is* being asked survives untouched.

On top of that there are scenario tests through the real `submit()` path: a location kind that is no longer ticked, a build-up window that was answered away (gated on a radio rather than on a visibility rule), the answers of a step that does not apply, a melding that must not carry permit answers, a permit application that must keep its risk scan, a copied application, and a resumed draft.

For the overviews: build-up and take-down times that were answered away are gone from both the times overview and the summary, while the state itself still holds them.

Anchors guard the other direction: with nothing withdrawn the outputs are byte for byte what they were before the prune, an answered gate that keeps its field visible keeps its value, and with every question still being asked the summary is byte for byte the one the raw state produces.

All of the leak tests fail on the unchanged code and pass on this branch.

### Checks

- Full suite green: 1597 tests (194 unit, 1403 feature), run in blocking chunks over the whole `tests/Unit` and `tests/Feature` tree.
- `pint --test` clean, `phpstan` clean (499 files, no errors).
- The tests that came with #502 stay green; that change is untouched.

---

## Notes for review (not part of the PR body)

- **Divergence from the design note.** The note assumed `Hidden::rule()` treats "no opinion" as *showing* the field. It does not: the helper is `isFieldHidden($key) !== false`, so a `null` result hides the field. That matters for the planned "empty gate keeps the value" anchor. The gating question involved (`waarVindtHetEvenementPlaats`) is required, so an unanswered gate cannot reach the prune: `validateApplicableSteps()` halts the submit first. The anchor is therefore written as exactly that, plus a positive anchor that an answered gate which keeps its field visible keeps its value. `LocationKinds::isSelected()` itself is untouched, and the tests it has at the mapping layer are unchanged and green.
- **Derived values.** `isVergunningaanvraag` and `risicoClassificatie` are computed from answers that could in principle be pruned. They are not: the screening answer that turns an application into a permit application is always the visible one (the cascade hides only the questions after it), and the risk scan step applies exactly when its answers are asked. Both directions are asserted (a melding stays a melding, a permit application keeps its `risico_classificatie`).
- **The `getFlatFields()` memoisation was a real hazard, not a test artefact.** It only surfaced once the overviews started asking for the visible set during render: three previously green tests went red because the set cached at render time was reused at submit time. In the production submit request the order happens to be safe (the action runs before the render), but the reliance was accidental. The recursive walk removes it.
- **One existing test needed a line.** `SamenvattingStepTest` renders the summary against a hand-made stub that only offered `state()`; it now also offers `stateAsAsked()`. Three other stubs in the test suite were left alone because they do not touch these components. Worth a look in review: if you would rather have that contract enforced than documented, a small interface on `EventFormPage` plus the stub would do it. I left it out to keep the change small.
- **A/B evidence.** For the first commit, 13 of the 14 new tests fail without the fix; the one that passes is the validation-guard test, which documents existing behaviour rather than the leak. For the second commit, all 4 new overview tests fail without it while the 10 earlier ones stay green.
