### PR TITLE
Configure document confidentiality as one maximum level per role group

### DIFF
--- a/app/Enums/DocumentVertrouwelijkheden.php
+++ b/app/Enums/DocumentVertrouwelijkheden.php
@@ -3,9 +3,21 @@
 namespace App\Enums;
 
 use App\Services\Zgw\DocumentAudience;
+use App\Services\Zgw\ZgwConnectionConfig;
 
 /**
- * We only use Zaakvertrouwelijk, Vertrouwelijk and Confidentieel in the app.
+ * The eight vertrouwelijkheidaanduiding values of the ZGW standard.
+ *
+ * The cases are declared in the standard's own order, from the least to the most
+ * confidential level. That order is meaningful: the standard treats a maximum
+ * vertrouwelijkheidaanduiding as inclusive, so being allowed to see one level
+ * implies being allowed to see every less confidential one. {@see order()},
+ * {@see atMost()} and {@see mostConfidential()} are the only places that should
+ * express it, so the ordering lives in exactly one spot.
+ *
+ * Without a per-connection map the application uses only Zaakvertrouwelijk,
+ * Vertrouwelijk and Confidentieel; a connection with its own map may use the
+ * full scale.
  */
 enum DocumentVertrouwelijkheden: string
 {
@@ -19,39 +31,111 @@ enum DocumentVertrouwelijkheden: string
     case ZeerGegeheim = 'zeer_geheim';
 
     /**
-     * The vertrouwelijkheid levels a role may see by default, ordered from least
-     * to most confidential.
+     * The vertrouwelijkheid levels a role may see when the connection carries no
+     * map of its own, ordered from least to most confidential.
      *
-     * `openbaar` is included for every role: it is the least confidential level
-     * there is, so a role that may see zaakvertrouwelijk documents can certainly
-     * see public ones. Leaving it out meant a backend that labels documents
-     * `openbaar` (OneGround/RX Mission does this for system uploads) showed no
-     * documents at all, to nobody, while more confidential documents were
-     * visible.
+     * These are the legacy defaults and they are deliberately not derived from a
+     * maximum: they skip openbaar, beperkt_openbaar and intern entirely. A
+     * connection that wants the inclusive behaviour of the standard configures a
+     * maximum per role group instead (see {@see ZgwConnectionConfig::documentVisibilityForRole()}).
+     *
+     * @return array<int, string>
      */
     public static function fromUserRole(Role $role): array
     {
         return match ($role) {
-            Role::Organiser => [self::Openbaar->value, self::Zaakvertrouwelijk->value],
-            Role::Advisor => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value],
-            Role::MunicipalityAdmin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::ReviewerMunicipalityAdmin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Coordinator => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Reviewer => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::Admin => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
-            Role::KoppelingBeheerder => [self::Openbaar->value, self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Organiser => [self::Zaakvertrouwelijk->value],
+            Role::Advisor => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value],
+            Role::MunicipalityAdmin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::ReviewerMunicipalityAdmin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Coordinator => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Reviewer => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::Admin => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
+            Role::KoppelingBeheerder => [self::Zaakvertrouwelijk->value, self::Vertrouwelijk->value, self::Confidentieel->value],
         };
     }
 
     /**
-     * The levels a municipal user is offered when uploading a document, ordered
-     * from least to most confidential. The application deliberately uses only
-     * these three of the eight ZGW levels.
+     * All levels in the standard's order, from the least to the most confidential.
      *
+     * @return array<int, string>
+     */
+    public static function order(): array
+    {
+        return array_map(static fn (self $level): string => $level->value, self::cases());
+    }
+
+    /**
+     * The position of a level in that order, or null for a value outside the
+     * standard.
+     */
+    public static function rank(string $level): ?int
+    {
+        $position = array_search($level, self::order(), true);
+
+        return $position === false ? null : $position;
+    }
+
+    /**
+     * Every level up to and including the given maximum, ordered from the least
+     * to the most confidential.
+     *
+     * This is what a maximum vertrouwelijkheidaanduiding means in the standard:
+     * it is inclusive over the ordered scale, so a maximum of `intern` also
+     * covers `beperkt_openbaar` and `openbaar`. An unknown maximum yields an
+     * empty list rather than a guess.
+     *
+     * @return array<int, string>
+     */
+    public static function atMost(string $max): array
+    {
+        $rank = self::rank($max);
+
+        if ($rank === null) {
+            return [];
+        }
+
+        return array_slice(self::order(), 0, $rank + 1);
+    }
+
+    /**
+     * The most confidential of the given levels, or null when none of them is a
+     * level of the standard. Used to read a maximum out of a stored set.
+     *
+     * @param  array<int|string, mixed>  $levels
+     */
+    public static function mostConfidential(array $levels): ?string
+    {
+        $highest = null;
+        $highestRank = -1;
+
+        foreach ($levels as $level) {
+            if (! is_string($level)) {
+                continue;
+            }
+
+            $rank = self::rank($level);
+
+            if ($rank !== null && $rank > $highestRank) {
+                $highest = $level;
+                $highestRank = $rank;
+            }
+        }
+
+        return $highest;
+    }
+
+    /**
+     * The fixed upload choices for the default connection, ordered from least to
+     * most confidential. Used only for the default connection and for any
+     * connection without its own vertrouwelijkheid map; a connection with a map
+     * derives its levels from the maximum configured per role group instead
+     * (see {@see DocumentAudience}).
+     *
+     * The application deliberately uses only these three of the eight ZGW levels.
      * Which of them are actually offered, and which roles each of them reaches,
-     * follows the vertrouwelijkheid map of the connection the zaak runs on; see
-     * {@see DocumentAudience}. This list must therefore never be used to label
-     * the choice: it says nothing about who sees what.
+     * still follows the connection's map, so this list must never be used to
+     * label the choice: it says nothing about who sees what.
      *
      * @return array<int, string>
      */

--- a/app/Enums/DocumentVertrouwelijkheden.php
+++ b/app/Enums/DocumentVertrouwelijkheden.php
@@ -2,6 +2,8 @@
 
 namespace App\Enums;
 
+use App\Services\Zgw\DocumentAudience;
+
 /**
  * We only use Zaakvertrouwelijk, Vertrouwelijk and Confidentieel in the app.
  */
@@ -41,30 +43,24 @@ enum DocumentVertrouwelijkheden: string
         };
     }
 
-    public static function listUserRoles(): array
+    /**
+     * The levels a municipal user is offered when uploading a document, ordered
+     * from least to most confidential. The application deliberately uses only
+     * these three of the eight ZGW levels.
+     *
+     * Which of them are actually offered, and which roles each of them reaches,
+     * follows the vertrouwelijkheid map of the connection the zaak runs on; see
+     * {@see DocumentAudience}. This list must therefore never be used to label
+     * the choice: it says nothing about who sees what.
+     *
+     * @return array<int, string>
+     */
+    public static function uploadChoices(): array
     {
         return [
-            self::Zaakvertrouwelijk->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-                Role::Advisor,
-                Role::Organiser,
-            ],
-            self::Vertrouwelijk->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-                Role::Advisor,
-            ],
-            self::Confidentieel->value => [
-                // Role::Admin,
-                // Role::MunicipalityAdmin,
-                // Role::ReviewerMunicipalityAdmin,
-                Role::Reviewer,
-            ],
+            self::Zaakvertrouwelijk->value,
+            self::Vertrouwelijk->value,
+            self::Confidentieel->value,
         ];
     }
 }

--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -10,6 +10,7 @@ use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZgwConnect
 use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZgwConnections\Pages\ListMunicipalityZgwConnections;
 use App\Livewire\ConnectionVerifier;
 use App\Models\MunicipalityZgwConnection;
+use App\Services\Zgw\DocumentAudience;
 use BackedEnum;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Select;
@@ -224,29 +225,17 @@ class MunicipalityZgwConnectionResource extends Resource
      * binds to; the others inherit its value on save. Roles outside these groups
      * (platform admin, koppeling beheerder) always fall back to the defaults.
      *
-     * @return array<int, array{label: string, roles: array<int, Role>}>
+     * The groups are defined once in {@see DocumentAudience::groups()}, which
+     * also labels the upload choice with them, so the form and that choice can
+     * never describe different groups. They are listed there from the broadest
+     * to the narrowest audience and reversed here, so the form keeps showing
+     * them as organisator, adviseur, gemeente.
+     *
+     * @return array<int, array{label: string, audience: string, roles: array<int, Role>}>
      */
     protected static function vertrouwelijkheidGroups(): array
     {
-        return [
-            [
-                'label' => Role::Organiser->getLabel(),
-                'roles' => [Role::Organiser],
-            ],
-            [
-                'label' => Role::Advisor->getLabel(),
-                'roles' => [Role::Advisor],
-            ],
-            [
-                'label' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente'),
-                'roles' => [
-                    Role::Reviewer,
-                    Role::Coordinator,
-                    Role::MunicipalityAdmin,
-                    Role::ReviewerMunicipalityAdmin,
-                ],
-            ],
-        ];
+        return array_reverse(DocumentAudience::groups());
     }
 
     /**

--- a/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
+++ b/app/Filament/Municipality/Clusters/Settings/Resources/MunicipalityZgwConnections/MunicipalityZgwConnectionResource.php
@@ -11,8 +11,11 @@ use App\Filament\Municipality\Clusters\Settings\Resources\MunicipalityZgwConnect
 use App\Livewire\ConnectionVerifier;
 use App\Models\MunicipalityZgwConnection;
 use App\Services\Zgw\DocumentAudience;
+use App\Services\Zgw\ZgwConnectionConfig;
 use BackedEnum;
+use Closure;
 use Filament\Actions\Action;
+use Filament\Forms\Components\Placeholder;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
 use Filament\Forms\Components\TextInput;
@@ -27,6 +30,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Table;
+use Illuminate\Support\HtmlString;
 use Woweb\Zgw\Enums\ZgwVersion;
 
 class MunicipalityZgwConnectionResource extends Resource
@@ -170,6 +174,7 @@ class MunicipalityZgwConnectionResource extends Resource
                     ->description(__('municipality/resources/zgw_connection.sections.vertrouwelijkheid.description'))
                     ->columns(1)
                     ->schema([
+                        self::vertrouwelijkheidExplanation(),
                         ...self::vertrouwelijkheidRoleFields(),
                         Select::make('vertrouwelijkheid_map.upload_default.system')
                             ->label(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_system_default.label'))
@@ -181,42 +186,106 @@ class MunicipalityZgwConnectionResource extends Resource
     }
 
     /**
-     * One fieldset per document-facing role group, each with the visibility
-     * multi select and the upload default. Groups left blank fall back to the
-     * hardcoded {@see DocumentVertrouwelijkheden::fromUserRole()} defaults. The
-     * municipal handler roles share a single "Gemeente" group; the form binds to
-     * the group's canonical role and the choice is fanned out to the other roles
-     * on save by {@see pruneVertrouwelijkheidMap()}.
+     * A short explanation of how the vertrouwelijkheid settings work, shown above
+     * the per-role fieldsets: one maximum per role group with everything below it
+     * included, the maxima must run up, and the upload default is the fallback.
+     */
+    protected static function vertrouwelijkheidExplanation(): Placeholder
+    {
+        return Placeholder::make('vertrouwelijkheid_explanation')
+            ->label(__('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.title'))
+            ->visible(fn (Get $get): bool => self::documentUploadTabsEnabled($get))
+            ->content(new HtmlString(implode('', array_map(
+                static fn (string $paragraph): string => '<p class="mb-2">'.e($paragraph).'</p>',
+                [
+                    __('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.intro'),
+                    __('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.nesting'),
+                    __('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.upload'),
+                    __('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.default'),
+                    __('municipality/resources/zgw_connection.sections.vertrouwelijkheid.explanation.openbaar'),
+                ],
+            ))));
+    }
+
+    /**
+     * One fieldset per document-facing role group, each with the maximum visible
+     * level and the upload default. Groups left blank fall back to the hardcoded
+     * {@see DocumentVertrouwelijkheden::fromUserRole()} defaults. The municipal
+     * handler roles share a single "Gemeente" group; the form binds to the
+     * group's canonical role and the choice is fanned out to the other roles on
+     * save by {@see pruneVertrouwelijkheidMap()}.
+     *
+     * A group's maximum is inclusive: it also covers every less confidential
+     * level, which is what a maximum vertrouwelijkheidaanduiding means in the
+     * standard. The maxima must therefore run up (organisator ≤ adviseur ≤
+     * gemeente), so a broader audience always sees at least what a narrower one
+     * sees. That is enforced here with a blocking validation rule on the narrower
+     * selects, and clamped as a safety net for non-form writes in
+     * {@see pruneVertrouwelijkheidMap()}.
      *
      * @return array<int, Fieldset>
      */
     protected static function vertrouwelijkheidRoleFields(): array
     {
         $levels = self::vertrouwelijkheidLevelOptions();
+        $groups = self::vertrouwelijkheidGroups();
+        $fields = [];
 
-        return array_map(
-            static function (array $group) use ($levels): Fieldset {
-                $canonical = $group['roles'][0]->value;
+        foreach ($groups as $index => $group) {
+            $canonical = $group['roles'][0]->value;
+            // The next group is the immediately broader audience, if any; the
+            // groups run from the narrowest (organisator) to the broadest (gemeente).
+            $broader = $groups[$index + 1] ?? null;
 
-                return Fieldset::make($group['label'])
-                    ->columns(2)
-                    ->visible(fn (Get $get): bool => self::documentUploadTabsEnabled($get))
-                    ->schema([
-                        Select::make("vertrouwelijkheid_map.visibility.{$canonical}")
-                            ->label(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.label'))
-                            ->helperText(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.helper'))
-                            ->multiple()
-                            ->options($levels)
-                            ->native(false),
-                        Select::make("vertrouwelijkheid_map.upload_default.{$canonical}")
-                            ->label(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_upload_default.label'))
-                            ->helperText(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_upload_default.helper'))
-                            ->options($levels)
-                            ->native(false),
-                    ]);
-            },
-            self::vertrouwelijkheidGroups(),
-        );
+            $visibility = Select::make("vertrouwelijkheid_map.visibility.{$canonical}")
+                ->label(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.label'))
+                ->helperText(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.helper'))
+                ->hintIcon('heroicon-o-information-circle')
+                ->hintIconTooltip(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.tooltip'))
+                ->options($levels)
+                ->native(false);
+
+            if ($broader !== null) {
+                $broaderCanonical = $broader['roles'][0]->value;
+                $narrowerLabel = $group['audience'];
+                $broaderLabel = $broader['audience'];
+
+                $visibility->rule(static fn (Get $get): Closure => static function (string $attribute, mixed $value, Closure $fail) use ($get, $broaderCanonical, $narrowerLabel, $broaderLabel): void {
+                    $narrowerRank = is_string($value) ? DocumentVertrouwelijkheden::rank($value) : null;
+                    $broaderValue = $get("vertrouwelijkheid_map.visibility.{$broaderCanonical}");
+                    $broaderRank = is_string($broaderValue) ? DocumentVertrouwelijkheden::rank($broaderValue) : null;
+
+                    // Skip while either side is still blank: an empty select means
+                    // "fall back to the defaults", not "sees nothing".
+                    if ($narrowerRank === null || $broaderRank === null) {
+                        return;
+                    }
+
+                    if ($narrowerRank > $broaderRank) {
+                        $fail(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_visibility.nesting_error', [
+                            'narrower' => $narrowerLabel,
+                            'broader' => $broaderLabel,
+                        ]));
+                    }
+                });
+            }
+
+            $fields[] = Fieldset::make($group['label'])
+                ->columns(2)
+                ->visible(fn (Get $get): bool => self::documentUploadTabsEnabled($get))
+                ->schema([
+                    $visibility,
+                    Select::make("vertrouwelijkheid_map.upload_default.{$canonical}")
+                        ->label(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_upload_default.label'))
+                        ->helperText(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_upload_default.helper'))
+                        ->hintIcon('heroicon-o-information-circle')
+                        ->hintIconTooltip(__('municipality/resources/zgw_connection.fields.vertrouwelijkheid_upload_default.tooltip'))
+                        ->options($levels)
+                        ->native(false),
+                ]);
+        }
+
+        return $fields;
     }
 
     /**
@@ -285,6 +354,62 @@ class MunicipalityZgwConnectionResource extends Resource
     }
 
     /**
+     * Normalise the visibility map to a single maximum level per role group that
+     * never runs down (organisator ≤ adviseur ≤ gemeente), so a broader audience
+     * always sees at least what a narrower one sees. Works on the canonical roles
+     * before they are fanned out, and only touches groups that are explicitly
+     * configured: an empty group falls back to the defaults and is left alone.
+     *
+     * Two normalisations happen here. A group stored as a set of levels (the
+     * shape used before the maximum was introduced) is read as its most
+     * confidential member, and a broader group whose maximum sits below a
+     * narrower one is clamped up to it.
+     *
+     * This is a safety net for maps written outside the settings form (seeders,
+     * imports, direct DB edits). The form already blocks a maximum that runs down
+     * with a validation error before this runs, so it can never mask that error.
+     *
+     * @param  array<string, mixed>  $map
+     * @return array<string, mixed>
+     */
+    protected static function normaliseVertrouwelijkheidNesting(array $map): array
+    {
+        if (! isset($map['visibility']) || ! is_array($map['visibility'])) {
+            return $map;
+        }
+
+        // The groups run from the narrowest (organisator) to the broadest
+        // (gemeente); carry the highest maximum seen so far forward, so a broader
+        // group can never end up below a narrower one.
+        $floor = null;
+        $floorRank = -1;
+
+        foreach (self::vertrouwelijkheidGroups() as $group) {
+            $canonical = $group['roles'][0]->value;
+            $max = ZgwConnectionConfig::readVisibilityMax($map['visibility'][$canonical] ?? null);
+
+            if ($max === null) {
+                unset($map['visibility'][$canonical]);
+
+                continue;
+            }
+
+            $rank = DocumentVertrouwelijkheden::rank($max) ?? -1;
+
+            if ($floor !== null && $rank < $floorRank) {
+                $max = $floor;
+                $rank = $floorRank;
+            }
+
+            $map['visibility'][$canonical] = $max;
+            $floor = $max;
+            $floorRank = $rank;
+        }
+
+        return $map;
+    }
+
+    /**
      * Fan each role group's canonical choice out onto the roles it represents,
      * then drop empty visibility/upload-default entries so an unconfigured role
      * keeps falling back to the hardcoded defaults instead of being stored as an
@@ -300,6 +425,8 @@ class MunicipalityZgwConnectionResource extends Resource
         }
 
         $map = $data['vertrouwelijkheid_map'];
+
+        $map = self::normaliseVertrouwelijkheidNesting($map);
 
         foreach (self::vertrouwelijkheidGroups() as $group) {
             $roles = $group['roles'];
@@ -322,7 +449,7 @@ class MunicipalityZgwConnectionResource extends Resource
         if (isset($map['visibility']) && is_array($map['visibility'])) {
             $map['visibility'] = array_filter(
                 $map['visibility'],
-                static fn ($values): bool => is_array($values) && $values !== [],
+                static fn ($value): bool => is_string($value) && $value !== '',
             );
 
             if ($map['visibility'] === []) {

--- a/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
+++ b/app/Filament/Shared/Resources/Zaken/Actions/UploadDocumentAction.php
@@ -2,10 +2,10 @@
 
 namespace App\Filament\Shared\Resources\Zaken\Actions;
 
-use App\Enums\DocumentVertrouwelijkheden;
 use App\Enums\Role;
 use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Models\Zaak;
+use App\Services\Zgw\DocumentAudience;
 use App\Services\Zgw\UploadDocumentTypeResolver;
 use App\Services\Zgw\ZgwConnectionConfig;
 use App\Services\Zgw\ZgwResource;
@@ -162,23 +162,9 @@ class UploadDocumentAction
                 });
         }
 
-        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin])) {
-            $fields[] = Select::make('vertrouwelijkheidaanduiding')
-                ->label(__('Wie mag dit document inzien?'))
-                ->options(function () use ($zaak) {
-                    $vertrouwelijkheden = ZgwConnectionConfig::documentVisibilityForRole($zaak->zgwConnectionName(), auth()->user()->role);
-                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
-                    $options = [];
-                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
-                        if (in_array($key, $vertrouwelijkheden)) {
-                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
-                        }
-                    }
-
-                    return $options;
-                })
-                ->visible(fn (Get $get): bool => ! empty($get('document_metadata')))
-                ->required();
+        if ($vertrouwelijkheid = self::vertrouwelijkheidSelect($zaak)) {
+            $fields[] = $vertrouwelijkheid
+                ->visible(fn (Get $get): bool => ! empty($get('document_metadata')));
         }
 
         $metadataFields = [
@@ -224,22 +210,8 @@ class UploadDocumentAction
                 ->required();
         }
 
-        if (in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin])) {
-            $fields[] = Select::make('vertrouwelijkheidaanduiding')
-                ->label(__('Wie mag dit document inzien?'))
-                ->options(function () use ($zaak) {
-                    $vertrouwelijkheden = ZgwConnectionConfig::documentVisibilityForRole($zaak->zgwConnectionName(), auth()->user()->role);
-                    $rolesByVertrouwelijkheid = DocumentVertrouwelijkheden::listUserRoles();
-                    $options = [];
-                    foreach ($rolesByVertrouwelijkheid as $key => $roles) {
-                        if (in_array($key, $vertrouwelijkheden)) {
-                            $options[$key] = collect($roles)->map(fn (Role $role) => $role->getLabel())->join(', ');
-                        }
-                    }
-
-                    return $options;
-                })
-                ->required();
+        if ($vertrouwelijkheid = self::vertrouwelijkheidSelect($zaak)) {
+            $fields[] = $vertrouwelijkheid;
         }
 
         $fields[] = FileUpload::make('file')
@@ -270,6 +242,39 @@ class UploadDocumentAction
             ->maxLength(255);
 
         return $fields;
+    }
+
+    /**
+     * The "who may see this document" select, or null when it should not be
+     * shown at all.
+     *
+     * The options and their labels come from the vertrouwelijkheid map of the
+     * connection this zaak runs on, so each level is labelled with the role
+     * groups that will actually see it. The select is left out entirely when the
+     * current user may not choose (an organiser never does), and when the levels
+     * on offer reach exactly the same audience: a choice that changes nothing is
+     * a promise the filtering does not keep. In both cases the connection's
+     * upload default applies, which the action already falls back to when no
+     * value is submitted.
+     */
+    private static function vertrouwelijkheidSelect(Zaak $zaak): ?Select
+    {
+        $userRole = auth()->user()->role;
+
+        if (! in_array($userRole, [Role::Reviewer, Role::ReviewerMunicipalityAdmin, Role::Coordinator, Role::MunicipalityAdmin, Role::Admin], true)) {
+            return null;
+        }
+
+        $options = DocumentAudience::uploadOptions($zaak->zgwConnectionName(), $userRole);
+
+        if ($options === []) {
+            return null;
+        }
+
+        return Select::make('vertrouwelijkheidaanduiding')
+            ->label(__('Wie mag dit document inzien?'))
+            ->options($options)
+            ->required();
     }
 
     /**

--- a/app/Models/Zaak.php
+++ b/app/Models/Zaak.php
@@ -254,6 +254,17 @@ class Zaak extends Model implements Eventable
         );
     }
 
+    /**
+     * The zaaktype's documenttypes without the per-user visibility filter, for
+     * decisions that belong to the koppeling rather than to the current user.
+     *
+     * @return Collection<int, InformatieObjectTypeData>
+     */
+    public function catalogusDocumentTypes(): Collection
+    {
+        return $this->zaaktype?->catalogusDocumentTypes($this->zgwZaaktypeVersionUrl()) ?? collect();
+    }
+
     /** @return Attribute<array<string, mixed>|null, void> */
     protected function intrekkenResultaatType(): Attribute
     {

--- a/app/Models/Zaaktype.php
+++ b/app/Models/Zaaktype.php
@@ -158,7 +158,7 @@ class Zaaktype extends Model
      */
     public function documentTypesForUser(?string $versionUrl = null): Collection
     {
-        $types = $this->getDocumentTypes($versionUrl);
+        $types = $this->catalogusDocumentTypes($versionUrl);
 
         if (auth()->user()) {
             $allowed = ZgwConnectionConfig::documentVisibilityForRole($this->zgwConnectionName(), auth()->user()->role);
@@ -167,7 +167,25 @@ class Zaaktype extends Model
             $types = $types->filter(fn (InformatieObjectTypeData $type) => in_array($type->vertrouwelijkheidaanduiding?->value, $allowed, true));
         }
 
-        return $types->sortBy('omschrijving');
+        return $types;
+    }
+
+    /**
+     * Every documenttype of this zaaktype version as the catalogus defines it,
+     * without the per-user visibility filter.
+     *
+     * Use this wherever the answer belongs to the connection rather than to the
+     * person who happens to trigger it: which documenttype the koppeling
+     * configures for an upload is a property of the koppeling, not of what the
+     * uploader may see. The queued upload path already resolves it this way,
+     * simply because a job has no authenticated user to filter on, so reading it
+     * unfiltered keeps both paths answering the same thing.
+     *
+     * @return Collection<int, InformatieObjectTypeData>
+     */
+    public function catalogusDocumentTypes(?string $versionUrl = null): Collection
+    {
+        return $this->getDocumentTypes($versionUrl)->sortBy('omschrijving');
     }
 
     /** @return Attribute<Collection<array>|null, void> */

--- a/app/Services/Zgw/DocumentAudience.php
+++ b/app/Services/Zgw/DocumentAudience.php
@@ -62,6 +62,13 @@ class DocumentAudience
      * uploading a document, each labelled with the role groups that may see that
      * level on this connection.
      *
+     * The levels on offer are derived from the connection itself: the default
+     * connection (and any connection without its own map) keeps the fixed
+     * {@see DocumentVertrouwelijkheden::uploadChoices()}, while a connection with
+     * its own vertrouwelijkheid map offers the maxima that map configures, so the
+     * ladder follows the settings rather than a hardcoded list. Levels reaching
+     * the same audience are collapsed into a single rung.
+     *
      * Returns an empty array when the choice would be an illusion: nothing left
      * to pick, or every offered level reaching exactly the same audience (the
      * situation VRZL reported, where a connection map gives the municipal roles
@@ -76,7 +83,7 @@ class DocumentAudience
 
         $audiences = [];
 
-        foreach (DocumentVertrouwelijkheden::uploadChoices() as $level) {
+        foreach (self::candidateLevels($connectionName) as $level) {
             if (! in_array($level, $visibleToUploader, true)) {
                 continue;
             }
@@ -84,7 +91,11 @@ class DocumentAudience
             $audiences[$level] = self::audienceFor($connectionName, $level);
         }
 
-        if (! self::audiencesDiffer($audiences)) {
+        $rungs = self::distinctRungs($audiences);
+
+        // A single rung (or none) is no real choice: the caller then leaves the
+        // select out and the connection's upload default applies.
+        if (count($rungs) < 2) {
             return [];
         }
 
@@ -92,8 +103,72 @@ class DocumentAudience
             static fn (array $audience): string => $audience === []
                 ? __('Geen van deze rolgroepen')
                 : implode(', ', $audience),
-            $audiences,
+            $rungs,
         );
+    }
+
+    /**
+     * The vertrouwelijkheid levels to consider for the upload choice on this
+     * connection.
+     *
+     * The default connection, and any connection without its own visibility map,
+     * keeps the fixed {@see DocumentVertrouwelijkheden::uploadChoices()}, so its
+     * behaviour is unchanged. A connection with its own map offers the maxima it
+     * configures per role group, ordered from the least to the most confidential.
+     *
+     * Only the maxima can be rungs. A level below a group's maximum is seen by
+     * exactly the role groups that see that maximum, so it reaches the same
+     * audience and collapses into the same rung; taking the maxima directly says
+     * that in one step.
+     *
+     * @return array<int, string>
+     */
+    private static function candidateLevels(string $connectionName): array
+    {
+        if (ZgwConnectionConfig::isDefaultConnection($connectionName)) {
+            return DocumentVertrouwelijkheden::uploadChoices();
+        }
+
+        $configured = ZgwConnectionConfig::configuredVisibilityMaxLevels($connectionName);
+
+        return $configured === [] ? DocumentVertrouwelijkheden::uploadChoices() : $configured;
+    }
+
+    /**
+     * Collapse the level => audience map to one rung per distinct audience,
+     * keeping the most confidential level that reaches it (so a rung stays as
+     * restrictive as its audience allows, and the default connection reproduces
+     * its {zaakvertrouwelijk, vertrouwelijk, confidentieel} ladder exactly), and
+     * order the rungs from the broadest to the narrowest audience.
+     *
+     * @param  array<string, array<int, string>>  $audiences  level => audience labels, least confidential first
+     * @return array<string, array<int, string>> representative level => audience labels
+     */
+    private static function distinctRungs(array $audiences): array
+    {
+        $byAudience = [];
+
+        // $audiences runs from the least to the most confidential level, so the
+        // last level written for a given audience is the most confidential one
+        // reaching it.
+        foreach ($audiences as $level => $audience) {
+            $byAudience[implode('|', $audience)] = ['level' => $level, 'audience' => $audience];
+        }
+
+        // Broadest audience first. Nested visibility makes the audiences a chain
+        // by inclusion, so their sizes order them unambiguously.
+        usort(
+            $byAudience,
+            static fn (array $a, array $b): int => count($b['audience']) <=> count($a['audience']),
+        );
+
+        $rungs = [];
+
+        foreach ($byAudience as $rung) {
+            $rungs[$rung['level']] = $rung['audience'];
+        }
+
+        return $rungs;
     }
 
     /**
@@ -115,22 +190,5 @@ class DocumentAudience
         }
 
         return $labels;
-    }
-
-    /**
-     * Whether the offered levels tell the role groups apart at all. Two levels
-     * reaching the same audience are the same choice under a different name, and
-     * a single level (or none) is no choice to begin with.
-     *
-     * @param  array<string, array<int, string>>  $audiences
-     */
-    private static function audiencesDiffer(array $audiences): bool
-    {
-        $distinct = array_unique(array_map(
-            static fn (array $audience): string => implode('|', $audience),
-            $audiences,
-        ));
-
-        return count($distinct) > 1;
     }
 }

--- a/app/Services/Zgw/DocumentAudience.php
+++ b/app/Services/Zgw/DocumentAudience.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Zgw;
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+
+/**
+ * Answers "who really gets to see a document at this vertrouwelijkheid level on
+ * this connection", for the upload choice in the interface.
+ *
+ * The answer is read from the connection's vertrouwelijkheid map through
+ * {@see ZgwConnectionConfig::documentVisibilityForRole()} (which falls back to
+ * the hardcoded per-role defaults), so the choice offered at upload can never
+ * promise an audience the filtering does not honour.
+ */
+class DocumentAudience
+{
+    /**
+     * The role groups whose document visibility is configurable per connection,
+     * ordered from the broadest to the narrowest default audience.
+     *
+     * The first role of a group is the canonical one: the connection form binds
+     * to it and fans its value out over the other roles of the group on save
+     * (see MunicipalityZgwConnectionResource::pruneVertrouwelijkheidMap()), so
+     * the canonical role's visibility describes the whole group. Roles outside
+     * these groups (platform admin, koppeling beheerder) are not configurable
+     * and always see everything, which is why they carry no audience label.
+     *
+     * @return array<int, array{label: string, audience: string, roles: array<int, Role>}>
+     */
+    public static function groups(): array
+    {
+        return [
+            [
+                'label' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente'),
+                'audience' => __('municipality/resources/zgw_connection.vertrouwelijkheid_groups.gemeente_audience'),
+                'roles' => [
+                    Role::Reviewer,
+                    Role::Coordinator,
+                    Role::MunicipalityAdmin,
+                    Role::ReviewerMunicipalityAdmin,
+                ],
+            ],
+            [
+                'label' => Role::Advisor->getLabel(),
+                'audience' => Role::Advisor->getLabel(),
+                'roles' => [Role::Advisor],
+            ],
+            [
+                'label' => Role::Organiser->getLabel(),
+                'audience' => Role::Organiser->getLabel(),
+                'roles' => [Role::Organiser],
+            ],
+        ];
+    }
+
+    /**
+     * The vertrouwelijkheid levels a user of the given role may pick when
+     * uploading a document, each labelled with the role groups that may see that
+     * level on this connection.
+     *
+     * Returns an empty array when the choice would be an illusion: nothing left
+     * to pick, or every offered level reaching exactly the same audience (the
+     * situation VRZL reported, where a connection map gives the municipal roles
+     * every level and the other groups none of them). The caller then leaves the
+     * select out and the connection's upload default applies.
+     *
+     * @return array<string, string>
+     */
+    public static function uploadOptions(string $connectionName, Role $role): array
+    {
+        $visibleToUploader = ZgwConnectionConfig::documentVisibilityForRole($connectionName, $role);
+
+        $audiences = [];
+
+        foreach (DocumentVertrouwelijkheden::uploadChoices() as $level) {
+            if (! in_array($level, $visibleToUploader, true)) {
+                continue;
+            }
+
+            $audiences[$level] = self::audienceFor($connectionName, $level);
+        }
+
+        if (! self::audiencesDiffer($audiences)) {
+            return [];
+        }
+
+        return array_map(
+            static fn (array $audience): string => $audience === []
+                ? __('Geen van deze rolgroepen')
+                : implode(', ', $audience),
+            $audiences,
+        );
+    }
+
+    /**
+     * The labels of the role groups that may see a document at this level on
+     * this connection, broadest audience first.
+     *
+     * @return array<int, string>
+     */
+    public static function audienceFor(string $connectionName, string $level): array
+    {
+        $labels = [];
+
+        foreach (self::groups() as $group) {
+            $visibility = ZgwConnectionConfig::documentVisibilityForRole($connectionName, $group['roles'][0]);
+
+            if (in_array($level, $visibility, true)) {
+                $labels[] = $group['audience'];
+            }
+        }
+
+        return $labels;
+    }
+
+    /**
+     * Whether the offered levels tell the role groups apart at all. Two levels
+     * reaching the same audience are the same choice under a different name, and
+     * a single level (or none) is no choice to begin with.
+     *
+     * @param  array<string, array<int, string>>  $audiences
+     */
+    private static function audiencesDiffer(array $audiences): bool
+    {
+        $distinct = array_unique(array_map(
+            static fn (array $audience): string => implode('|', $audience),
+            $audiences,
+        ));
+
+        return count($distinct) > 1;
+    }
+}

--- a/app/Services/Zgw/UploadDocumentTypeResolver.php
+++ b/app/Services/Zgw/UploadDocumentTypeResolver.php
@@ -34,12 +34,20 @@ final class UploadDocumentTypeResolver
     /**
      * The informatieobjecttype url to apply when the user does not choose one,
      * or null when the zaaktype exposes no documenttypes at all.
+     *
+     * Deliberately reads the documenttypes unfiltered
+     * ({@see Zaak::catalogusDocumentTypes()}): this is the koppeling's choice,
+     * not the uploader's, so it must not depend on the levels that uploader may
+     * see. Reading the per-user collection made the answer depend on where the
+     * code ran, since the queued path has no authenticated user to filter on,
+     * and it returned null whenever the catalogus labels its documenttypes at a
+     * level outside the uploader's visible set.
      */
     public static function defaultFor(Zaak $zaak): ?string
     {
-        $types = $zaak->document_types;
+        $types = $zaak->catalogusDocumentTypes();
 
-        if ($types === null || $types->isEmpty()) {
+        if ($types->isEmpty()) {
             return null;
         }
 

--- a/app/Services/Zgw/ZgwConnectionConfig.php
+++ b/app/Services/Zgw/ZgwConnectionConfig.php
@@ -63,27 +63,126 @@ class ZgwConnectionConfig
 
     /**
      * The vertrouwelijkheidaanduiding values a given role may see on this
-     * connection. A connection without a configured map falls back to the
-     * hardcoded {@see DocumentVertrouwelijkheden::fromUserRole()} defaults, so
-     * the role-based filtering stays on either way.
+     * connection.
+     *
+     * Two regimes, deliberately kept apart:
+     *
+     * - A connection without a map for this role falls back to the hardcoded
+     *   {@see DocumentVertrouwelijkheden::fromUserRole()} sets. Those are the
+     *   legacy three-step defaults and are used verbatim, so the default
+     *   connection behaves exactly as it always has.
+     * - A connection whose map configures this role stores a single maximum
+     *   vertrouwelijkheidaanduiding, which the standard defines as inclusive
+     *   over the ordered scale. The set is derived from it with
+     *   {@see DocumentVertrouwelijkheden::atMost()}.
+     *
+     * Either way the answer is a set of levels, so every consumer of the
+     * role-based filtering stays unchanged.
      *
      * @return array<int, string>
      */
     public static function documentVisibilityForRole(string $connectionName, Role $role): array
     {
-        $visibility = config("zgw.connections.{$connectionName}.vertrouwelijkheid_map.visibility");
+        $max = self::documentVisibilityMaxForRole($connectionName, $role);
 
-        if (is_array($visibility) && isset($visibility[$role->value]) && is_array($visibility[$role->value])) {
-            return array_values(array_map(strval(...), $visibility[$role->value]));
+        if ($max !== null) {
+            return DocumentVertrouwelijkheden::atMost($max);
         }
 
         return DocumentVertrouwelijkheden::fromUserRole($role);
     }
 
     /**
+     * The maximum vertrouwelijkheidaanduiding this connection's map allows the
+     * given role to see, or null when the role is not configured (and the
+     * hardcoded defaults apply).
+     */
+    public static function documentVisibilityMaxForRole(string $connectionName, Role $role): ?string
+    {
+        $visibility = config("zgw.connections.{$connectionName}.vertrouwelijkheid_map.visibility");
+
+        if (! is_array($visibility) || ! isset($visibility[$role->value])) {
+            return null;
+        }
+
+        return self::readVisibilityMax($visibility[$role->value]);
+    }
+
+    /**
+     * Read a stored visibility entry as a single maximum level.
+     *
+     * The current form stores one level per role group. Maps written before the
+     * maximum was introduced stored the full set of visible levels; such a set is
+     * read as its most confidential member, which is the maximum it expressed.
+     * Anything else (an empty set, an unknown level) reads as "not configured".
+     */
+    public static function readVisibilityMax(mixed $stored): ?string
+    {
+        if (is_string($stored)) {
+            return DocumentVertrouwelijkheden::tryFrom($stored)?->value;
+        }
+
+        if (is_array($stored)) {
+            return DocumentVertrouwelijkheden::mostConfidential($stored);
+        }
+
+        return null;
+    }
+
+    /**
+     * The distinct maximum levels this connection's map configures across its
+     * role groups: the levels that actually separate one role group from the
+     * next, ordered from the least to the most confidential.
+     *
+     * These are the rungs the upload choice can offer. Any level in between is
+     * seen by exactly the same role groups as the maximum just above it, so it
+     * would collapse into that rung anyway.
+     *
+     * Empty when the connection has no visibility map, in which case the caller
+     * falls back to the fixed {@see DocumentVertrouwelijkheden::uploadChoices()}.
+     *
+     * @return array<int, string>
+     */
+    public static function configuredVisibilityMaxLevels(string $connectionName): array
+    {
+        $visibility = config("zgw.connections.{$connectionName}.vertrouwelijkheid_map.visibility");
+
+        if (! is_array($visibility)) {
+            return [];
+        }
+
+        $maxima = [];
+
+        foreach ($visibility as $stored) {
+            $max = self::readVisibilityMax($stored);
+
+            if ($max !== null) {
+                $maxima[$max] = true;
+            }
+        }
+
+        return array_values(array_filter(
+            DocumentVertrouwelijkheden::order(),
+            static fn (string $level): bool => isset($maxima[$level]),
+        ));
+    }
+
+    /**
      * The default vertrouwelijkheidaanduiding applied when a user of the given
      * role uploads a document without choosing one. Falls back to the legacy
-     * behaviour (organiser = zaakvertrouwelijk, everyone else = vertrouwelijk).
+     * behaviour (the organiser gets zaakvertrouwelijk, everyone else
+     * vertrouwelijk).
+     *
+     * One exception, and it is deliberately narrow. An organiser never gets the
+     * choice select, so this default carries all of their uploads. On a
+     * connection that configures a maximum for the organiser, `openbaar` is by
+     * construction at or below every role group's maximum and therefore visible
+     * to all of them, which is what an organiser upload is meant to be, while
+     * `zaakvertrouwelijk` may sit above the maxima and hide the document from
+     * everyone. Without such a maximum the visibility falls back to the legacy
+     * sets, which do not contain `openbaar` at all: defaulting to it there would
+     * produce exactly the invisible upload it is meant to prevent, so the legacy
+     * `zaakvertrouwelijk` stands.
      */
     public static function uploadDefaultForRole(string $connectionName, Role $role): string
     {
@@ -91,6 +190,10 @@ class ZgwConnectionConfig
 
         if (is_array($defaults) && isset($defaults[$role->value]) && is_string($defaults[$role->value]) && $defaults[$role->value] !== '') {
             return $defaults[$role->value];
+        }
+
+        if ($role === Role::Organiser && self::documentVisibilityMaxForRole($connectionName, $role) !== null) {
+            return DocumentVertrouwelijkheden::Openbaar->value;
         }
 
         return match ($role) {

--- a/database/migrations/2026_08_21_090000_convert_vertrouwelijkheid_visibility_to_max_level.php
+++ b/database/migrations/2026_08_21_090000_convert_vertrouwelijkheid_visibility_to_max_level.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Converts the per-role entries of `vertrouwelijkheid_map.visibility` from a
+     * set of visible levels to the single maximum level that now describes them.
+     *
+     * A maximum vertrouwelijkheidaanduiding is inclusive over the ordered scale
+     * (openbaar through zeer_geheim), so one level per role group expresses the
+     * same thing a set did, without allowing gaps a role-based filter cannot
+     * honour. A stored set is converted to its most confidential member: that is
+     * the level it granted access up to, and every less confidential level it
+     * listed is covered by the maximum anyway.
+     *
+     * Entries that are already a single level, and levels outside the standard,
+     * are left untouched, so the migration is safe to run more than once.
+     */
+    public function up(): void
+    {
+        $this->convert(static function (mixed $stored): mixed {
+            if (! is_array($stored)) {
+                return $stored;
+            }
+
+            return DocumentVertrouwelijkheden::mostConfidential($stored);
+        });
+    }
+
+    /**
+     * Expands each maximum back into the set of levels it covers. That restores
+     * a working map rather than the literal previous value: a set with gaps was
+     * never expressible as a maximum, and the maximum covers every level below it
+     * by definition.
+     */
+    public function down(): void
+    {
+        $this->convert(static function (mixed $stored): mixed {
+            if (! is_string($stored)) {
+                return $stored;
+            }
+
+            $levels = DocumentVertrouwelijkheden::atMost($stored);
+
+            return $levels === [] ? $stored : $levels;
+        });
+    }
+
+    /**
+     * Rewrite every connection's visibility entries with the given converter,
+     * writing back only when something actually changed.
+     */
+    private function convert(callable $converter): void
+    {
+        DB::table('municipality_zgw_connections')
+            ->whereNotNull('vertrouwelijkheid_map')
+            ->orderBy('id')
+            ->each(function (object $connection) use ($converter): void {
+                $map = json_decode((string) $connection->vertrouwelijkheid_map, true);
+
+                if (! is_array($map) || ! isset($map['visibility']) || ! is_array($map['visibility'])) {
+                    return;
+                }
+
+                $original = $map['visibility'];
+                $converted = [];
+
+                foreach ($original as $role => $stored) {
+                    $value = $converter($stored);
+
+                    // A set holding no level of the standard says nothing; drop
+                    // the entry so the role falls back to the defaults.
+                    if ($value !== null) {
+                        $converted[$role] = $value;
+                    }
+                }
+
+                if ($converted === $original) {
+                    return;
+                }
+
+                if ($converted === []) {
+                    unset($map['visibility']);
+                } else {
+                    $map['visibility'] = $converted;
+                }
+
+                DB::table('municipality_zgw_connections')
+                    ->where('id', $connection->id)
+                    ->update(['vertrouwelijkheid_map' => $map === [] ? null : json_encode($map)]);
+            });
+    }
+};

--- a/docs/functionaliteiten/zgw-koppelingbeheer.md
+++ b/docs/functionaliteiten/zgw-koppelingbeheer.md
@@ -262,15 +262,21 @@ In deze sectie bepaal je hoe Eventloket zaken van deze koppeling toont en notifi
 
 ### 5.6 Vertrouwelijkheid
 
-Hier bepaal je per rolgroep welke vertrouwelijkheidsniveaus zichtbaar zijn en welk niveau standaard wordt gebruikt bij het uploaden van een document. De rolgroepen zijn Organisator, Adviseur en Gemeente (behandelaars en beheerders).
+Hier bepaal je per rolgroep het maximaal zichtbare vertrouwelijkheidsniveau en welk niveau standaard wordt gebruikt bij het uploaden van een document. De rolgroepen zijn Organisator, Adviseur en Gemeente (behandelaars en beheerders).
 
-- **Zichtbare niveaus.** De vertrouwelijkheidsniveaus die deze rolgroep mag zien.
+- **Maximaal zichtbaar niveau.** Het hoogste vertrouwelijkheidsniveau dat deze rolgroep mag zien.
 - **Standaard bij uploaden.** Het niveau dat vooraf is ingevuld wanneer iemand uit deze rolgroep een document uploadt.
 - **Standaard voor systeemdocumenten.** Het niveau voor automatisch gegenereerde documenten, namelijk de aanvraag-PDF en de formulier-bijlagen.
 
-Laat een veld leeg om de standaardwaarden van Eventloket aan te houden. De rol-gebaseerde filtering blijft altijd actief, ongeacht deze instellingen. Als alle drie de document-tabbladen zijn uitgeschakeld, verdwijnen de per-rol velden vanzelf, omdat er dan toch niet geüpload kan worden. De standaard voor systeemdocumenten blijft dan wel relevant.
+**Een maximum is inclusief.** De ZGW-standaard ordent de acht niveaus van open naar gesloten: openbaar, beperkt openbaar, intern, zaakvertrouwelijk, vertrouwelijk, confidentieel, geheim, zeer geheim. Een maximale vertrouwelijkheidaanduiding betekent in die standaard "dit niveau en alles wat opener is". Zet je de gemeente op "Intern", dan ziet de gemeente dus ook "Beperkt openbaar" en "Openbaar", en niets daarboven. Je hoeft de opener niveaus niet apart aan te vinken.
 
-**Wat een behandelaar hiervan ziet bij het uploaden.** In het uploadvenster staat de keuze "Wie mag dit document inzien?". De niveaus in die keuze en de rolgroepen die erbij staan, komen uit de zichtbare niveaus die je hier instelt. Kies je bijvoorbeeld dat de organisator ook vertrouwelijke stukken mag zien, dan staat de organisator vanaf dat moment bij dat niveau vermeld. Maken de aangeboden niveaus voor geen enkele rolgroep verschil, bijvoorbeeld omdat alleen de gemeenterollen ze mogen zien, dan verdwijnt de keuze en krijgt het document het niveau uit "Standaard bij uploaden". Een keuze die niets verandert wordt dus niet voorgelegd.
+**Houd de maxima oplopend.** Het maximum van de organisator mag niet hoger liggen dan dat van de adviseur, en dat van de adviseur niet hoger dan dat van de gemeente. Zo blijven de doelgroepen genest: organisator binnen adviseur binnen gemeente. Een instelling die daarvan afwijkt wordt bij het opslaan geweigerd met een foutmelding die de betrokken rolgroepen noemt.
+
+Laat een veld leeg om de standaardwaarden van Eventloket aan te houden. Die standaardwaarden zijn de vaste drietrap vanaf zaakvertrouwelijk (organisator zaakvertrouwelijk, adviseur ook vertrouwelijk, gemeente ook confidentieel) en volgen niet het maximum-model. De rol-gebaseerde filtering blijft altijd actief, ongeacht deze instellingen. Als alle drie de document-tabbladen zijn uitgeschakeld, verdwijnen de per-rol velden vanzelf, omdat er dan toch niet geüpload kan worden. De standaard voor systeemdocumenten blijft dan wel relevant.
+
+**Wat een behandelaar hiervan ziet bij het uploaden.** In het uploadvenster staat de keuze "Wie mag dit document inzien?". Elk ingesteld maximum levert één regel in die keuze, met daarbij de rolgroepen die dat niveau mogen zien. Zet je de organisator op "Openbaar", de adviseur op "Beperkt openbaar" en de gemeente op "Intern", dan krijgt de behandelaar drie keuzes: openbaar voor iedereen, beperkt openbaar voor gemeente en adviseur, en intern alleen voor de gemeente. Maken de maxima voor geen enkele rolgroep verschil, dan verdwijnt de keuze en krijgt het document het niveau uit "Standaard bij uploaden". Een keuze die niets verandert wordt dus niet voorgelegd.
+
+**Systeemdocumenten op openbaar.** Omdat "Openbaar" het meest open niveau is, valt het altijd binnen elk ingesteld maximum. Zet een zaaksysteem zijn eigen uploads op openbaar, dan zijn die documenten op een koppeling met ingestelde maxima voor elke rolgroep zichtbaar. Op een koppeling zonder ingestelde maxima gelden de standaardwaarden, en die bevatten openbaar niet.
 
 Twee vaste gedragsregels gelden altijd, los van deze instellingen:
 

--- a/docs/functionaliteiten/zgw-koppelingbeheer.md
+++ b/docs/functionaliteiten/zgw-koppelingbeheer.md
@@ -270,6 +270,8 @@ Hier bepaal je per rolgroep welke vertrouwelijkheidsniveaus zichtbaar zijn en we
 
 Laat een veld leeg om de standaardwaarden van Eventloket aan te houden. De rol-gebaseerde filtering blijft altijd actief, ongeacht deze instellingen. Als alle drie de document-tabbladen zijn uitgeschakeld, verdwijnen de per-rol velden vanzelf, omdat er dan toch niet geüpload kan worden. De standaard voor systeemdocumenten blijft dan wel relevant.
 
+**Wat een behandelaar hiervan ziet bij het uploaden.** In het uploadvenster staat de keuze "Wie mag dit document inzien?". De niveaus in die keuze en de rolgroepen die erbij staan, komen uit de zichtbare niveaus die je hier instelt. Kies je bijvoorbeeld dat de organisator ook vertrouwelijke stukken mag zien, dan staat de organisator vanaf dat moment bij dat niveau vermeld. Maken de aangeboden niveaus voor geen enkele rolgroep verschil, bijvoorbeeld omdat alleen de gemeenterollen ze mogen zien, dan verdwijnt de keuze en krijgt het document het niveau uit "Standaard bij uploaden". Een keuze die niets verandert wordt dus niet voorgelegd.
+
 Twee vaste gedragsregels gelden altijd, los van deze instellingen:
 
 - Een organisator ziet de documenten die hij zelf heeft ingediend altijd terug, ook als het vertrouwelijkheidsniveau van die documenten buiten de zichtbare niveaus van de organisator valt.

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -20,7 +20,15 @@ return [
         ],
         'vertrouwelijkheid' => [
             'heading' => 'Vertrouwelijkheid',
-            'description' => 'Bepaal per rol welke vertrouwelijkheidsniveaus zichtbaar zijn en welk niveau standaard bij uploaden wordt gebruikt. Laat een rol leeg om de standaardwaarden van Eventloket aan te houden. De rol-gebaseerde filtering blijft altijd actief.',
+            'description' => 'Bepaal per rolgroep het maximaal zichtbare vertrouwelijkheidsniveau en welk niveau standaard bij uploaden wordt gebruikt. Laat een rolgroep leeg om de standaardwaarden van Eventloket aan te houden. De rol-gebaseerde filtering blijft altijd actief.',
+            'explanation' => [
+                'title' => 'Zo werkt de vertrouwelijkheid-instelling',
+                'intro' => 'Per rolgroep kiest u één maximaal zichtbaar niveau. Alle opener niveaus zijn daarbij automatisch inbegrepen: staat de gemeente op "Intern", dan ziet de gemeente ook "Beperkt openbaar" en "Openbaar", maar niets daarboven. Dit volgt de ZGW-standaard, die een maximale vertrouwelijkheidaanduiding inclusief opvat over de schaal openbaar, beperkt openbaar, intern, zaakvertrouwelijk, vertrouwelijk, confidentieel, geheim, zeer geheim.',
+                'nesting' => 'Houd de maxima oplopend: het maximum van de organisator mag niet hoger liggen dan dat van de adviseur, en dat van de adviseur niet hoger dan dat van de gemeente. Zo vormen de rolgroepen geneste doelgroepen (organisator binnen adviseur binnen gemeente). Een instelling die daarvan afwijkt wordt bij het opslaan geweigerd.',
+                'upload' => 'Dezelfde maxima bepalen wat een behandelaar bij het uploaden kan kiezen. Elk ingesteld maximum is één keuze in de lijst "Wie mag dit document inzien?", met daarbij de rolgroepen die dat niveau mogen zien. Maken de maxima geen onderscheid tussen de rolgroepen, dan verdwijnt die keuze.',
+                'default' => '"Standaard bij uploaden" is de terugvaloptie: dit niveau geldt wanneer er geen keuze wordt gemaakt, bijvoorbeeld bij uploads door de organisator of wanneer de maxima geen onderscheid tussen de rolgroepen maken.',
+                'openbaar' => '"Openbaar" is het meest open niveau en valt dus altijd binnen elk ingesteld maximum. Documenten die automatisch op openbaar worden gezet, zoals systeemuploads vanuit het zaaksysteem, zijn op een eigen koppeling met ingestelde maxima daarom voor elke rolgroep zichtbaar.',
+            ],
         ],
         'features' => [
             'heading' => 'Eventloket functies',
@@ -60,12 +68,15 @@ return [
             'helper' => 'RSIN die als bronorganisatie op elke zaak wordt gezet.',
         ],
         'vertrouwelijkheid_visibility' => [
-            'label' => 'Zichtbare niveaus',
-            'helper' => 'De vertrouwelijkheidsniveaus die deze rol mag zien. Leeg laten valt terug op de standaard.',
+            'label' => 'Maximaal zichtbaar niveau',
+            'helper' => 'Het hoogste vertrouwelijkheidsniveau dat deze rolgroep mag zien. Alle opener niveaus zijn automatisch inbegrepen. Leeg laten valt terug op de standaard.',
+            'tooltip' => 'Een maximum is inclusief: kiest u "Intern", dan ziet deze rolgroep ook "Beperkt openbaar" en "Openbaar", maar niets daarboven.',
+            'nesting_error' => 'Het maximum van :broader mag niet lager liggen dan dat van :narrower. Houd de doelgroepen oplopend genest: organisator binnen adviseur binnen gemeente.',
         ],
         'vertrouwelijkheid_upload_default' => [
             'label' => 'Standaard bij uploaden',
-            'helper' => 'Het niveau dat vooraf is ingevuld wanneer deze rol een document uploadt. Leeg laten valt terug op de standaard.',
+            'helper' => 'Het niveau dat vooraf is ingevuld wanneer deze rolgroep een document uploadt. Leeg laten valt terug op de standaard.',
+            'tooltip' => 'Terugvaloptie: dit niveau wordt gebruikt als er geen keuze wordt gemaakt, bijvoorbeeld bij uploads door de organisator of wanneer de ingestelde maxima geen onderscheid tussen de rolgroepen maken.',
         ],
         'vertrouwelijkheid_system_default' => [
             'label' => 'Standaard voor systeemdocumenten',

--- a/lang/nl/municipality/resources/zgw_connection.php
+++ b/lang/nl/municipality/resources/zgw_connection.php
@@ -107,6 +107,9 @@ return [
 
     'vertrouwelijkheid_groups' => [
         'gemeente' => 'Gemeente (behandelaars en beheerders)',
+        // Short form, used where the group is named as an audience ("wie mag dit
+        // document inzien?") instead of as a form heading.
+        'gemeente_audience' => 'Gemeente',
     ],
 
     'vertrouwelijkheid_levels' => [

--- a/tests/Feature/Filament/Municipality/Resources/MunicipalityZgwConnectionResourceTest.php
+++ b/tests/Feature/Filament/Municipality/Resources/MunicipalityZgwConnectionResourceTest.php
@@ -140,7 +140,7 @@ it('stores the vertrouwelijkheid map from the form', function () {
 
     livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
         ->fillForm([
-            'vertrouwelijkheid_map.visibility.organiser' => ['zaakvertrouwelijk', 'vertrouwelijk'],
+            'vertrouwelijkheid_map.visibility.organiser' => 'vertrouwelijk',
             'vertrouwelijkheid_map.upload_default.organiser' => 'vertrouwelijk',
             'vertrouwelijkheid_map.upload_default.system' => 'confidentieel',
         ])
@@ -152,7 +152,7 @@ it('stores the vertrouwelijkheid map from the form', function () {
     // toEqual (==), not toBe (===): JSON object key order is not significant and
     // differs by database driver (MySQL reorders the keys of the stored map).
     expect($connection->vertrouwelijkheid_map)->toEqual([
-        'visibility' => ['organiser' => ['zaakvertrouwelijk', 'vertrouwelijk']],
+        'visibility' => ['organiser' => 'vertrouwelijk'],
         'upload_default' => ['organiser' => 'vertrouwelijk', 'system' => 'confidentieel'],
     ]);
 });
@@ -162,7 +162,7 @@ it('fans the gemeente group choice out to every municipal handler role', functio
 
     livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
         ->fillForm([
-            'vertrouwelijkheid_map.visibility.reviewer' => ['zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+            'vertrouwelijkheid_map.visibility.reviewer' => 'confidentieel',
             'vertrouwelijkheid_map.upload_default.reviewer' => 'confidentieel',
         ])
         ->call('save')
@@ -170,13 +170,11 @@ it('fans the gemeente group choice out to every municipal handler role', functio
 
     $connection->refresh();
 
-    $allLevels = ['zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'];
-
     expect($connection->vertrouwelijkheid_map['visibility'])->toBe([
-        'reviewer' => $allLevels,
-        'coordinator' => $allLevels,
-        'municipality_admin' => $allLevels,
-        'reviewer_municipality_admin' => $allLevels,
+        'reviewer' => 'confidentieel',
+        'coordinator' => 'confidentieel',
+        'municipality_admin' => 'confidentieel',
+        'reviewer_municipality_admin' => 'confidentieel',
     ])->and($connection->vertrouwelijkheid_map['upload_default'])->toBe([
         'reviewer' => 'confidentieel',
         'coordinator' => 'confidentieel',
@@ -190,8 +188,8 @@ it('prunes empty roles so they fall back to the defaults', function () {
 
     livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
         ->fillForm([
-            'vertrouwelijkheid_map.visibility.organiser' => ['zaakvertrouwelijk'],
-            'vertrouwelijkheid_map.visibility.advisor' => [],
+            'vertrouwelijkheid_map.visibility.organiser' => 'zaakvertrouwelijk',
+            'vertrouwelijkheid_map.visibility.advisor' => null,
             'vertrouwelijkheid_map.upload_default.reviewer' => null,
         ])
         ->call('save')
@@ -200,7 +198,104 @@ it('prunes empty roles so they fall back to the defaults', function () {
     $connection->refresh();
 
     expect($connection->vertrouwelijkheid_map)->toBe([
-        'visibility' => ['organiser' => ['zaakvertrouwelijk']],
+        'visibility' => ['organiser' => 'zaakvertrouwelijk'],
+    ]);
+});
+
+it('blocks a maximum that runs down with a validation error', function () {
+    $connection = MunicipalityZgwConnection::factory()->for($this->municipality)->create();
+
+    // The organiser is given a maximum (intern) above the advisor's: a broader
+    // audience must always see at least what a narrower one sees.
+    livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
+        ->fillForm([
+            'vertrouwelijkheid_map.visibility.organiser' => 'intern',
+            'vertrouwelijkheid_map.visibility.advisor' => 'openbaar',
+            'vertrouwelijkheid_map.visibility.reviewer' => 'intern',
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['vertrouwelijkheid_map.visibility.organiser']);
+
+    // Nothing is persisted while the map is invalid.
+    expect($connection->fresh()->vertrouwelijkheid_map)->toBeNull();
+});
+
+it('blocks a gemeente maximum below the advisor maximum', function () {
+    $connection = MunicipalityZgwConnection::factory()->for($this->municipality)->create();
+
+    livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
+        ->fillForm([
+            'vertrouwelijkheid_map.visibility.organiser' => 'openbaar',
+            'vertrouwelijkheid_map.visibility.advisor' => 'intern',
+            'vertrouwelijkheid_map.visibility.reviewer' => 'beperkt_openbaar',
+        ])
+        ->call('save')
+        ->assertHasFormErrors(['vertrouwelijkheid_map.visibility.advisor']);
+
+    expect($connection->fresh()->vertrouwelijkheid_map)->toBeNull();
+});
+
+it('accepts maxima that run up', function () {
+    $connection = MunicipalityZgwConnection::factory()->for($this->municipality)->create();
+
+    livewire(EditMunicipalityZgwConnection::class, ['record' => $connection->getKey()])
+        ->fillForm([
+            'vertrouwelijkheid_map.visibility.organiser' => 'openbaar',
+            'vertrouwelijkheid_map.visibility.advisor' => 'beperkt_openbaar',
+            'vertrouwelijkheid_map.visibility.reviewer' => 'intern',
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    expect($connection->fresh()->vertrouwelijkheid_map['visibility'])->toMatchArray([
+        'organiser' => 'openbaar',
+        'advisor' => 'beperkt_openbaar',
+        'reviewer' => 'intern',
+    ]);
+});
+
+it('clamps a map written outside the form as a safety net', function () {
+    // pruneVertrouwelijkheidMap runs on save (after the form validation above has
+    // already blocked a maximum that runs down), and is the second line for
+    // seeders and direct writes: a broader group is clamped up to the narrower
+    // one instead of being stored below it.
+    $result = MunicipalityZgwConnectionResource::pruneVertrouwelijkheidMap([
+        'vertrouwelijkheid_map' => [
+            'visibility' => [
+                'organiser' => 'intern',
+                'advisor' => 'openbaar',
+                'reviewer' => 'openbaar',
+            ],
+        ],
+    ]);
+
+    expect($result['vertrouwelijkheid_map']['visibility']['organiser'])->toBe('intern')
+        ->and($result['vertrouwelijkheid_map']['visibility']['advisor'])->toBe('intern')
+        ->and($result['vertrouwelijkheid_map']['visibility']['reviewer'])->toBe('intern')
+        // The gemeente choice is still fanned out to the other municipal roles.
+        ->and($result['vertrouwelijkheid_map']['visibility']['coordinator'])->toBe('intern');
+});
+
+it('converts a legacy map of level sets to a maximum on save', function () {
+    // Compatibility with maps stored before the maximum was introduced: each set
+    // is read as its most confidential member.
+    $result = MunicipalityZgwConnectionResource::pruneVertrouwelijkheidMap([
+        'vertrouwelijkheid_map' => [
+            'visibility' => [
+                'organiser' => ['openbaar'],
+                'advisor' => ['openbaar', 'beperkt_openbaar'],
+                'reviewer' => ['openbaar', 'beperkt_openbaar', 'intern'],
+            ],
+        ],
+    ]);
+
+    expect($result['vertrouwelijkheid_map']['visibility'])->toBe([
+        'organiser' => 'openbaar',
+        'advisor' => 'beperkt_openbaar',
+        'reviewer' => 'intern',
+        'coordinator' => 'intern',
+        'municipality_admin' => 'intern',
+        'reviewer_municipality_admin' => 'intern',
     ]);
 });
 

--- a/tests/Feature/Filament/Shared/Resources/Zaken/OrganiserUploadDocumentTypeTest.php
+++ b/tests/Feature/Filament/Shared/Resources/Zaken/OrganiserUploadDocumentTypeTest.php
@@ -14,6 +14,7 @@ use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
+use App\Services\Zgw\UploadDocumentTypeResolver;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Repeater;
 use Illuminate\Support\Facades\Config;
@@ -25,13 +26,17 @@ use Tests\Fakes\ZgwHttpFake;
 use function Pest\Livewire\livewire;
 
 /**
- * The zaaktype exposes two documenttypes the organiser may see. Their
- * omschrijvingen are chosen so the three possible outcomes are distinguishable:
- * "Aanvraagformulier" is the first type after sorting (the last-resort
- * heuristic), "Bijlage" is what the omschrijving heuristic prefers, and either
- * can be named by the koppeling.
+ * The zaaktype exposes two documenttypes. Their omschrijvingen are chosen so the
+ * three possible outcomes are distinguishable: "Aanvraagformulier" is the first
+ * type after sorting (the last-resort heuristic), "Bijlage" is what the
+ * omschrijving heuristic prefers, and either can be named by the koppeling.
+ *
+ * They default to zaakvertrouwelijk, which every role sees on a connection
+ * without a vertrouwelijkheid map, so the documenttype select is populated and
+ * these tests are about type resolution and nothing else. Pass another level to
+ * put the types outside a role's visible set.
  */
-function fakeTwoDocumentTypes(): array
+function fakeTwoDocumentTypes(string $vertrouwelijkheid = 'zaakvertrouwelijk'): array
 {
     $first = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
     $second = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/2';
@@ -53,14 +58,14 @@ function fakeTwoDocumentTypes(): array
             'uuid' => '1',
             'url' => $first,
             'omschrijving' => 'Aanvraagformulier',
-            'vertrouwelijkheidaanduiding' => 'openbaar',
+            'vertrouwelijkheidaanduiding' => $vertrouwelijkheid,
             'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
         ], 200),
         $second => Http::response([
             'uuid' => '2',
             'url' => $second,
             'omschrijving' => 'Bijlage',
-            'vertrouwelijkheidaanduiding' => 'openbaar',
+            'vertrouwelijkheidaanduiding' => $vertrouwelijkheid,
             'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
         ], 200),
         ZgwHttpFake::$baseUrl.'/documenten/api/v1/enkelvoudiginformatieobjecten*' => Http::response([
@@ -253,6 +258,61 @@ test('an organiser upload falls back to the heuristic when the koppeling leaves 
         UploadDocumentsJob::class,
         fn (UploadDocumentsJob $job): bool => $job->files[0]['informatieobjecttype'] === $types['bijlage'],
     );
+});
+
+test('an organiser upload takes the documenttype from the koppeling even when the types sit outside their visible set', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    // A catalogus that labels its documenttypes openbaar, on a connection with no
+    // vertrouwelijkheid map: the defaults start at zaakvertrouwelijk, so no role
+    // sees these types. The koppeling's choice of documenttype is not the
+    // uploader's to make, so it must not depend on that.
+    $types = fakeTwoDocumentTypes('openbaar');
+    mapBijlageDocumentType($this->municipality, 'Aanvraagformulier');
+
+    $path = 'documents/organiser-file.pdf';
+    Storage::put($path, '%PDF-1.4 organiser file');
+
+    $zaak = ($this->makeZaak)();
+
+    $this->actingAs($this->organiser);
+
+    expect($zaak->document_types)->toBeEmpty()
+        ->and($zaak->catalogusDocumentTypes())->toHaveCount(2);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Plattegrond', 'informatieobjecttype' => $types['bijlage']],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->files[0]['informatieobjecttype'] === $types['aanvraagformulier'],
+    );
+});
+
+test('the queued and the web upload path resolve the same documenttype', function () {
+    Storage::fake('local');
+
+    // The queued path has no authenticated user and therefore never filtered;
+    // the web path did. Both must answer the same, whatever the uploader sees.
+    $types = fakeTwoDocumentTypes('openbaar');
+    mapBijlageDocumentType($this->municipality, 'Aanvraagformulier');
+
+    $zaak = ($this->makeZaak)();
+
+    $withoutUser = UploadDocumentTypeResolver::defaultFor($zaak);
+
+    $this->actingAs($this->organiser);
+
+    expect(UploadDocumentTypeResolver::defaultFor($zaak))
+        ->toBe($types['aanvraagformulier'])
+        ->and($withoutUser)->toBe($types['aanvraagformulier']);
 });
 
 test('a coordinator upload keeps the chosen documenttype', function () {

--- a/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
+++ b/tests/Feature/Filament/Shared/Resources/Zaken/UploadDocumentActionTest.php
@@ -169,7 +169,8 @@ test('upload action successfully stores a document via OpenZaak and dispatches r
     ], $zaak);
 
     // Assert the POST to create the informatieobject was made, with the
-    // finalised 'definitief' status.
+    // finalised 'definitief' status. An organiser upload carries no explicit
+    // choice, so it falls back to the connection default.
     Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
         && $request->method() === 'POST'
         && $request->data()['titel'] === 'Testbestand'
@@ -301,7 +302,10 @@ test('organiser uploads set confidentiality to zaakvertrouwelijk automatically',
         'file_name' => 'test-document.pdf',
     ], $zaak);
 
-    // Assert vertrouwelijkheidaanduiding is set to zaakvertrouwelijk for organiser
+    // Regression anchor for the default connection: an organiser never gets the
+    // choice select, and without a configured maximum the visibility falls back
+    // to the legacy sets, which start at zaakvertrouwelijk and do not contain
+    // openbaar. Defaulting to openbaar here would hide the upload from everyone.
     Http::assertSent(fn ($request) => str_contains($request->url(), '/documenten/api/v1/enkelvoudiginformatieobjecten')
         && $request->method() === 'POST'
         && $request->data()['vertrouwelijkheidaanduiding'] === DocumentVertrouwelijkheden::Zaakvertrouwelijk->value

--- a/tests/Feature/Migrations/ConvertVertrouwelijkheidVisibilityToMaxLevelTest.php
+++ b/tests/Feature/Migrations/ConvertVertrouwelijkheidVisibilityToMaxLevelTest.php
@@ -1,0 +1,108 @@
+<?php
+
+use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
+use Illuminate\Database\Migrations\Migration;
+
+/**
+ * Load the data migration under test. It is an anonymous class, so it has to be
+ * required rather than instantiated by name.
+ */
+function visibilityMaxMigration(): Migration
+{
+    return require database_path('migrations/2026_08_21_090000_convert_vertrouwelijkheid_visibility_to_max_level.php');
+}
+
+function connectionWithMap(?array $map): MunicipalityZgwConnection
+{
+    return MunicipalityZgwConnection::factory()
+        ->for(Municipality::factory())
+        ->create(['vertrouwelijkheid_map' => $map]);
+}
+
+it('converts a stored set of levels to the maximum it expressed', function () {
+    $connection = connectionWithMap([
+        'visibility' => [
+            'organiser' => ['openbaar'],
+            'advisor' => ['openbaar', 'beperkt_openbaar'],
+            'reviewer' => ['openbaar', 'beperkt_openbaar', 'intern'],
+            'coordinator' => ['openbaar', 'beperkt_openbaar', 'intern'],
+        ],
+        'upload_default' => ['organiser' => 'openbaar', 'system' => 'openbaar'],
+    ]);
+
+    visibilityMaxMigration()->up();
+
+    expect($connection->fresh()->vertrouwelijkheid_map)->toEqual([
+        'visibility' => [
+            'organiser' => 'openbaar',
+            'advisor' => 'beperkt_openbaar',
+            'reviewer' => 'intern',
+            'coordinator' => 'intern',
+        ],
+        // Everything outside the visibility map is left untouched.
+        'upload_default' => ['organiser' => 'openbaar', 'system' => 'openbaar'],
+    ]);
+});
+
+it('takes the most confidential level regardless of the order in the set', function () {
+    $connection = connectionWithMap([
+        'visibility' => [
+            'reviewer' => ['confidentieel', 'openbaar', 'vertrouwelijk'],
+        ],
+    ]);
+
+    visibilityMaxMigration()->up();
+
+    expect($connection->fresh()->vertrouwelijkheid_map['visibility']['reviewer'])
+        ->toBe('confidentieel');
+});
+
+it('drops an entry that names no level of the standard', function () {
+    $connection = connectionWithMap([
+        'visibility' => ['organiser' => [], 'advisor' => ['nonsense']],
+        'upload_default' => ['system' => 'openbaar'],
+    ]);
+
+    visibilityMaxMigration()->up();
+
+    // A role without an entry falls back to the hardcoded defaults, which is
+    // what an unreadable entry meant anyway.
+    expect($connection->fresh()->vertrouwelijkheid_map)
+        ->toEqual(['upload_default' => ['system' => 'openbaar']]);
+});
+
+it('leaves a map that already holds maxima untouched, and runs twice safely', function () {
+    $map = [
+        'visibility' => ['organiser' => 'openbaar', 'reviewer' => 'intern'],
+        'upload_default' => ['system' => 'openbaar'],
+    ];
+
+    $connection = connectionWithMap($map);
+
+    visibilityMaxMigration()->up();
+    visibilityMaxMigration()->up();
+
+    expect($connection->fresh()->vertrouwelijkheid_map)->toEqual($map);
+});
+
+it('ignores connections without a map', function () {
+    $connection = connectionWithMap(null);
+
+    visibilityMaxMigration()->up();
+
+    expect($connection->fresh()->vertrouwelijkheid_map)->toBeNull();
+});
+
+it('expands a maximum back into the levels it covers on rollback', function () {
+    $connection = connectionWithMap([
+        'visibility' => ['organiser' => 'openbaar', 'reviewer' => 'intern'],
+    ]);
+
+    visibilityMaxMigration()->down();
+
+    expect($connection->fresh()->vertrouwelijkheid_map['visibility'])->toEqual([
+        'organiser' => ['openbaar'],
+        'reviewer' => ['openbaar', 'beperkt_openbaar', 'intern'],
+    ]);
+});

--- a/tests/Feature/MultiUploadDocumentActionTest.php
+++ b/tests/Feature/MultiUploadDocumentActionTest.php
@@ -13,6 +13,7 @@ use App\Models\Zaak;
 use App\Models\Zaaktype;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Repeater;
+use Filament\Forms\Components\Select;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
@@ -36,6 +37,23 @@ beforeEach(function () {
     $this->coordinator = User::factory()->create(['role' => Role::Coordinator]);
     $this->coordinator->municipalities()->attach($this->municipality);
 });
+
+/**
+ * The options of the "who may see this document" select in the multi upload
+ * schema, or null when the schema does not offer the select at all.
+ *
+ * @return array<string, string>|null
+ */
+function confidentialityOptions(Zaak $zaak): ?array
+{
+    foreach (UploadDocumentAction::schema($zaak) as $field) {
+        if ($field instanceof Select && $field->getName() === 'vertrouwelijkheidaanduiding') {
+            return $field->getOptions();
+        }
+    }
+
+    return null;
+}
 
 test('upload action exists on ZaakDocumentsTable', function () {
     $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
@@ -214,6 +232,146 @@ test('coordinator can choose the confidentiality level when uploading documents'
         ->callTableAction('upload', data: [
             'files' => [$path],
             'vertrouwelijkheidaanduiding' => DocumentVertrouwelijkheden::Confidentieel->value,
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Intern advies', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->vertrouwelijkheidaanduiding === DocumentVertrouwelijkheden::Confidentieel->value,
+    );
+});
+
+test('the confidentiality choices are labelled with the enum defaults on a connection without a map', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    expect(confidentialityOptions($zaak))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+test('the confidentiality choices are labelled with the audiences of the active connection', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    // This connection lets the advisor see zaakvertrouwelijk documents, which
+    // the hardcoded defaults do not, and keeps the organiser on openbaar only.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    expect(confidentialityOptions($zaak))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+test('the confidentiality select disappears when the levels reach the same audience', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    // The situation reported on the VRZL staging connection: the municipal roles
+    // see every level and nobody else sees any of them, so the three choices
+    // make no difference at all.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    $fieldNames = array_map(
+        fn (Field|Repeater $field): string => $field->getName(),
+        UploadDocumentAction::schema($zaak),
+    );
+
+    expect($fieldNames)->not->toContain('vertrouwelijkheidaanduiding');
+});
+
+test('an upload without the select applies the upload default of the connection', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/coordinator-file.pdf';
+    Storage::put($path, '%PDF-1.4 coordinator file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', [
+        'visibility' => [
+            Role::Organiser->value => ['openbaar'],
+            Role::Advisor->value => ['openbaar'],
+            Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+            Role::Coordinator->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        ],
+        'upload_default' => [
+            Role::Coordinator->value => DocumentVertrouwelijkheden::Confidentieel->value,
+        ],
+    ]);
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen/1',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+                'informatieobjecttype' => $documentTypeUrl,
+            ],
+        ]), 200),
+        $documentTypeUrl => Http::response([
+            'uuid' => '1',
+            'url' => $documentTypeUrl,
+            'omschrijving' => 'Bijlage',
+            'vertrouwelijkheidaanduiding' => 'zaakvertrouwelijk',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->coordinator);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
             'document_metadata' => [
                 ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Intern advies', 'informatieobjecttype' => $documentTypeUrl],
             ],

--- a/tests/Feature/MultiUploadDocumentActionTest.php
+++ b/tests/Feature/MultiUploadDocumentActionTest.php
@@ -7,10 +7,13 @@ use App\Filament\Shared\Resources\Zaken\Actions\UploadDocumentAction;
 use App\Jobs\Zaak\UploadDocumentsJob;
 use App\Livewire\Zaken\ZaakDocumentsTable;
 use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
 use App\Models\Zaaktype;
+use App\Services\Zgw\DocumentAudience;
+use App\Services\Zgw\ZgwConnectionConfig;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
@@ -265,16 +268,18 @@ test('the confidentiality choices are labelled with the enum defaults on a conne
     ]);
 });
 
-test('the confidentiality choices are labelled with the audiences of the active connection', function () {
+test('the confidentiality choices on the default connection honour a visibility map', function () {
     $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
     ZgwHttpFake::wildcardFake();
 
     // This connection lets the advisor see zaakvertrouwelijk documents, which
     // the hardcoded defaults do not, and keeps the organiser on openbaar only.
+    // vertrouwelijk and confidentieel both reach only the gemeente here, so they
+    // collapse into a single rung keyed by the connection's gemeente maximum.
     Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar'],
-        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'zaakvertrouwelijk',
+        Role::Reviewer->value => 'confidentieel',
     ]);
 
     $zaak = Zaak::factory()->create([
@@ -287,7 +292,6 @@ test('the confidentiality choices are labelled with the audiences of the active 
 
     expect(confidentialityOptions($zaak))->toBe([
         DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur',
-        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente',
         DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
     ]);
 });
@@ -296,13 +300,12 @@ test('the confidentiality select disappears when the levels reach the same audie
     $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
     ZgwHttpFake::wildcardFake();
 
-    // The situation reported on the VRZL staging connection: the municipal roles
-    // see every level and nobody else sees any of them, so the three choices
-    // make no difference at all.
+    // The municipal roles top out above every level the other groups can see, so
+    // the fixed upload choices make no difference at all.
     Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar'],
-        Role::Advisor->value => ['openbaar'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'openbaar',
+        Role::Reviewer->value => 'confidentieel',
     ]);
 
     $zaak = Zaak::factory()->create([
@@ -321,6 +324,232 @@ test('the confidentiality select disappears when the levels reach the same audie
     expect($fieldNames)->not->toContain('vertrouwelijkheidaanduiding');
 });
 
+/**
+ * Give the coordinator's municipality its own active ZGW connection carrying a
+ * vertrouwelijkheid map with a maximum per role group (organisator openbaar ≤
+ * adviseur beperkt_openbaar ≤ gemeente intern), and return a zaak that resolves
+ * to it.
+ */
+function zaakOnStagingConnection(Municipality $municipality, Organisation $organisation, string $zgwZaakUrl): Zaak
+{
+    MunicipalityZgwConnection::factory()->active()->create([
+        'municipality_id' => $municipality->id,
+        'zaken_url' => ZgwHttpFake::$baseUrl.'/zaken/api/v1/',
+        'catalogi_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/',
+        'documenten_url' => ZgwHttpFake::$baseUrl.'/documenten/api/v1/',
+        'besluiten_url' => ZgwHttpFake::$baseUrl.'/besluiten/api/v1/',
+        'notificaties_url' => ZgwHttpFake::$baseUrl.'/notificaties/api/v1/',
+        'vertrouwelijkheid_map' => [
+            'visibility' => [
+                Role::Organiser->value => 'openbaar',
+                Role::Advisor->value => 'beperkt_openbaar',
+                Role::Reviewer->value => 'intern',
+                Role::Coordinator->value => 'intern',
+                Role::MunicipalityAdmin->value => 'intern',
+                Role::ReviewerMunicipalityAdmin->value => 'intern',
+            ],
+            'upload_default' => [
+                'system' => 'openbaar',
+            ],
+        ],
+    ]);
+
+    $zaaktype = Zaaktype::factory()->create([
+        'zgw_zaaktype_url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        'municipality_id' => $municipality->id,
+        'connection' => "gemeente_{$municipality->id}",
+    ]);
+
+    return Zaak::factory()->create([
+        'zaaktype_id' => $zaaktype->id,
+        'organisation_id' => $organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+}
+
+test('the confidentiality choices are derived from a municipal connection map', function () {
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    ZgwHttpFake::wildcardFake();
+
+    $zaak = zaakOnStagingConnection($this->municipality, $this->organisation, $zgwZaakUrl);
+
+    $this->actingAs($this->coordinator);
+
+    // Three meaningful, nested rungs derived from the connection's own map, keyed
+    // by the maxima it configures, not the hardcoded upload choices.
+    expect($zaak->zgwConnectionName())->toBe("gemeente_{$this->municipality->id}")
+        ->and(confidentialityOptions($zaak))->toBe([
+            'openbaar' => 'Gemeente, Adviseur, Organisator',
+            'beperkt_openbaar' => 'Gemeente, Adviseur',
+            'intern' => 'Gemeente',
+        ]);
+});
+
+test('a coordinator upload writes the derived level chosen on a municipal connection', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/coordinator-file.pdf';
+    Storage::put($path, '%PDF-1.4 coordinator file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen/1',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+                'informatieobjecttype' => $documentTypeUrl,
+            ],
+        ]), 200),
+        $documentTypeUrl => Http::response([
+            'uuid' => '1',
+            'url' => $documentTypeUrl,
+            'omschrijving' => 'Bijlage',
+            // openbaar so the coordinator, whose visibility on this connection is
+            // openbaar/beperkt_openbaar/intern, may pick this document type.
+            'vertrouwelijkheidaanduiding' => 'openbaar',
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+
+    $zaak = zaakOnStagingConnection($this->municipality, $this->organisation, $zgwZaakUrl);
+
+    $this->actingAs($this->coordinator);
+
+    // "Deel met de adviseur" is the beperkt_openbaar rung on this connection.
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
+            'vertrouwelijkheidaanduiding' => 'beperkt_openbaar',
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Advies', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->vertrouwelijkheidaanduiding === 'beperkt_openbaar',
+    );
+});
+
+/**
+ * Fake the catalogus so a single document type at the given vertrouwelijkheid is
+ * offered on the zaaktype, and let every other ZGW call answer 200.
+ */
+function fakeDocumentType(string $documentTypeUrl, string $vertrouwelijkheid): void
+{
+    Http::fake([
+        ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen*' => Http::response(ZgwHttpFake::envelope([
+            [
+                'url' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktype-informatieobjecttypen/1',
+                'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+                'informatieobjecttype' => $documentTypeUrl,
+            ],
+        ]), 200),
+        $documentTypeUrl => Http::response([
+            'uuid' => '1',
+            'url' => $documentTypeUrl,
+            'omschrijving' => 'Bijlage',
+            'vertrouwelijkheidaanduiding' => $vertrouwelijkheid,
+            'zaaktype' => ZgwHttpFake::$baseUrl.'/catalogi/api/v1/zaaktypen/1',
+        ], 200),
+        ZgwHttpFake::$baseUrl.'*' => Http::response([], 200),
+    ]);
+}
+
+test('an organiser upload on a connection with maxima lands on openbaar', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/organiser-file.pdf';
+    Storage::put($path, '%PDF-1.4 organiser file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    fakeDocumentType($documentTypeUrl, 'openbaar');
+
+    $zaak = zaakOnStagingConnection($this->municipality, $this->organisation, $zgwZaakUrl);
+
+    $this->actingAs($this->organiser);
+
+    // An organiser never gets the select, so the connection default decides. This
+    // connection configures a maximum for the organiser, so openbaar is at or
+    // below every group's maximum and the upload is visible to all of them.
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Draaiboek', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    Queue::assertPushed(
+        UploadDocumentsJob::class,
+        fn (UploadDocumentsJob $job): bool => $job->vertrouwelijkheidaanduiding === DocumentVertrouwelijkheden::Openbaar->value,
+    );
+
+    expect(DocumentAudience::audienceFor($zaak->zgwConnectionName(), DocumentVertrouwelijkheden::Openbaar->value))
+        ->toBe(['Gemeente', 'Adviseur', 'Organisator']);
+});
+
+test('an organiser upload on the default connection stays visible to the gemeente', function () {
+    Queue::fake();
+    Storage::fake('local');
+
+    $path = 'documents/organiser-file.pdf';
+    Storage::put($path, '%PDF-1.4 organiser file');
+
+    $zgwZaakUrl = ZgwHttpFake::fakeSingleZaak();
+    $documentTypeUrl = ZgwHttpFake::$baseUrl.'/catalogi/api/v1/informatieobjecttypen/1';
+
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+
+    fakeDocumentType($documentTypeUrl, 'zaakvertrouwelijk');
+
+    $zaak = Zaak::factory()->create([
+        'zaaktype_id' => $this->zaaktype->id,
+        'organisation_id' => $this->organisation->id,
+        'zgw_zaak_url' => $zgwZaakUrl,
+    ]);
+
+    $this->actingAs($this->organiser);
+
+    livewire(ZaakDocumentsTable::class, ['zaak' => $zaak])
+        ->callTableAction('upload', data: [
+            'files' => [$path],
+            'document_metadata' => [
+                ['_temp_path' => '/tmp/php1', 'path' => $path, 'titel' => 'Draaiboek', 'informatieobjecttype' => $documentTypeUrl],
+            ],
+        ])
+        ->assertHasNoTableActionErrors();
+
+    $pushed = null;
+
+    Queue::assertPushed(UploadDocumentsJob::class, function (UploadDocumentsJob $job) use (&$pushed): bool {
+        $pushed = $job->vertrouwelijkheidaanduiding;
+
+        return true;
+    });
+
+    // The level an organiser upload carries here must be one the default
+    // connection actually shows, or the document reaches nobody. Without a map
+    // the visible sets start at zaakvertrouwelijk, so openbaar would do exactly
+    // that.
+    expect($pushed)->toBe(DocumentVertrouwelijkheden::Zaakvertrouwelijk->value)
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Organiser))
+        ->toContain($pushed)
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Reviewer))
+        ->toContain($pushed)
+        ->and(DocumentAudience::audienceFor('main', $pushed))
+        ->toBe(['Gemeente', 'Adviseur', 'Organisator']);
+});
+
 test('an upload without the select applies the upload default of the connection', function () {
     Queue::fake();
     Storage::fake('local');
@@ -333,10 +562,10 @@ test('an upload without the select applies the upload default of the connection'
 
     Config::set('zgw.connections.main.vertrouwelijkheid_map', [
         'visibility' => [
-            Role::Organiser->value => ['openbaar'],
-            Role::Advisor->value => ['openbaar'],
-            Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
-            Role::Coordinator->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+            Role::Organiser->value => 'openbaar',
+            Role::Advisor->value => 'openbaar',
+            Role::Reviewer->value => 'confidentieel',
+            Role::Coordinator->value => 'confidentieel',
         ],
         'upload_default' => [
             Role::Coordinator->value => DocumentVertrouwelijkheden::Confidentieel->value,

--- a/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
+++ b/tests/Feature/Zaken/ZaakDocumentVisibilityTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
  */
 
 use App\Enums\Role;
+use App\Models\Municipality;
+use App\Models\MunicipalityZgwConnection;
 use App\Models\Organisation;
 use App\Models\User;
 use App\Models\Zaak;
@@ -59,19 +61,19 @@ test('an organiser always sees their own submitted documents, even above their v
         documentWith('own-vertrouwelijk', 'vertrouwelijk'),      // the organiser's own → always visible
         documentWith('other-vertrouwelijk', 'vertrouwelijk'),    // same level but not theirs → hidden
         documentWith('case-confidential', 'zaakvertrouwelijk'),  // in the organiser's default visible set
-        documentWith('public', 'openbaar'),                      // openbaar is visible to every role
+        documentWith('public', 'openbaar'),                      // outside the defaults → hidden here
     ]);
 
     $visible = $zaak->filterDocumentenForRole($documents, Role::Organiser)->pluck('uuid');
 
-    expect($visible->all())->toEqualCanonicalizing(['own-vertrouwelijk', 'case-confidential', 'public']);
+    expect($visible->all())->toEqualCanonicalizing(['own-vertrouwelijk', 'case-confidential']);
 });
 
-test('an openbaar document is visible to every role', function (Role $role) {
-    // openbaar is the least confidential level there is, so a role that may see
-    // zaakvertrouwelijk documents may certainly see public ones. Leaving it out
-    // of the defaults meant a backend that labels its documents openbaar
-    // (OneGround does this for system uploads) showed nothing to anyone.
+test('an openbaar document follows the defaults on a connection without a map', function (Role $role) {
+    // Regression anchor. The defaults are a fixed set starting at
+    // zaakvertrouwelijk, not a maximum, so openbaar is outside them. A
+    // connection whose backend labels documents openbaar configures a maximum
+    // instead (see the test below).
     $zaak = Zaak::factory()->create([
         'organisation_id' => Organisation::factory()->create()->id,
         'zaaktype_id' => Zaaktype::factory()->create()->id,
@@ -79,7 +81,7 @@ test('an openbaar document is visible to every role', function (Role $role) {
 
     $visible = $zaak->filterDocumentenForRole(collect([documentWith('public', 'openbaar')]), $role);
 
-    expect($visible->pluck('uuid')->all())->toBe(['public']);
+    expect($visible->pluck('uuid')->all())->toBe([]);
 })->with([
     'organiser' => Role::Organiser,
     'advisor' => Role::Advisor,
@@ -87,6 +89,46 @@ test('an openbaar document is visible to every role', function (Role $role) {
     'municipality admin' => Role::MunicipalityAdmin,
     'coordinator' => Role::Coordinator,
     'admin' => Role::Admin,
+]);
+
+test('an openbaar document is visible to every role on a connection with maxima', function (Role $role) {
+    // openbaar is the least confidential level there is, so it sits at or below
+    // every configured maximum. A backend that labels its own uploads openbaar
+    // therefore reaches all role groups here, which is the point of the model.
+    $municipality = Municipality::factory()->create();
+
+    MunicipalityZgwConnection::factory()->active()->create([
+        'municipality_id' => $municipality->id,
+        'vertrouwelijkheid_map' => [
+            'visibility' => [
+                Role::Organiser->value => 'openbaar',
+                Role::Advisor->value => 'beperkt_openbaar',
+                Role::Reviewer->value => 'intern',
+                Role::Coordinator->value => 'intern',
+                Role::MunicipalityAdmin->value => 'intern',
+                Role::ReviewerMunicipalityAdmin->value => 'intern',
+            ],
+        ],
+    ]);
+
+    $zaak = Zaak::factory()->create([
+        'organisation_id' => Organisation::factory()->create()->id,
+        'zaaktype_id' => Zaaktype::factory()->create([
+            'municipality_id' => $municipality->id,
+            'connection' => "gemeente_{$municipality->id}",
+        ])->id,
+    ]);
+
+    $visible = $zaak->filterDocumentenForRole(collect([documentWith('public', 'openbaar')]), $role);
+
+    expect($zaak->zgwConnectionName())->toBe("gemeente_{$municipality->id}")
+        ->and($visible->pluck('uuid')->all())->toBe(['public']);
+})->with([
+    'organiser' => Role::Organiser,
+    'advisor' => Role::Advisor,
+    'reviewer' => Role::Reviewer,
+    'municipality admin' => Role::MunicipalityAdmin,
+    'coordinator' => Role::Coordinator,
 ]);
 
 test('a document above the role its clearance stays hidden', function () {

--- a/tests/Unit/Enums/DocumentVertrouwelijkhedenTest.php
+++ b/tests/Unit/Enums/DocumentVertrouwelijkhedenTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+
+it('orders the levels as the standard does, least confidential first', function () {
+    expect(DocumentVertrouwelijkheden::order())->toBe([
+        'openbaar',
+        'beperkt_openbaar',
+        'intern',
+        'zaakvertrouwelijk',
+        'vertrouwelijk',
+        'confidentieel',
+        'geheim',
+        'zeer_geheim',
+    ])
+        ->and(DocumentVertrouwelijkheden::rank('openbaar'))->toBe(0)
+        ->and(DocumentVertrouwelijkheden::rank('zeer_geheim'))->toBe(7)
+        ->and(DocumentVertrouwelijkheden::rank('geen_niveau'))->toBeNull();
+});
+
+it('reads a maximum as inclusive over that order', function () {
+    expect(DocumentVertrouwelijkheden::atMost('intern'))
+        ->toBe(['openbaar', 'beperkt_openbaar', 'intern'])
+        ->and(DocumentVertrouwelijkheden::atMost('openbaar'))->toBe(['openbaar'])
+        ->and(DocumentVertrouwelijkheden::atMost('zeer_geheim'))
+        ->toBe(DocumentVertrouwelijkheden::order())
+        // An unknown maximum yields nothing rather than a guess.
+        ->and(DocumentVertrouwelijkheden::atMost('geen_niveau'))->toBe([]);
+});
+
+it('picks the most confidential level out of a set', function () {
+    expect(DocumentVertrouwelijkheden::mostConfidential(['openbaar', 'intern', 'beperkt_openbaar']))
+        ->toBe('intern')
+        // Ordering inside the set is irrelevant, only confidentiality counts.
+        ->and(DocumentVertrouwelijkheden::mostConfidential(['confidentieel', 'openbaar']))
+        ->toBe('confidentieel')
+        ->and(DocumentVertrouwelijkheden::mostConfidential([]))->toBeNull()
+        ->and(DocumentVertrouwelijkheden::mostConfidential(['geen_niveau', 42, null]))->toBeNull()
+        // A set mixing known and unknown levels still yields the known maximum.
+        ->and(DocumentVertrouwelijkheden::mostConfidential(['geen_niveau', 'openbaar']))
+        ->toBe('openbaar');
+});
+
+it('keeps the legacy defaults outside the maximum model', function () {
+    // The defaults are a fixed set, not a maximum: they skip the three levels
+    // below zaakvertrouwelijk, so a connection wanting those configures a map.
+    expect(DocumentVertrouwelijkheden::fromUserRole(Role::Organiser))
+        ->toBe(['zaakvertrouwelijk'])
+        ->and(DocumentVertrouwelijkheden::fromUserRole(Role::Organiser))
+        ->not->toBe(DocumentVertrouwelijkheden::atMost('zaakvertrouwelijk'))
+        ->and(DocumentVertrouwelijkheden::uploadChoices())
+        ->toBe(['zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel']);
+});

--- a/tests/Unit/Zgw/DocumentAudienceTest.php
+++ b/tests/Unit/Zgw/DocumentAudienceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\DocumentVertrouwelijkheden;
+use App\Enums\Role;
+use App\Services\Zgw\DocumentAudience;
+use Illuminate\Support\Facades\Config;
+
+it('names the role groups from the broadest to the narrowest audience', function () {
+    $groups = DocumentAudience::groups();
+
+    expect(array_column($groups, 'audience'))->toBe(['Gemeente', 'Adviseur', 'Organisator'])
+        // The canonical role of each group is the one the connection form binds
+        // to, so reading its visibility describes the whole group.
+        ->and(array_map(fn (array $group): Role => $group['roles'][0], $groups))
+        ->toBe([Role::Reviewer, Role::Advisor, Role::Organiser]);
+});
+
+it('labels every level with the enum defaults on a connection without a map', function () {
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+
+    expect(DocumentAudience::uploadOptions('main', Role::Reviewer))->toBe([
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Adviseur',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+it('labels every level with the visibility map of the connection', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([
+        // The organiser sees vertrouwelijk here and the advisor sees none of the
+        // three: the hardcoded defaults claim the opposite for both.
+        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Organisator',
+        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Organisator',
+        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+    ]);
+});
+
+it('offers no choice when every level reaches the same audience', function () {
+    // The VRZL staging situation: the municipal roles see everything, the other
+    // groups see none of the three levels on offer.
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+});
+
+it('offers no choice when the uploader may see at most one of the levels', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+});
+
+it('reads the audience of a single level from the connection', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Advisor->value => ['openbaar'],
+        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+    ]);
+
+    expect(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value))
+        ->toBe(['Gemeente', 'Organisator'])
+        ->and(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Confidentieel->value))
+        ->toBe([]);
+});

--- a/tests/Unit/Zgw/DocumentAudienceTest.php
+++ b/tests/Unit/Zgw/DocumentAudienceTest.php
@@ -15,9 +15,11 @@ it('names the role groups from the broadest to the narrowest audience', function
         ->toBe([Role::Reviewer, Role::Advisor, Role::Organiser]);
 });
 
-it('labels every level with the enum defaults on a connection without a map', function () {
+it('labels every level with the enum defaults on the default connection', function () {
     Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
 
+    // Regression anchor: the "main" OpenZaak connection keeps the fixed
+    // {zaakvertrouwelijk, vertrouwelijk, confidentieel} ladder unchanged.
     expect(DocumentAudience::uploadOptions('main', Role::Reviewer))->toBe([
         DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Adviseur, Organisator',
         DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Adviseur',
@@ -25,49 +27,108 @@ it('labels every level with the enum defaults on a connection without a map', fu
     ]);
 });
 
-it('labels every level with the visibility map of the connection', function () {
+it('keeps the fixed ladder on the default connection even when a map is present', function () {
+    // The default connection never derives its ladder from a map: even a map
+    // using openbaar/beperkt_openbaar/intern leaves it on the fixed upload
+    // choices, none of which this map makes visible, so no real choice remains.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
+    ]);
+
+    expect(DocumentAudience::uploadOptions('main', Role::Reviewer))->toBe([]);
+});
+
+it('derives an oplopende ladder from the maxima a connection configures', function () {
+    // Three maxima, three nested audiences, one rung each. The levels in between
+    // (nothing here) would reach the same audience as the maximum above them.
     Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk'],
-        Role::Advisor->value => ['openbaar'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
     ]);
 
     expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([
-        // The organiser sees vertrouwelijk here and the advisor sees none of the
-        // three: the hardcoded defaults claim the opposite for both.
-        DocumentVertrouwelijkheden::Zaakvertrouwelijk->value => 'Gemeente, Organisator',
-        DocumentVertrouwelijkheden::Vertrouwelijk->value => 'Gemeente, Organisator',
-        DocumentVertrouwelijkheden::Confidentieel->value => 'Gemeente',
+        'openbaar' => 'Gemeente, Adviseur, Organisator',
+        'beperkt_openbaar' => 'Gemeente, Adviseur',
+        'intern' => 'Gemeente',
     ]);
 });
 
-it('offers no choice when every level reaches the same audience', function () {
-    // The VRZL staging situation: the municipal roles see everything, the other
-    // groups see none of the three levels on offer.
+it('offers a rung per distinct maximum, not per level in between', function () {
+    // The gemeente maximum spans four levels the other groups cannot see, but
+    // they all reach the same audience, so they form a single rung keyed by the
+    // maximum itself.
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'zaakvertrouwelijk',
+        Role::Advisor->value => 'zaakvertrouwelijk',
+        Role::Reviewer->value => 'confidentieel',
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([
+        'zaakvertrouwelijk' => 'Gemeente, Adviseur, Organisator',
+        'confidentieel' => 'Gemeente',
+    ]);
+});
+
+it('offers no choice when every group has the same maximum', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'zaakvertrouwelijk',
+        Role::Advisor->value => 'zaakvertrouwelijk',
+        Role::Reviewer->value => 'zaakvertrouwelijk',
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+});
+
+it('offers no choice when the uploader may see at most one distinct audience', function () {
+    // The uploader (an advisor here) tops out at openbaar, which everyone sees,
+    // so there is a single rung and no choice.
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'openbaar',
+        Role::Reviewer->value => 'intern',
+    ]);
+
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Advisor))->toBe([]);
+});
+
+it('derives the same ladder from a legacy map stored as sets of levels', function () {
+    // Compatibility: a map written before the maximum was introduced still reads
+    // as the maximum each set expressed, so the ladder is unchanged.
     Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
         Role::Organiser->value => ['openbaar'],
-        Role::Advisor->value => ['openbaar'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'],
+        Role::Advisor->value => ['openbaar', 'beperkt_openbaar'],
+        Role::Reviewer->value => ['openbaar', 'beperkt_openbaar', 'intern'],
     ]);
 
-    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([
+        'openbaar' => 'Gemeente, Adviseur, Organisator',
+        'beperkt_openbaar' => 'Gemeente, Adviseur',
+        'intern' => 'Gemeente',
+    ]);
 });
 
-it('offers no choice when the uploader may see at most one of the levels', function () {
+it('shows an openbaar document to every role group on a connection with maxima', function () {
+    // openbaar is the least confidential level, so it sits at or below every
+    // maximum. A backend that labels its own uploads openbaar is therefore
+    // visible to all three groups here, which is what the maximum model buys.
     Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
-        Role::Advisor->value => ['openbaar', 'zaakvertrouwelijk'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
     ]);
 
-    expect(DocumentAudience::uploadOptions('gemeente_9', Role::Reviewer))->toBe([]);
+    expect(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Openbaar->value))
+        ->toBe(['Gemeente', 'Adviseur', 'Organisator']);
 });
 
 it('reads the audience of a single level from the connection', function () {
     Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
-        Role::Advisor->value => ['openbaar'],
-        Role::Reviewer->value => ['openbaar', 'zaakvertrouwelijk'],
+        Role::Organiser->value => 'zaakvertrouwelijk',
+        Role::Advisor->value => 'openbaar',
+        Role::Reviewer->value => 'zaakvertrouwelijk',
     ]);
 
     expect(DocumentAudience::audienceFor('gemeente_9', DocumentVertrouwelijkheden::Zaakvertrouwelijk->value))

--- a/tests/Unit/Zgw/ZgwConnectionConfigTest.php
+++ b/tests/Unit/Zgw/ZgwConnectionConfigTest.php
@@ -43,33 +43,128 @@ it('uses the connection RSIN for bronorganisatie when set', function () {
 it('falls back to the enum defaults for document visibility', function () {
     Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
 
+    // Regression anchor: without a map the sets are the legacy three-step ones,
+    // spelled out here rather than compared to the enum, so a change to either
+    // side shows up.
     expect(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Organiser))
-        ->toBe(DocumentVertrouwelijkheden::fromUserRole(Role::Organiser))
+        ->toBe(['zaakvertrouwelijk'])
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Advisor))
+        ->toBe(['zaakvertrouwelijk', 'vertrouwelijk'])
         ->and(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Reviewer))
+        ->toBe(['zaakvertrouwelijk', 'vertrouwelijk', 'confidentieel'])
+        // openbaar is deliberately absent: the defaults are not a maximum.
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('main', Role::Reviewer))
+        ->not->toContain(DocumentVertrouwelijkheden::Openbaar->value);
+});
+
+it('derives the visible set from the maximum a connection configures', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'intern',
+    ]);
+
+    // A maximum is inclusive over the standard's order, so everything below it
+    // comes along.
+    expect(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Organiser))
+        ->toBe(['openbaar', 'beperkt_openbaar', 'intern'])
+        // A role without an entry still falls back to the enum default.
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Advisor))
+        ->toBe(DocumentVertrouwelijkheden::fromUserRole(Role::Advisor))
+        ->and(ZgwConnectionConfig::documentVisibilityMaxForRole('gemeente_9', Role::Organiser))
+        ->toBe('intern')
+        ->and(ZgwConnectionConfig::documentVisibilityMaxForRole('gemeente_9', Role::Advisor))
+        ->toBeNull();
+});
+
+it('reads a legacy set of levels as the maximum it expressed', function () {
+    // Maps stored before the maximum was introduced hold the full set. The most
+    // confidential member is the level the set granted access up to.
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => ['openbaar', 'beperkt_openbaar'],
+        Role::Advisor->value => ['zaakvertrouwelijk', 'openbaar'],
+        // An entry naming no level of the standard says nothing at all.
+        Role::Reviewer->value => ['nonsense'],
+    ]);
+
+    expect(ZgwConnectionConfig::readVisibilityMax(['openbaar', 'intern', 'beperkt_openbaar']))
+        ->toBe('intern')
+        ->and(ZgwConnectionConfig::readVisibilityMax([]))->toBeNull()
+        ->and(ZgwConnectionConfig::documentVisibilityMaxForRole('gemeente_9', Role::Organiser))
+        ->toBe('beperkt_openbaar')
+        // Order within the stored set does not matter, only confidentiality.
+        ->and(ZgwConnectionConfig::documentVisibilityMaxForRole('gemeente_9', Role::Advisor))
+        ->toBe('zaakvertrouwelijk')
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Advisor))
+        ->toBe(['openbaar', 'beperkt_openbaar', 'intern', 'zaakvertrouwelijk'])
+        ->and(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Reviewer))
         ->toBe(DocumentVertrouwelijkheden::fromUserRole(Role::Reviewer));
 });
 
-it('uses the connection visibility map when configured', function () {
-    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
-        Role::Organiser->value => ['openbaar', 'zaakvertrouwelijk'],
-    ]);
-
-    expect(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Organiser))
-        ->toBe(['openbaar', 'zaakvertrouwelijk'])
-        // A role without an entry still falls back to the enum default.
-        ->and(ZgwConnectionConfig::documentVisibilityForRole('gemeente_9', Role::Advisor))
-        ->toBe(DocumentVertrouwelijkheden::fromUserRole(Role::Advisor));
-});
-
-it('falls back to the legacy upload defaults per role', function () {
+it('falls back to the legacy upload defaults on a connection without a map', function () {
     Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
 
+    // An organiser never gets the choice select, so this default carries all of
+    // their uploads. Without a configured maximum the visible sets start at
+    // zaakvertrouwelijk, so openbaar would be visible to nobody: the legacy
+    // default stands.
     expect(ZgwConnectionConfig::uploadDefaultForRole('main', Role::Organiser))
         ->toBe(DocumentVertrouwelijkheden::Zaakvertrouwelijk->value)
         ->and(ZgwConnectionConfig::uploadDefaultForRole('main', Role::Advisor))
         ->toBe(DocumentVertrouwelijkheden::Vertrouwelijk->value)
         ->and(ZgwConnectionConfig::uploadDefaultForRole('main', Role::Reviewer))
         ->toBe(DocumentVertrouwelijkheden::Vertrouwelijk->value);
+});
+
+it('defaults an organiser upload to openbaar on a connection with a maximum', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
+    ]);
+
+    // Here openbaar sits at or below every maximum, so an organiser upload is
+    // visible to every role group. The other roles keep the legacy default.
+    expect(ZgwConnectionConfig::uploadDefaultForRole('gemeente_9', Role::Organiser))
+        ->toBe(DocumentVertrouwelijkheden::Openbaar->value)
+        ->and(ZgwConnectionConfig::uploadDefaultForRole('gemeente_9', Role::Advisor))
+        ->toBe(DocumentVertrouwelijkheden::Vertrouwelijk->value);
+});
+
+it('never defaults an organiser upload to a level the connection hides', function () {
+    // The failure this guards against: an organiser gets no choice select, so a
+    // default outside every group's visible set produces a document nobody can
+    // open, the organiser included. Asserted for both regimes.
+    Config::set('zgw.connections.main.vertrouwelijkheid_map', null);
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
+    ]);
+
+    foreach (['main', 'gemeente_9'] as $connection) {
+        $default = ZgwConnectionConfig::uploadDefaultForRole($connection, Role::Organiser);
+
+        foreach ([Role::Organiser, Role::Advisor, Role::Reviewer] as $role) {
+            expect(ZgwConnectionConfig::documentVisibilityForRole($connection, $role))
+                ->toContain($default);
+        }
+    }
+});
+
+it('reads the distinct maximum levels a connection map configures', function () {
+    Config::set('zgw.connections.gemeente_9.vertrouwelijkheid_map.visibility', [
+        Role::Organiser->value => 'openbaar',
+        Role::Advisor->value => 'beperkt_openbaar',
+        Role::Reviewer->value => 'intern',
+        // The fanned-out municipal roles repeat the gemeente maximum.
+        Role::Coordinator->value => 'intern',
+    ]);
+
+    // Ordered from the least to the most confidential, deduplicated.
+    expect(ZgwConnectionConfig::configuredVisibilityMaxLevels('gemeente_9'))
+        ->toBe(['openbaar', 'beperkt_openbaar', 'intern'])
+        // A connection without a map configures nothing of its own.
+        ->and(ZgwConnectionConfig::configuredVisibilityMaxLevels('main'))
+        ->toBe([]);
 });
 
 it('uses the connection upload default per role when configured', function () {


### PR DESCRIPTION
## Why

When a document is uploaded to a zaak, the uploader picks who may see it. That
choice has to line up with the per-connection visibility map, otherwise the label
promises an audience the filtering does not honour. #491 fixed the label side by
routing the choice through `DocumentAudience`, but it was reverted, and even with
it back the offered levels were still the hardcoded `{zaakvertrouwelijk,
vertrouwelijk, confidentieel}`. On a connection whose map uses `openbaar`,
`beperkt_openbaar` and `intern`, none of those three fixed levels told the role
groups apart, so the select disappeared entirely and a handler could not share a
document with one group rather than another.

Storing the visibility as an arbitrary set of levels per role group was the
deeper problem. The ZGW standard does not work that way: an authorisation
carries a *maximum* vertrouwelijkheidaanduiding, and that maximum is inclusive
over an ordered scale, so being allowed to see one level implies being allowed to
see every less confidential one. A set allows gaps the standard cannot express,
and two sets that overlap without nesting produce audiences that are not a chain,
which is exactly what a ladder needs them to be.

This PR reapplies #491 and then models the setting the way the standard does: one
maximum per role group, everything below it included.

## What changed

The first commit reapplies #491 (the revert-of-the-revert) unchanged, as the
regression anchor. The second commit is the model itself. The branch keeps two
commits rather than adding a third on top: the earlier version of the second
commit built a multi-select ladder that this change replaces wholesale, so
reviewing both in sequence would mean reading the same code twice, once as dead
code. The branch has not been pushed before, so nothing was based on it.

**The ordering, in one place (`DocumentVertrouwelijkheden`)**
- The enum cases were already declared in the standard's order (`openbaar`,
  `beperkt_openbaar`, `intern`, `zaakvertrouwelijk`, `vertrouwelijk`,
  `confidentieel`, `geheim`, `zeer_geheim`). That order is now expressed
  explicitly as `order()`, `rank()`, `atMost()` and `mostConfidential()`, and
  every caller goes through them, so there is one definition of "less
  confidential than".

**Two regimes, kept apart (`ZgwConnectionConfig::documentVisibilityForRole()`)**
- A role without a configured maximum falls back to the hardcoded
  `fromUserRole()` sets verbatim. The default connection therefore behaves
  exactly as it does today, down to the stored values.
- A role with a configured maximum gets `atMost($max)`: every level up to and
  including it.
- Either way the method still answers with a set of levels, so `Zaak`,
  `Zaaktype`, `ViewZaak`, `DocumentNotificationReceived` and `DocumentAudience`
  are untouched.

**`fromUserRole()` no longer adds `openbaar` to every role**
- That addition (on this branch only, not on `main`) was a workaround for a
  backend that labels its own uploads `openbaar`: without it those documents were
  visible to nobody. It also silently widened the default connection for every
  role, which is a behaviour change nobody asked for.
- The maximum model makes it unnecessary. A connection that needs those levels
  configures a maximum, and `openbaar` is then by construction at or below every
  group's maximum, so such a document reaches all of them. The default connection
  goes back to the three-step sets from `zaakvertrouwelijk` up.

**Rungs from maxima (`DocumentAudience::uploadOptions()`)**
- The candidate levels come from the maxima the connection configures instead of
  a fixed list. Only a maximum can be a rung: a level below one is seen by exactly
  the role groups that see that maximum, so it reaches the same audience and
  collapses into it.
- The default connection, and any connection without a map, keeps the fixed
  `uploadChoices()`. Levels reaching the same audience still collapse (most
  confidential level as representative), rungs are still ordered broadest audience
  first, and a single rung still drops the select.

**Organiser upload default (`ZgwConnectionConfig::uploadDefaultForRole()`)**
- An organiser never gets the choice select, so this default carries all of their
  uploads. On a connection that configures a maximum for the organiser it is
  `openbaar`, which is visible to every role group there.
- Without such a maximum the legacy `zaakvertrouwelijk` stands. The fallback sets
  start at `zaakvertrouwelijk` and do not contain `openbaar`, so defaulting to
  `openbaar` there would produce a document visible to nobody: precisely the
  failure this default exists to prevent. There is a test asserting that the
  organiser default is inside the visible set of all three role groups, in both
  regimes.

**Settings form (`MunicipalityZgwConnectionResource`)**
- One "maximaal zichtbaar niveau" select per role group over the full scale,
  replacing the multi-select.
- A blocking validation rule keeps the maxima running up (organisator at most
  adviseur, adviseur at most gemeente), with a message naming the two groups
  involved. Both directions are covered by a test.
- `pruneVertrouwelijkheidMap()` clamps a broader group up to a narrower one as a
  safety net for writes that bypass the form (seeders, imports, direct edits). It
  runs after the form validation, so it can never mask that error. The existing
  fan-out over the municipal handler roles is unchanged.
- A blank group still means "fall back to the defaults", unchanged.

**Compatibility and migration**
- A visibility entry stored as a set of levels is read as the maximum it
  expressed, its most confidential member, at read time (`readVisibilityMax()`)
  and when a save passes through `pruneVertrouwelijkheidMap()`. Document
  filtering therefore keeps working on an unmigrated row. The settings form
  itself does require the migration to have run first: its single-value selects
  receive the stored value as-is, so opening the edit form on a row still
  holding the array shape errors. The migration runs as part of the deploy, so
  that window does not occur in practice.
- `2026_08_21_090000_convert_vertrouwelijkheid_visibility_to_max_level` rewrites
  the stored shape. It is idempotent, leaves everything outside
  `visibility` alone, drops an entry naming no level of the standard (which then
  falls back to the defaults), and expands each maximum back into the levels it
  covers on rollback.

**Documentation and admin guidance**
- The explanation above the fieldsets, the field tooltips and the admin manual
  section were rewritten for the maximum model: one maximum per group, opener
  levels automatically included, maxima must run up, and a document labelled
  `openbaar` is visible to every role group on a connection with maxima.

## Notes for the reviewer

- **The Dutch copy is up for review.** The explanation paragraphs, the two
  tooltips, the nesting error and the manual section are new or rewritten text;
  wording is easy to adjust.
- **A partially configured map is a mixed state.** If one group has a maximum and
  another is left blank, the blank one falls back to the legacy sets, which do not
  contain the open levels. The maxima then do not form a chain and the ladder can
  look odd. This is the pre-existing "blank means defaults" semantics, kept
  deliberately; the admin text says to configure the groups together. Worth a
  decision if you would rather have a blank group inherit from the narrower one.
- **A connection without a map keeps the legacy behaviour.** Reverting the
  `openbaar` addition means a backend that labels its own uploads `openbaar`
  shows them to nobody again until that connection configures maxima. That is the
  intended consequence of separating the two regimes, but it is the one behaviour
  that changes for an existing connection with no map.
- **Tests.** Full suite green on the rebased branch: 1965 tests (289 unit, 1676
  feature) in blocking chunks, `pint` and `phpstan` clean. New coverage: the enum
  ordering helpers, both visibility regimes, the legacy-set reading, the derived
  ladder, the nesting validation in both directions, the clamp, the migration
  (including rollback and a second run), the organiser default in both regimes,
  and an `openbaar` document seen by every role group on a connection with maxima.
- **A/B verified.** Removing the validation rule reddens the two nesting tests;
  removing the clamp reddens the clamp test; restoring the `openbaar` addition
  plus an unconditional `openbaar` organiser default reddens six regression
  anchors; removing the legacy-set reading reddens three compatibility tests; and
  making the maximum exclusive instead of inclusive reddens sixteen tests.
- **After merge and deploy**, configure the maxima on a connection that needs
  them (an ascending organisator/adviseur/gemeente configuration over `openbaar`,
  `beperkt_openbaar` and `intern`) so the three-rung ladder shows up in the upload
  dialog.


## Third commit: resolve the koppeling documenttype independently of the uploader's clearance

Rebased onto `32008935` after #506 merged. The ladder and the organiser
documenttype resolver each work on their own, but together they left an organiser
unable to upload on a zaaktype whose catalogus labels its documenttypes at a
level outside the visible sets.

`UploadDocumentTypeResolver::defaultFor()` read `Zaak::$document_types`, the
accessor that filters documenttypes by what the *current user* may see. That is
the wrong input twice over. The documenttype is the koppeling's choice, not the
uploader's, and an organiser never picks one, so filtering the candidates by the
organiser's clearance decides a connection-level setting per user and yields no
documenttype at all when the catalogus sits above that clearance. It also made
the answer depend on where the code ran: the queued path has no authenticated
user and never filtered, while the web path did, so the same upload could resolve
two different documenttypes.

`Zaaktype::catalogusDocumentTypes()` now exposes the unfiltered catalogus read
that `documentTypesForUser()` was already built on, `Zaak` mirrors it, and the
resolver uses it. The per-user accessor is unchanged, so the documenttype selects
keep offering only types the user may see, which is what that filter is for.

The resolver's own test fixture defaulted to documenttypes labelled `openbaar`,
which is outside the fallback sets used when a connection carries no
vertrouwelijkheid map, so those tests exercised an empty catalogus without
meaning to. The fixture now takes the level as an argument, defaulting to one
every role sees on such a connection, and two new tests pin the behaviour: an
organiser upload with the types outside every visible set, and the queued and web
paths agreeing.

Full suite green: 1981 tests, `pint` and `phpstan` clean.
